### PR TITLE
Fixed shaders rendering black on non-OpenGL, added every blend mode, and fixed multi-camera zoom under global shaders

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ The project is split into several modules, each serving a specific purpose:
 - **`flixelgdx-basisu-plugin`**: Compression plugin that automatically downloads a Basis Universal binary for the current OS and applies `.ktx2` compression for every `.png` asset.
 - **`flixelgdx-teavm-plugin`**: Plugin that automates the workflow for web games. This includes copying assets, creating the HTML index file, extracting native scripts, and more.
 - **`flixelgdx-logging-plugin`**: Plugin that runs after `compile*` and rewrites `FlixelLogger` and **`Flixel`** static `info(...)` / `warn(...)` / `error(...)` / `debug(...)` calls to injected hooks / `*WithSite` overloads so logs show accurate file and line without relying on stack walking (essential on the web and helpful on the JVM).
-- **`flixelgdx-shader-plugin`**: Plugin that bundles bgfx's `shaderc` binaries and automatically compiles GLSL shaders for each graphics API. 
+- **`flixelgdx-shader-plugin`**: Plugin that bundles bgfx's `shaderc` binaries for all platforms and automatically compiles GLSL shaders for each graphics API. 
 - **`flixelgdx-json-processor`**: Annotation processor for the framework's JSON annotation `@JsonSeralizable`.
 - **`flixelgdx-test`**: **Test-only** module. Holds JUnit tests for `flixelgdx-core` (tweens, utilities, signals, etc.). It is not published to Maven; run `./gradlew :flixelgdx-test:test` locally and in CI.
 

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -255,12 +255,12 @@ The template pre-creates a `FlixelGame` subclass and a `FlixelState` in `core/sr
 
 **Platform run commands:**
 
-| Platform | Generator option | Run command |
-|----------|-------------|---|
-| **Desktop (LWJGL3)** | Check **Desktop (LWJGL3)** | `./gradlew :lwjgl3:run` |
-| **Web (TeaVM)** | Check **Web (TeaVM)** | `./gradlew :teavm:run` |
-| **Android** | Check **Android** | `./gradlew :android:installDebug` |
-| **iOS** | Coming soon | - |
+| Platform | Run command |
+|----------|---|
+| **Desktop (LWJGL3)** | `./gradlew :lwjgl3:run` |
+| **Web (TeaVM)** | `./gradlew :teavm:run` |
+| **Android** | `./gradlew :android:installDebug` |
+| **iOS** | - |
 
 Now that you have the project downloaded, you need to actually test your local changes, rather than from Maven Central. There are two methods of doing this:
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -1709,7 +1709,8 @@ public abstract class FlixelGame implements FlixelUpdatable, FlixelDrawable, Fli
       }
 
       /**
-       * Sets the starting window size and the dimensions of the first camera.
+       * Sets the starting window size and the dimensions of the first camera. Also sets
+       * the render resolution by default.
        *
        * @param width The width in pixels.
        * @param height The height in pixels.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -617,7 +617,9 @@ public abstract class FlixelGame implements FlixelUpdatable, FlixelDrawable, Fli
           if (camera.width != fboOrthoW || camera.height != fboOrthoH) {
             fboOrthoW = camera.width;
             fboOrthoH = camera.height;
-            fboOrtho.setToOrtho2D(0, 0, fboOrthoW, fboOrthoH);
+            // Match the active backend's depth range; the 4-arg overload assumes OpenGL's [-1, 1],
+            // which depth-clips the composite quad to black on Vulkan, Metal, and Direct3D.
+            fboOrtho.setToOrtho2D(0, 0, fboOrthoW, fboOrthoH, Flixel.graphics.isDepthZeroToOne());
           }
           batch.setProjection(fboOrtho);
           batch.setShader(cameraShader);
@@ -1024,7 +1026,9 @@ public abstract class FlixelGame implements FlixelUpdatable, FlixelDrawable, Fli
       if (w != fboOrthoW || h != fboOrthoH) {
         fboOrthoW = w;
         fboOrthoH = h;
-        fboOrtho.setToOrtho2D(0, 0, w, h);
+        // Same depth-range caveat as the per-camera composite: without the backend flag this quad
+        // is clipped to black on the [0, 1] depth backends (Vulkan, Metal, Direct3D).
+        fboOrtho.setToOrtho2D(0, 0, w, h, Flixel.graphics.isDepthZeroToOne());
       }
       batch.setProjection(fboOrtho);
       batch.setShader(gs);

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
@@ -779,12 +779,54 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
     return spriteProgram;
   }
 
-  /** Maps a blend mode to bgfx state blend bits. */
+  /**
+   * Maps a blend mode to bgfx state blend bits.
+   *
+   * <p>The framework uses straight (non-premultiplied) alpha: the sprite fragment shader outputs
+   * {@code texture * vertexColor} without folding alpha into the color channels. Each mode below is
+   * therefore expressed so a sprite's own alpha (and tint alpha) is respected at blend time through
+   * the {@code SRC_ALPHA} factor where the classic premultiplied formulation would use {@code ONE}.
+   *
+   * <p>The alpha channel always accumulates with a standard "over" ({@code srcA = ONE},
+   * {@code dstA = 1 - srcA}) no matter what the color channels do. That keeps the alpha a camera or
+   * global shader later reads out of a render target correct, so blended sprites composite properly
+   * instead of punching holes or squaring their own alpha (which the old shared {@code BLEND_ALPHA}
+   * state did on both channels).
+   */
   private static long blendState(@NotNull FlixelBlendMode mode) {
+    // Standard "over" for the alpha channel, shared by every blended mode.
+    long srcA = BGFX.BGFX_STATE_BLEND_ONE;
+    long dstA = BGFX.BGFX_STATE_BLEND_INV_SRC_ALPHA;
     return switch (mode) {
+      // No blending at all: the source overwrites the destination, alpha included.
       case NONE -> 0L;
-      case ADD -> BGFX.BGFX_STATE_BLEND_ADD;
-      case NORMAL, MULTIPLY, SCREEN, SUBTRACT, LIGHTEN, DARKEN -> BGFX.BGFX_STATE_BLEND_ALPHA;
+      // color = src * srcAlpha + dst * (1 - srcAlpha).
+      case NORMAL -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_SRC_ALPHA, BGFX.BGFX_STATE_BLEND_INV_SRC_ALPHA, srcA, dstA);
+      // color = src * srcAlpha + dst. Brightens; a faded sprite adds less.
+      case ADD -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_SRC_ALPHA, BGFX.BGFX_STATE_BLEND_ONE, srcA, dstA);
+      // color = src * dst + dst * (1 - srcAlpha). A pure multiply where opaque, unchanged where clear.
+      case MULTIPLY -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_DST_COLOR, BGFX.BGFX_STATE_BLEND_INV_SRC_ALPHA, srcA, dstA);
+      // color = src + dst * (1 - src). Lightens without blowing out to white the way ADD can.
+      case SCREEN -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_ONE, BGFX.BGFX_STATE_BLEND_INV_SRC_COLOR, srcA, dstA);
+      // color = dst - src * srcAlpha, via the reverse-subtract equation on the color channels only.
+      case SUBTRACT -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_SRC_ALPHA, BGFX.BGFX_STATE_BLEND_ONE, srcA, dstA)
+          | BGFX.BGFX_STATE_BLEND_EQUATION_SEPARATE(
+              BGFX.BGFX_STATE_BLEND_EQUATION_REVSUB, BGFX.BGFX_STATE_BLEND_EQUATION_ADD);
+      // color = max(src, dst) per channel. The MAX equation ignores the color factors.
+      case LIGHTEN -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_ONE, BGFX.BGFX_STATE_BLEND_ONE, srcA, dstA)
+          | BGFX.BGFX_STATE_BLEND_EQUATION_SEPARATE(
+              BGFX.BGFX_STATE_BLEND_EQUATION_MAX, BGFX.BGFX_STATE_BLEND_EQUATION_ADD);
+      // color = min(src, dst) per channel. The MIN equation ignores the color factors.
+      case DARKEN -> BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_ONE, BGFX.BGFX_STATE_BLEND_ONE, srcA, dstA)
+          | BGFX.BGFX_STATE_BLEND_EQUATION_SEPARATE(
+              BGFX.BGFX_STATE_BLEND_EQUATION_MIN, BGFX.BGFX_STATE_BLEND_EQUATION_ADD);
     };
   }
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
@@ -117,6 +117,22 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
   @NotNull
   private final int[] viewStack = new int[16];
 
+  /**
+   * Framebuffer bound at each {@link #viewStack} level ({@code -1} is the back buffer), plus that
+   * level's pixel size. When a render target (for example a global shader FBO) wraps the whole
+   * camera loop, {@link #beginCameraPass()} reads these so every camera can still get its own view
+   * into the same framebuffer instead of sharing one, which is what keeps per-camera zoom and scroll
+   * from overwriting each other.
+   */
+  @NotNull
+  private final short[] viewStackFrameBuffer = new short[16];
+
+  @NotNull
+  private final int[] viewStackWidth = new int[16];
+
+  @NotNull
+  private final int[] viewStackHeight = new int[16];
+
   @NotNull
   private final BGFXVertexLayout vertexLayout = BGFXVertexLayout.create();
 
@@ -206,6 +222,7 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
     this.viewportWidth = width;
     this.viewportHeight = height;
     this.viewStack[0] = SCREEN_CLEAR_VIEW;
+    this.viewStackFrameBuffer[0] = -1;
     this.viewStackDepth = 1;
 
     this.api = apiFromRenderer(BGFX.bgfx_get_renderer_type());
@@ -376,18 +393,24 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
     // bgfx applies the view transform per view for the whole frame, so sharing one view would let
     // the last camera's zoom and scroll overwrite every other camera's.
     //
-    // Only top-level (screen) passes are isolated here. When a render target is already active (for
-    // example a global shader FBO that wraps every camera), we keep drawing into that target's view
-    // rather than popping it off the stack.
-    if (viewStackDepth != 1) {
-      return;
+    // This holds even when a render target already wraps the camera loop (for example a global
+    // shader FBO): each camera still gets a fresh view, bound to that target's framebuffer, so the
+    // per-camera transforms survive instead of collapsing onto the last camera's.
+    int level = viewStackDepth - 1;
+    int view;
+    if (level == 0) {
+      view = nextScreenView;
+      if (nextScreenView < MAX_SCREEN_VIEWS - 1) {
+        nextScreenView++;
+      }
+      // On screen, draw into the render-resolution scene surface when one is active, else the back buffer.
+      BGFX.bgfx_set_view_frame_buffer(view, sceneActive ? sceneFrameBuffer() : (short) -1);
+    } else {
+      view = nextTargetView++;
+      BGFX.bgfx_set_view_frame_buffer(view, viewStackFrameBuffer[level]);
+      BGFX.bgfx_set_view_rect(view, 0, 0, viewStackWidth[level], viewStackHeight[level]);
     }
-    int view = nextScreenView;
-    if (nextScreenView < MAX_SCREEN_VIEWS - 1) {
-      nextScreenView++;
-    }
-    viewStack[0] = view;
-    BGFX.bgfx_set_view_frame_buffer(view, sceneActive ? sceneFrameBuffer() : (short) -1);
+    viewStack[level] = view;
     BGFX.bgfx_set_view_clear(view, BGFX.BGFX_CLEAR_NONE, 0, 1f, 0);
     BGFX.bgfx_set_view_mode(view, BGFX.BGFX_VIEW_MODE_SEQUENTIAL);
     BGFX.bgfx_touch(view);
@@ -682,12 +705,19 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
   void pushRenderTarget(short frameBuffer, int width, int height) {
     int view = nextTargetView++;
     if (viewStackDepth < viewStack.length) {
-      viewStack[viewStackDepth++] = view;
+      viewStack[viewStackDepth] = view;
+      viewStackFrameBuffer[viewStackDepth] = frameBuffer;
+      viewStackWidth[viewStackDepth] = width;
+      viewStackHeight[viewStackDepth] = height;
+      viewStackDepth++;
     }
     BGFX.bgfx_set_view_frame_buffer(view, frameBuffer);
     BGFX.bgfx_set_view_mode(view, BGFX.BGFX_VIEW_MODE_SEQUENTIAL);
     BGFX.bgfx_set_view_rect(view, 0, 0, width, height);
     BGFX.bgfx_set_view_clear(view, BGFX.BGFX_CLEAR_COLOR, 0, 1f, 0);
+    // Touch so the target still clears even when the camera loop redirects its draws into fresh
+    // per-camera views bound to this same framebuffer (see beginCameraPass).
+    BGFX.bgfx_touch(view);
   }
 
   /** Returns submissions to the previously active view. */


### PR DESCRIPTION
## Description

Three rendering bugs, all around shaders / cameras on the desktop bgfx backend. Found and verified in a real game project (a VCR camera shader on a menu, a grayscale global shader, a blend-mode test scene, and a multi-camera zoom scene). bgfx picks Vulkan on most Linux machines, which is where the first and third bugs surface; the second is API-independent.

**1. Camera and global shaders rendered as a black screen on non-OpenGL backends.**
The per-camera composite (`FlixelGame.draw`) and the global shader chain (`applyGlobalShaderChain`) built their composite ortho with the 4-arg `setToOrtho2D(...)`, which hardcodes OpenGL's `[-1, 1]` depth range. On Vulkan, Metal, and Direct3D (all `[0, 1]`) that depth-clips the full-screen composite quad, so any camera shader or global shader produced a black screen. Both now pass `Flixel.graphics.isDepthZeroToOne()`, matching what the scene-resolution blit in `endScene()` already does.

**2. Most blend modes did nothing.**
In the bgfx backend, `MULTIPLY`, `SCREEN`, `SUBTRACT`, `LIGHTEN`, and `DARKEN` all fell through to plain `BLEND_ALPHA`, so only `NORMAL` and `ADD` had any visible effect. Each mode now gets its own bgfx blend func (and equation, for subtract/min/max), keeping straight (non-premultiplied) alpha semantics so a sprite's own alpha is still respected. The alpha channel now blends separately with a standard "over" so a render target's alpha stays correct for later shader composites, instead of squaring it the way the shared `BLEND_ALPHA` state did on both channels.

**3. Camera zoom/scroll collapsed onto the last camera when a global shader was active.**
The global shader FBO wraps the whole camera loop in one bgfx render-target view, and `beginCameraPass` returned early in that case, so every camera submitted into that single view. bgfx applies one transform per view for the whole frame, so only the last camera's zoom and scroll survived and every other camera was rendered through it. In a multi-camera scene (a zoomed, bouncing gameplay camera plus a static HUD) the game camera's zoom got clobbered, which looked like the view snapping to a corner. `beginCameraPass` now allocates a fresh view per camera even when a render target is active, binding each to that target's framebuffer, so per-camera transforms are preserved.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence

Verified on the Vulkan backend in a consuming game project:

- **Blend modes**: a test scene with a single overlay square in every mode across a bright band and a dark band. Each mode now renders distinctly and correctly (ADD blows out to white over the bright band, MULTIPLY darkens, SCREEN lightens, SUBTRACT/DARKEN/LIGHTEN behave as expected). Before, all of them looked identical to NORMAL.
- **Camera shader**: a VCR/CRT camera shader on the main menu. Previously a black screen on Vulkan; now the CRT effect composites correctly over the menu.
- **Global shader**: a grayscale global shader over the whole scene. Previously black; now the full composited scene desaturates.
- **Multi-camera zoom under a global shader**: a two-camera scene (cam0 zoom 1 drawing corner markers at the screen edges, cam1 zoom 2 drawing a centered marker). Before the fix, three of the four corner markers flew off-screen because cam0 was forced through cam1's zoom-2 transform; after the fix, all four corners hug the edges and only cam1's marker is magnified.

Ran on both OpenGL and Vulkan to confirm parity. Framework unit tests, `spotlessApply`, and Javadoc lint all pass.

> Note (separate issue, not addressed here): the framework's Javadoc documents a top-left / y-down coordinate system, but the bgfx viewport projection is currently y-up (a sprite at `(10, 10)` renders near the bottom). The consuming game appears to be authored against the current y-up behavior, so changing it would be a breaking change and is left out of this bug-fix PR. Flagging it for a follow-up decision.
