### PR TITLE
Added a Kotlin extension module for idiomatic FlixelGDX syntax

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,6 +7,7 @@ FlixelGDX is organized into multiple Gradle modules to separate the core framewo
 The project is split into several modules, each serving a specific purpose:
 
 - **`flixelgdx-core`**: The heart of FlixelGDX. It contains the base framework classes (`FlixelGame`, `FlixelSprite`, `FlixelState`, etc.) and logic that is platform-independent. Every platform in the entire framework depends on this.
+- **`flixelgdx-ktx`**: Optional Kotlin extension layer. Adds idiomatic Kotlin syntax (operators, destructuring, and a tween builder DSL) on top of `flixelgdx-core` for Kotlin users. It contains no runtime logic of its own and stays allocation-free so it is safe to use in per-frame code.
 - **`flixelgdx-desktop`**: The primary desktop backend using the third release of the **[Lightweight Java Game Library](https://www.lwjgl.org/)**.
 - **`flixelgdx-html5`**: The backend for the web using [TeaVM](https://teavm.org) to transpile Java bytecode to JavaScript or WebAssembly, allowing games to run seamlessly in a browser.
 - **`flixelgdx-android`**: The backend for Android mobile devices.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,12 +7,12 @@ FlixelGDX is organized into multiple Gradle modules to separate the core framewo
 The project is split into several modules, each serving a specific purpose:
 
 - **`flixelgdx-core`**: The heart of FlixelGDX. It contains the base framework classes (`FlixelGame`, `FlixelSprite`, `FlixelState`, etc.) and logic that is platform-independent. Every platform in the entire framework depends on this.
-- **`flixelgdx-ktx`**: Optional Kotlin extension layer. Adds idiomatic Kotlin syntax (operators, destructuring, and a tween builder DSL) on top of `flixelgdx-core` for Kotlin users. It contains no runtime logic of its own and stays allocation-free so it is safe to use in per-frame code.
 - **`flixelgdx-desktop`**: The primary desktop backend using the third release of the **[Lightweight Java Game Library](https://www.lwjgl.org/)**.
 - **`flixelgdx-html5`**: The backend for the web using [TeaVM](https://teavm.org) to transpile Java bytecode to JavaScript or WebAssembly, allowing games to run seamlessly in a browser.
 - **`flixelgdx-android`**: The backend for Android mobile devices.
 - **`flixelgdx-ios`**: Planned backend for iOS mobile devices. Not supported yet. Currently only fail-fasts when attempted to be used.
 - **`flixelgdx-jvm`**: JVM-only helpers that are not suitable for the browser or other non-JVM targets (stack traces, optional log files, etc.).
+- **`flixelgdx-ktx`**: Optional Kotlin extension layer. Adds idiomatic Kotlin syntax (operators, destructuring, and a tween builder DSL) on top of `flixelgdx-core` for Kotlin users. It contains no runtime logic of its own and stays allocation-free so it is safe to use in per-frame code.
 - **`flixelgdx-basisu-plugin`**: Compression plugin that automatically downloads a Basis Universal binary for the current OS and applies `.ktx2` compression for every `.png` asset.
 - **`flixelgdx-teavm-plugin`**: Plugin that automates the workflow for web games. This includes copying assets, creating the HTML index file, extracting native scripts, and more.
 - **`flixelgdx-logging-plugin`**: Plugin that runs after `compile*` and rewrites `FlixelLogger` and **`Flixel`** static `info(...)` / `warn(...)` / `error(...)` / `debug(...)` calls to injected hooks / `*WithSite` overloads so logs show accurate file and line without relying on stack walking (essential on the web and helpful on the JVM).

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
   implementation("com.diffplug.spotless:spotless-plugin-gradle:8.6.0")
   implementation("com.vanniktech:gradle-maven-publish-plugin:0.33.0")
   implementation("com.android.tools.build:gradle:8.7.3")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.20")
 }

--- a/build-logic/src/main/kotlin/flixelgdx.kotlin-library.gradle.kts
+++ b/build-logic/src/main/kotlin/flixelgdx.kotlin-library.gradle.kts
@@ -19,6 +19,17 @@ plugins {
 
 kotlin {
   jvmToolchain(17)
+
+  // Build against an older Kotlin baseline than the compiler so the published artifact stays
+  // consumable by projects on older Kotlin toolchains. The compiler is 2.2.x (required by Gradle 9),
+  // but emitting 2.0 metadata and depending on the 2.0 standard library keeps the module readable by
+  // any consumer on Kotlin 2.0 or newer.
+  coreLibrariesVersion = "2.0.21"
+
+  compilerOptions {
+    apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+  }
 }
 
 // JitPack rewrites Gradle module metadata and drops classifier compatibility data, causing

--- a/build-logic/src/main/kotlin/flixelgdx.kotlin-library.gradle.kts
+++ b/build-logic/src/main/kotlin/flixelgdx.kotlin-library.gradle.kts
@@ -1,0 +1,66 @@
+/**
+ * Convention for FlixelGDX Kotlin library modules.
+ *
+ * <p>Applies {@code flixelgdx.java-base} for shared setup (coordinates, repositories, Spotless,
+ * IDE metadata), then layers on: the Kotlin JVM plugin targeting a Java 17 toolchain, the
+ * {@code java-library} surface area, and the Vanniktech Maven publish pipeline used by every
+ * other published module.
+ *
+ * <p>Unlike {@code flixelgdx.java-library} this convention does not configure the Javadoc task,
+ * since Kotlin sources do not produce Javadoc through it.
+ */
+
+plugins {
+  id("flixelgdx.java-base")
+  id("org.jetbrains.kotlin.jvm")
+  `java-library`
+  id("com.vanniktech.maven.publish")
+}
+
+kotlin {
+  jvmToolchain(17)
+}
+
+// JitPack rewrites Gradle module metadata and drops classifier compatibility data, causing
+// consumers to resolve wrong variants. POMs stay correct; omit .module files so metadata is
+// sourced from the POM alone. Mirrors flixelgdx.java-library.
+tasks.matching { it.name.startsWith("generateMetadataFileFor") }.configureEach {
+  enabled = false
+}
+
+mavenPublishing {
+  publishToMavenCentral()
+
+  val hasSigning = findProperty("flixel.signing.enabled")?.toString() == "true"
+    || findProperty("signing.keyId") != null
+    || findProperty("signingInMemoryKeyId") != null
+  if (hasSigning) {
+    signAllPublications()
+  }
+
+  coordinates(project.group as String, project.name, project.version as String)
+
+  pom {
+    name = rootProject.property("pomName") as String
+    description = rootProject.property("pomDescription") as String
+    url = rootProject.property("pomUrl") as String
+    licenses {
+      license {
+        name = rootProject.property("pomLicenseName") as String
+        url = rootProject.property("pomLicenseUrl") as String
+        distribution = "repo"
+      }
+    }
+    developers {
+      developer {
+        id = rootProject.property("pomDeveloperId") as String
+        name = rootProject.property("pomDeveloperName") as String
+      }
+    }
+    scm {
+      connection = rootProject.property("pomScmConnection") as String
+      developerConnection = rootProject.property("pomScmDeveloperConnection") as String
+      url = rootProject.property("pomScmUrl") as String
+    }
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
   alias(libs.plugins.spotless) apply false
   alias(libs.plugins.vanniktech) apply false
   alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.kotlin.jvm) apply false
 }
 
 val groupId: String by project

--- a/flixelgdx-ktx/build.gradle.kts
+++ b/flixelgdx-ktx/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+  id("flixelgdx.kotlin-library")
+}
+
+dependencies {
+  // The KTX module only adds idiomatic Kotlin syntax on top of the backend-agnostic core surface;
+  // it pulls in nothing platform-specific. It is exposed with `api` so Kotlin consumers that depend
+  // on this module also see the core types the extensions operate on.
+  api(project(":flixelgdx-core"))
+  implementation(libs.jetbrains.annotations)
+}

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelArrays.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelArrays.kt
@@ -1,0 +1,132 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelArrays")
+
+package org.flixelgdx.ktx.collections
+
+import org.flixelgdx.collections.FlixelArray
+import org.flixelgdx.collections.FlixelFloatArray
+import org.flixelgdx.collections.FlixelIntArray
+
+/**
+ * Idiomatic Kotlin operators for FlixelGDX arrays.
+ *
+ * Indexing (`array[i]` and `array[i] = value`) already works out of the box, because Kotlin maps
+ * Java `get`/`set` methods to the index operators automatically. This file adds the pieces Kotlin
+ * cannot infer from the Java side: `+=`/`-=`, the `in` operator, and small conveniences.
+ *
+ * None of these helpers allocate. The `iterator()` helpers for the primitive arrays do allocate a
+ * single iterator object per loop, so prefer the `forEach` helpers or an indexed loop in per-frame
+ * code.
+ */
+
+/** Appends [value] to the array, so `array += value` reads like a normal Kotlin collection. */
+operator fun <T> FlixelArray<T>.plusAssign(value: T?) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun <T> FlixelArray<T>.minusAssign(value: T?) {
+  removeValue(value, false)
+}
+
+/** Reports whether [value] is present using `equals`, enabling `value in array`. */
+operator fun <T> FlixelArray<T>.contains(value: T?): Boolean = contains(value, false)
+
+/** Reports whether the array has at least one element. */
+fun FlixelArray<*>.isNotEmpty(): Boolean = size != 0
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelArray<*>.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices, handy for `for (i in array.indices)`. */
+val FlixelArray<*>.indices: IntRange
+  get() = 0 until size
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelIntArray.plusAssign(value: Int) = add(value)
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelIntArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelIntArray.indices: IntRange
+  get() = 0 until size
+
+/**
+ * Iterates every element without allocating, so `array.forEach { ... }` stays safe in per-frame
+ * code. The lambda is inlined, so no iterator or closure object is created.
+ */
+inline fun FlixelIntArray.forEach(action: (Int) -> Unit) {
+  for (i in 0 until size) {
+    action(get(i))
+  }
+}
+
+/**
+ * Lets `for (value in array)` work on the primitive array. This allocates one iterator per loop;
+ * use [forEach] or an indexed loop in hot paths.
+ */
+operator fun FlixelIntArray.iterator(): IntIterator =
+  object : IntIterator() {
+    private var index = 0
+
+    override fun hasNext(): Boolean = index < size
+
+    override fun nextInt(): Int = get(index++)
+  }
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelFloatArray.plusAssign(value: Float) = add(value)
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelFloatArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelFloatArray.indices: IntRange
+  get() = 0 until size
+
+/**
+ * Iterates every element without allocating, so `array.forEach { ... }` stays safe in per-frame
+ * code. The lambda is inlined, so no iterator or closure object is created.
+ */
+inline fun FlixelFloatArray.forEach(action: (Float) -> Unit) {
+  for (i in 0 until size) {
+    action(get(i))
+  }
+}
+
+/**
+ * Lets `for (value in array)` work on the primitive array. This allocates one iterator per loop;
+ * use [forEach] or an indexed loop in hot paths.
+ */
+operator fun FlixelFloatArray.iterator(): FloatIterator =
+  object : FloatIterator() {
+    private var index = 0
+
+    override fun hasNext(): Boolean = index < size
+
+    override fun nextFloat(): Float = get(index++)
+  }

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelArrays.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelArrays.kt
@@ -26,20 +26,39 @@
 package org.flixelgdx.ktx.collections
 
 import org.flixelgdx.collections.FlixelArray
+import org.flixelgdx.collections.FlixelBooleanArray
+import org.flixelgdx.collections.FlixelByteArray
+import org.flixelgdx.collections.FlixelCharArray
 import org.flixelgdx.collections.FlixelFloatArray
 import org.flixelgdx.collections.FlixelIntArray
+import org.flixelgdx.collections.FlixelLongArray
+import org.flixelgdx.collections.FlixelShortArray
 
 /**
- * Idiomatic Kotlin operators for FlixelGDX arrays.
+ * Idiomatic Kotlin operators and factories for FlixelGDX arrays.
  *
- * Indexing (`array[i]` and `array[i] = value`) already works out of the box, because Kotlin maps
- * Java `get`/`set` methods to the index operators automatically. This file adds the pieces Kotlin
- * cannot infer from the Java side: `+=`/`-=`, the `in` operator, and small conveniences.
+ * A few things already work through Java interop and need no help here:
  *
- * None of these helpers allocate. The `iterator()` helpers for the primitive arrays do allocate a
- * single iterator object per loop, so prefer the `forEach` helpers or an indexed loop in per-frame
- * code.
+ * - Indexing (`array[i]` and `array[i] = value`), because Kotlin maps Java `get`/`set` to the index
+ *   operators automatically.
+ * - Membership on the primitive arrays (`value in array`), because each one has a Java `contains`
+ *   method. [FlixelCharArray] gets both `in` and iteration from Kotlin's own `CharSequence` support.
+ *
+ * This file adds the pieces Kotlin cannot infer: `+=`/`-=`, small conveniences, the `flixel*ArrayOf`
+ * builders, and typed iterators for `for` loops.
+ *
+ * The `forEach` helpers are inlined and allocate nothing, so prefer them in per-frame code. The
+ * `iterator()` helpers used by `for` loops allocate one iterator object per loop.
  */
+
+/** Creates an array containing [elements], the FlixelGDX counterpart to Kotlin's `arrayOf`. */
+fun <T> flixelArrayOf(vararg elements: T): FlixelArray<T> {
+  val array = FlixelArray<T>(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
 
 /** Appends [value] to the array, so `array += value` reads like a normal Kotlin collection. */
 operator fun <T> FlixelArray<T>.plusAssign(value: T?) = add(value)
@@ -63,8 +82,168 @@ val FlixelArray<*>.lastIndex: Int
 val FlixelArray<*>.indices: IntRange
   get() = 0 until size
 
+/** Creates a boolean array containing [elements]. */
+fun flixelBooleanArrayOf(vararg elements: Boolean): FlixelBooleanArray {
+  val array = FlixelBooleanArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelBooleanArray.plusAssign(value: Boolean) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun FlixelBooleanArray.minusAssign(value: Boolean) {
+  removeValue(value)
+}
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelBooleanArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelBooleanArray.indices: IntRange
+  get() = 0 until size
+
+/** Iterates every element without allocating; the lambda is inlined. */
+inline fun FlixelBooleanArray.forEach(action: (Boolean) -> Unit) {
+  for (i in 0 until size) {
+    action(get(i))
+  }
+}
+
+/** Lets `for (value in array)` work. Allocates one iterator per loop; use [forEach] in hot paths. */
+operator fun FlixelBooleanArray.iterator(): BooleanIterator =
+  object : BooleanIterator() {
+    private var index = 0
+
+    override fun hasNext(): Boolean = index < size
+
+    override fun nextBoolean(): Boolean = get(index++)
+  }
+
+/** Creates a byte array containing [elements]. */
+fun flixelByteArrayOf(vararg elements: Byte): FlixelByteArray {
+  val array = FlixelByteArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelByteArray.plusAssign(value: Byte) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun FlixelByteArray.minusAssign(value: Byte) {
+  removeValue(value)
+}
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelByteArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelByteArray.indices: IntRange
+  get() = 0 until size
+
+/** Iterates every element without allocating; the lambda is inlined. */
+inline fun FlixelByteArray.forEach(action: (Byte) -> Unit) {
+  for (i in 0 until size) {
+    action(get(i))
+  }
+}
+
+/** Lets `for (value in array)` work. Allocates one iterator per loop; use [forEach] in hot paths. */
+operator fun FlixelByteArray.iterator(): ByteIterator =
+  object : ByteIterator() {
+    private var index = 0
+
+    override fun hasNext(): Boolean = index < size
+
+    override fun nextByte(): Byte = get(index++)
+  }
+
+/** Creates a char array containing [elements]. */
+fun flixelCharArrayOf(vararg elements: Char): FlixelCharArray {
+  val array = FlixelCharArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelCharArray.plusAssign(value: Char) = add(value)
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelCharArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelCharArray.indices: IntRange
+  get() = 0 until size
+
+/** Creates a short array containing [elements]. */
+fun flixelShortArrayOf(vararg elements: Short): FlixelShortArray {
+  val array = FlixelShortArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelShortArray.plusAssign(value: Short) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun FlixelShortArray.minusAssign(value: Short) {
+  removeValue(value)
+}
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelShortArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelShortArray.indices: IntRange
+  get() = 0 until size
+
+/** Iterates every element without allocating; the lambda is inlined. */
+inline fun FlixelShortArray.forEach(action: (Short) -> Unit) {
+  for (i in 0 until size) {
+    action(get(i))
+  }
+}
+
+/** Lets `for (value in array)` work. Allocates one iterator per loop; use [forEach] in hot paths. */
+operator fun FlixelShortArray.iterator(): ShortIterator =
+  object : ShortIterator() {
+    private var index = 0
+
+    override fun hasNext(): Boolean = index < size
+
+    override fun nextShort(): Short = get(index++)
+  }
+
+/** Creates an int array containing [elements]. */
+fun flixelIntArrayOf(vararg elements: Int): FlixelIntArray {
+  val array = FlixelIntArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
 /** Appends [value], so `array += value` reads naturally on the primitive array. */
 operator fun FlixelIntArray.plusAssign(value: Int) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun FlixelIntArray.minusAssign(value: Int) {
+  removeValue(value)
+}
 
 /** The index of the last element, or `-1` when the array is empty. */
 val FlixelIntArray.lastIndex: Int
@@ -74,20 +253,14 @@ val FlixelIntArray.lastIndex: Int
 val FlixelIntArray.indices: IntRange
   get() = 0 until size
 
-/**
- * Iterates every element without allocating, so `array.forEach { ... }` stays safe in per-frame
- * code. The lambda is inlined, so no iterator or closure object is created.
- */
+/** Iterates every element without allocating; the lambda is inlined. */
 inline fun FlixelIntArray.forEach(action: (Int) -> Unit) {
   for (i in 0 until size) {
     action(get(i))
   }
 }
 
-/**
- * Lets `for (value in array)` work on the primitive array. This allocates one iterator per loop;
- * use [forEach] or an indexed loop in hot paths.
- */
+/** Lets `for (value in array)` work. Allocates one iterator per loop; use [forEach] in hot paths. */
 operator fun FlixelIntArray.iterator(): IntIterator =
   object : IntIterator() {
     private var index = 0
@@ -97,8 +270,64 @@ operator fun FlixelIntArray.iterator(): IntIterator =
     override fun nextInt(): Int = get(index++)
   }
 
+/** Creates a long array containing [elements]. */
+fun flixelLongArrayOf(vararg elements: Long): FlixelLongArray {
+  val array = FlixelLongArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
+/** Appends [value], so `array += value` reads naturally on the primitive array. */
+operator fun FlixelLongArray.plusAssign(value: Long) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun FlixelLongArray.minusAssign(value: Long) {
+  removeValue(value)
+}
+
+/** The index of the last element, or `-1` when the array is empty. */
+val FlixelLongArray.lastIndex: Int
+  get() = size - 1
+
+/** The range of valid indices for this array. */
+val FlixelLongArray.indices: IntRange
+  get() = 0 until size
+
+/** Iterates every element without allocating; the lambda is inlined. */
+inline fun FlixelLongArray.forEach(action: (Long) -> Unit) {
+  for (i in 0 until size) {
+    action(get(i))
+  }
+}
+
+/** Lets `for (value in array)` work. Allocates one iterator per loop; use [forEach] in hot paths. */
+operator fun FlixelLongArray.iterator(): LongIterator =
+  object : LongIterator() {
+    private var index = 0
+
+    override fun hasNext(): Boolean = index < size
+
+    override fun nextLong(): Long = get(index++)
+  }
+
+/** Creates a float array containing [elements]. */
+fun flixelFloatArrayOf(vararg elements: Float): FlixelFloatArray {
+  val array = FlixelFloatArray(elements.size)
+  for (element in elements) {
+    array.add(element)
+  }
+  return array
+}
+
 /** Appends [value], so `array += value` reads naturally on the primitive array. */
 operator fun FlixelFloatArray.plusAssign(value: Float) = add(value)
+
+/** Removes the first element equal to [value], so `array -= value` mirrors [plusAssign]. */
+operator fun FlixelFloatArray.minusAssign(value: Float) {
+  removeValue(value)
+}
 
 /** The index of the last element, or `-1` when the array is empty. */
 val FlixelFloatArray.lastIndex: Int
@@ -108,20 +337,14 @@ val FlixelFloatArray.lastIndex: Int
 val FlixelFloatArray.indices: IntRange
   get() = 0 until size
 
-/**
- * Iterates every element without allocating, so `array.forEach { ... }` stays safe in per-frame
- * code. The lambda is inlined, so no iterator or closure object is created.
- */
+/** Iterates every element without allocating; the lambda is inlined. */
 inline fun FlixelFloatArray.forEach(action: (Float) -> Unit) {
   for (i in 0 until size) {
     action(get(i))
   }
 }
 
-/**
- * Lets `for (value in array)` work on the primitive array. This allocates one iterator per loop;
- * use [forEach] or an indexed loop in hot paths.
- */
+/** Lets `for (value in array)` work. Allocates one iterator per loop; use [forEach] in hot paths. */
 operator fun FlixelFloatArray.iterator(): FloatIterator =
   object : FloatIterator() {
     private var index = 0

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelMaps.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelMaps.kt
@@ -25,16 +25,34 @@
 
 package org.flixelgdx.ktx.collections
 
+import org.flixelgdx.collections.FlixelIdentityMap
+import org.flixelgdx.collections.FlixelIntMap
+import org.flixelgdx.collections.FlixelLongMap
 import org.flixelgdx.collections.FlixelMap
+import org.flixelgdx.collections.FlixelObjectFloatMap
+import org.flixelgdx.collections.FlixelObjectIntMap
 
 /**
- * Idiomatic Kotlin operators for [FlixelMap].
+ * Idiomatic Kotlin operators and factories for the FlixelGDX map types.
  *
- * Reading with `map[key]` already works through Java interop. This file adds writing with
- * `map[key] = value`, the `in` operator, and destructuring iteration so `for ((k, v) in map)`
- * reads like a standard Kotlin map. None of these helpers allocate on their own; the `for` loop
- * reuses the map's own entry iterator.
+ * Reading with `map[key]` already works through Java interop wherever the map has a single-argument
+ * getter (the object-keyed and primitive-keyed maps). Membership uses `key in map`, which delegates
+ * to each map's constant-time `containsKey`; iteration reuses the map's own entry iterator. This
+ * file adds writing with `map[key] = value`, the `in` operator, the `flixel*MapOf` builders, and
+ * destructuring so `for ((key, value) in map)` reads like a standard Kotlin map.
+ *
+ * The primitive-value maps ([FlixelObjectIntMap], [FlixelObjectFloatMap]) do not support `map[key]`
+ * reads, since their getter needs an explicit default; call `get(key, default)` for those.
  */
+
+/** Creates a map containing [pairs], the FlixelGDX counterpart to Kotlin's `mapOf`. */
+fun <K : Any, V> flixelMapOf(vararg pairs: Pair<K, V>): FlixelMap<K, V> {
+  val map = FlixelMap<K, V>(pairs.size)
+  for ((key, value) in pairs) {
+    map.put(key, value)
+  }
+  return map
+}
 
 /** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
 operator fun <K : Any, V> FlixelMap<K, V>.set(key: K, value: V?) {
@@ -55,3 +73,151 @@ operator fun <K, V> FlixelMap.Entry<K, V>.component2(): V = value
 
 /** Reports whether the map has at least one entry. */
 fun FlixelMap<*, *>.isNotEmpty(): Boolean = size != 0
+
+/** Creates an identity map containing [pairs], where keys are compared by reference. */
+fun <K : Any, V> flixelIdentityMapOf(vararg pairs: Pair<K, V>): FlixelIdentityMap<K, V> {
+  val map = FlixelIdentityMap<K, V>(pairs.size)
+  for ((key, value) in pairs) {
+    map.put(key, value)
+  }
+  return map
+}
+
+/** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
+operator fun <K : Any, V> FlixelIdentityMap<K, V>.set(key: K, value: V?) {
+  put(key, value)
+}
+
+/** Reports whether [key] is present, enabling `key in map`. */
+operator fun <K : Any, V> FlixelIdentityMap<K, V>.contains(key: K): Boolean = containsKey(key)
+
+/** Iterates the map's entries so `for (entry in map)` and destructuring loops work. */
+operator fun <K, V> FlixelIdentityMap<K, V>.iterator(): Iterator<FlixelIdentityMap.Entry<K, V>> =
+  entries().iterator()
+
+/** The key half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K, V> FlixelIdentityMap.Entry<K, V>.component1(): K = key
+
+/** The value half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K, V> FlixelIdentityMap.Entry<K, V>.component2(): V = value
+
+/** Reports whether the map has at least one entry. */
+fun FlixelIdentityMap<*, *>.isNotEmpty(): Boolean = size != 0
+
+/** Creates an int-keyed map containing [pairs]. */
+fun <V> flixelIntMapOf(vararg pairs: Pair<Int, V>): FlixelIntMap<V> {
+  val map = FlixelIntMap<V>(pairs.size)
+  for ((key, value) in pairs) {
+    map.put(key, value)
+  }
+  return map
+}
+
+/** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
+operator fun <V> FlixelIntMap<V>.set(key: Int, value: V?) {
+  put(key, value)
+}
+
+/** Reports whether [key] is present, enabling `key in map`. */
+operator fun FlixelIntMap<*>.contains(key: Int): Boolean = containsKey(key)
+
+/** Iterates the map's entries so `for (entry in map)` and destructuring loops work. */
+operator fun <V> FlixelIntMap<V>.iterator(): Iterator<FlixelIntMap.Entry<V>> = entries().iterator()
+
+/** The key half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <V> FlixelIntMap.Entry<V>.component1(): Int = key
+
+/** The value half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <V> FlixelIntMap.Entry<V>.component2(): V = value
+
+/** Reports whether the map has at least one entry. */
+fun FlixelIntMap<*>.isNotEmpty(): Boolean = size != 0
+
+/** Creates a long-keyed map containing [pairs]. */
+fun <V> flixelLongMapOf(vararg pairs: Pair<Long, V>): FlixelLongMap<V> {
+  val map = FlixelLongMap<V>(pairs.size)
+  for ((key, value) in pairs) {
+    map.put(key, value)
+  }
+  return map
+}
+
+/** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
+operator fun <V> FlixelLongMap<V>.set(key: Long, value: V?) {
+  put(key, value)
+}
+
+/** Reports whether [key] is present, enabling `key in map`. */
+operator fun FlixelLongMap<*>.contains(key: Long): Boolean = containsKey(key)
+
+/** Iterates the map's entries so `for (entry in map)` and destructuring loops work. */
+operator fun <V> FlixelLongMap<V>.iterator(): Iterator<FlixelLongMap.Entry<V>> = entries().iterator()
+
+/** The key half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <V> FlixelLongMap.Entry<V>.component1(): Long = key
+
+/** The value half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <V> FlixelLongMap.Entry<V>.component2(): V = value
+
+/** Reports whether the map has at least one entry. */
+fun FlixelLongMap<*>.isNotEmpty(): Boolean = size != 0
+
+/** Creates a map from object keys to `int` values containing [pairs]. */
+fun <K : Any> flixelObjectIntMapOf(vararg pairs: Pair<K, Int>): FlixelObjectIntMap<K> {
+  val map = FlixelObjectIntMap<K>(pairs.size)
+  for ((key, value) in pairs) {
+    map.put(key, value)
+  }
+  return map
+}
+
+/** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
+operator fun <K : Any> FlixelObjectIntMap<K>.set(key: K, value: Int) {
+  put(key, value)
+}
+
+/** Reports whether [key] is present, enabling `key in map`. */
+operator fun <K : Any> FlixelObjectIntMap<K>.contains(key: K): Boolean = containsKey(key)
+
+/** Iterates the map's entries so `for (entry in map)` and destructuring loops work. */
+operator fun <K> FlixelObjectIntMap<K>.iterator(): Iterator<FlixelObjectIntMap.Entry<K>> =
+  entries().iterator()
+
+/** The key half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K> FlixelObjectIntMap.Entry<K>.component1(): K = key
+
+/** The value half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K> FlixelObjectIntMap.Entry<K>.component2(): Int = value
+
+/** Reports whether the map has at least one entry. */
+fun FlixelObjectIntMap<*>.isNotEmpty(): Boolean = size != 0
+
+/** Creates a map from object keys to `float` values containing [pairs]. */
+fun <K : Any> flixelObjectFloatMapOf(vararg pairs: Pair<K, Float>): FlixelObjectFloatMap<K> {
+  val map = FlixelObjectFloatMap<K>(pairs.size)
+  for ((key, value) in pairs) {
+    map.put(key, value)
+  }
+  return map
+}
+
+/** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
+operator fun <K : Any> FlixelObjectFloatMap<K>.set(key: K, value: Float) {
+  put(key, value)
+}
+
+/** Reports whether [key] is present, enabling `key in map`. */
+operator fun <K : Any> FlixelObjectFloatMap<K>.contains(key: K): Boolean = containsKey(key)
+
+/** Iterates the map's entries so `for (entry in map)` and destructuring loops work. */
+operator fun <K> FlixelObjectFloatMap<K>.iterator(): Iterator<FlixelObjectFloatMap.Entry<K>> =
+  entries().iterator()
+
+/** The key half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K> FlixelObjectFloatMap.Entry<K>.component1(): K = key
+
+/** The value half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K> FlixelObjectFloatMap.Entry<K>.component2(): Float = value
+
+/** Reports whether the map has at least one entry. */
+fun FlixelObjectFloatMap<*>.isNotEmpty(): Boolean = size != 0

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelMaps.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelMaps.kt
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelMaps")
+
+package org.flixelgdx.ktx.collections
+
+import org.flixelgdx.collections.FlixelMap
+
+/**
+ * Idiomatic Kotlin operators for [FlixelMap].
+ *
+ * Reading with `map[key]` already works through Java interop. This file adds writing with
+ * `map[key] = value`, the `in` operator, and destructuring iteration so `for ((k, v) in map)`
+ * reads like a standard Kotlin map. None of these helpers allocate on their own; the `for` loop
+ * reuses the map's own entry iterator.
+ */
+
+/** Associates [value] with [key], so `map[key] = value` reads like a Kotlin map assignment. */
+operator fun <K : Any, V> FlixelMap<K, V>.set(key: K, value: V?) {
+  put(key, value)
+}
+
+/** Reports whether [key] is present, enabling `key in map`. */
+operator fun <K : Any, V> FlixelMap<K, V>.contains(key: K): Boolean = containsKey(key)
+
+/** Iterates the map's entries so `for (entry in map)` and destructuring loops work. */
+operator fun <K, V> FlixelMap<K, V>.iterator(): Iterator<FlixelMap.Entry<K, V>> = entries().iterator()
+
+/** The key half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K, V> FlixelMap.Entry<K, V>.component1(): K = key
+
+/** The value half of an entry, enabling `for ((key, value) in map)`. */
+operator fun <K, V> FlixelMap.Entry<K, V>.component2(): V = value
+
+/** Reports whether the map has at least one entry. */
+fun FlixelMap<*, *>.isNotEmpty(): Boolean = size != 0

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelPools.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelPools.kt
@@ -69,7 +69,7 @@ fun <T : Any> flixelPool(
  * ```
  *
  * The object is freed even if [block] throws. This function is inlined, so the lambda adds no
- * allocation and it is safe to call every frame.
+ * allocation, and it is safe to call every frame.
  *
  * @param block Runs against the borrowed object before it is freed.
  */

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelPools.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelPools.kt
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelPools")
+
+package org.flixelgdx.ktx.collections
+
+import org.flixelgdx.collections.FlixelPool
+
+/**
+ * Boilerplate reducers for [FlixelPool].
+ *
+ * In Java a pool is created by subclassing [FlixelPool] and overriding `newObject()`. In Kotlin the
+ * [flixelPool] builder collapses that ceremony into a single lambda, and [use] borrows an object
+ * for the duration of a block and frees it automatically, so callers never forget to return it.
+ */
+
+/**
+ * Creates a pool that builds new objects with [factory].
+ *
+ * This avoids the anonymous-subclass ceremony the Java API requires:
+ *
+ * ```
+ * val bullets = flixelPool { Bullet() }
+ * val enemies = flixelPool(initialCapacity = 64) { Enemy() }
+ * ```
+ *
+ * The [factory] is stored once on the returned pool, so no allocation happens per obtained object
+ * beyond the object itself.
+ *
+ * @param initialCapacity The starting size of the internal free-object storage.
+ * @param max The largest number of free objects to retain; objects freed beyond this are discarded.
+ * @param factory Produces a fresh, ready-to-use object when the pool has none free.
+ */
+fun <T : Any> flixelPool(
+  initialCapacity: Int = 16,
+  max: Int = Int.MAX_VALUE,
+  factory: () -> T,
+): FlixelPool<T> =
+  object : FlixelPool<T>(initialCapacity, max) {
+    override fun newObject(): T = factory()
+  }
+
+/**
+ * Borrows an object for the duration of [block], then returns it to the pool automatically.
+ *
+ * ```
+ * pool.use { bullet -> bullet.fire() }
+ * ```
+ *
+ * The object is freed even if [block] throws. This function is inlined, so the lambda adds no
+ * allocation and it is safe to call every frame.
+ *
+ * @param block Runs against the borrowed object before it is freed.
+ */
+inline fun <T : Any> FlixelPool<T>.use(block: (T) -> Unit) {
+  val obj = obtain()
+  try {
+    block(obj)
+  } finally {
+    free(obj)
+  }
+}

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelSets.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/collections/FlixelSets.kt
@@ -1,0 +1,130 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelSets")
+
+package org.flixelgdx.ktx.collections
+
+import org.flixelgdx.collections.FlixelIntSet
+import org.flixelgdx.collections.FlixelLongSet
+import org.flixelgdx.collections.FlixelSet
+
+/**
+ * Idiomatic Kotlin operators and factories for the FlixelGDX set types.
+ *
+ * Membership already works through the sets' own hashing: `value in set` calls each set's Java
+ * `contains`, which is a constant-time lookup. This file adds `+=`/`-=`, the `flixel*SetOf`
+ * builders, and iteration helpers.
+ *
+ * [FlixelSet] is `Iterable`, so `for (value in set)` works directly. The primitive sets are backed
+ * by open-addressed hashing with no stable index, so instead of a `for` loop they expose an inlined,
+ * allocation-free [forEach] that reuses each set's own iterator.
+ */
+
+/** Creates a set containing [elements], the FlixelGDX counterpart to Kotlin's `setOf`. */
+fun <T : Any> flixelSetOf(vararg elements: T): FlixelSet<T> {
+  val set = FlixelSet<T>(elements.size)
+  for (element in elements) {
+    set.add(element)
+  }
+  return set
+}
+
+/** Adds [value] to the set, so `set += value` reads like a Kotlin collection. */
+operator fun <T : Any> FlixelSet<T>.plusAssign(value: T) {
+  add(value)
+}
+
+/** Removes [value] from the set, so `set -= value` mirrors [plusAssign]. */
+operator fun <T : Any> FlixelSet<T>.minusAssign(value: T) {
+  remove(value)
+}
+
+/** Reports whether the set has at least one element. */
+fun FlixelSet<*>.isNotEmpty(): Boolean = size != 0
+
+/** Creates an int set containing [elements]. */
+fun flixelIntSetOf(vararg elements: Int): FlixelIntSet {
+  val set = FlixelIntSet(elements.size)
+  for (element in elements) {
+    set.add(element)
+  }
+  return set
+}
+
+/** Adds [value] to the set, so `set += value` reads like a Kotlin collection. */
+operator fun FlixelIntSet.plusAssign(value: Int) {
+  add(value)
+}
+
+/** Removes [value] from the set, so `set -= value` mirrors [plusAssign]. */
+operator fun FlixelIntSet.minusAssign(value: Int) {
+  remove(value)
+}
+
+/** Reports whether the set has at least one element. */
+fun FlixelIntSet.isNotEmpty(): Boolean = size != 0
+
+/**
+ * Iterates every element without allocating, reusing the set's own iterator. The lambda is inlined,
+ * so this is safe to call every frame.
+ */
+inline fun FlixelIntSet.forEach(action: (Int) -> Unit) {
+  val iterator = iterator()
+  while (iterator.hasNext) {
+    action(iterator.next())
+  }
+}
+
+/** Creates a long set containing [elements]. */
+fun flixelLongSetOf(vararg elements: Long): FlixelLongSet {
+  val set = FlixelLongSet(elements.size)
+  for (element in elements) {
+    set.add(element)
+  }
+  return set
+}
+
+/** Adds [value] to the set, so `set += value` reads like a Kotlin collection. */
+operator fun FlixelLongSet.plusAssign(value: Long) {
+  add(value)
+}
+
+/** Removes [value] from the set, so `set -= value` mirrors [plusAssign]. */
+operator fun FlixelLongSet.minusAssign(value: Long) {
+  remove(value)
+}
+
+/** Reports whether the set has at least one element. */
+fun FlixelLongSet.isNotEmpty(): Boolean = size != 0
+
+/**
+ * Iterates every element without allocating, reusing the set's own iterator. The lambda is inlined,
+ * so this is safe to call every frame.
+ */
+inline fun FlixelLongSet.forEach(action: (Long) -> Unit) {
+  val iterator = iterator()
+  while (iterator.hasNext) {
+    action(iterator.next())
+  }
+}

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/group/FlixelGroups.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/group/FlixelGroups.kt
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelGroups")
+
+package org.flixelgdx.ktx.group
+
+import org.flixelgdx.group.FlixelGroupable
+
+/**
+ * Idiomatic Kotlin operators for anything that is a [FlixelGroupable], which covers every group
+ * type in the framework.
+ *
+ * These make membership read like a Kotlin collection (`group += player`, `group -= enemy`,
+ * `group[i]`, `for (m in group)`). None of them allocate, except the `iterator()` used by `for`
+ * loops, which creates one iterator object per loop. For per-frame iteration prefer an indexed loop
+ * using [size] and `group[i]`.
+ */
+
+/** Adds [member] to the group, so `group += member` reads like a Kotlin collection. */
+operator fun <T> FlixelGroupable<T>.plusAssign(member: T) = add(member)
+
+/** Removes [member] from the group, so `group -= member` mirrors [plusAssign]. */
+operator fun <T> FlixelGroupable<T>.minusAssign(member: T) = remove(member)
+
+/** Returns the member at [index], so `group[i]` reads like array access. */
+operator fun <T> FlixelGroupable<T>.get(index: Int): T = getMembers()!!.get(index)
+
+/** Iterates the group's members so `for (member in group)` works. */
+operator fun <T> FlixelGroupable<T>.iterator(): Iterator<T> = getMembers()!!.iterator()
+
+/** The number of member slots in the group, including empty ones. */
+val FlixelGroupable<*>.size: Int
+  get() = getMembers()!!.size

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/math/FlixelRects.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/math/FlixelRects.kt
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelRects")
+
+package org.flixelgdx.ktx.math
+
+import org.flixelgdx.math.FlixelRect
+
+/**
+ * Idiomatic Kotlin helpers for [FlixelRect].
+ *
+ * Point containment already reads well through Java interop: `point in rect` calls
+ * `FlixelRect.contains(FlixelVector)`. This file adds destructuring so a rectangle can be unpacked
+ * into its four components. None of these helpers allocate.
+ */
+
+/** The x component, enabling `val (x, y, width, height) = rect`. */
+operator fun FlixelRect.component1(): Float = x
+
+/** The y component, enabling `val (x, y, width, height) = rect`. */
+operator fun FlixelRect.component2(): Float = y
+
+/** The width component, enabling `val (x, y, width, height) = rect`. */
+operator fun FlixelRect.component3(): Float = width
+
+/** The height component, enabling `val (x, y, width, height) = rect`. */
+operator fun FlixelRect.component4(): Float = height

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/math/FlixelVectors.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/math/FlixelVectors.kt
@@ -1,0 +1,90 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelVectors")
+
+package org.flixelgdx.ktx.math
+
+import org.flixelgdx.math.FlixelVector
+
+/**
+ * Idiomatic Kotlin operators for [FlixelVector].
+ *
+ * There are two families here, and the difference matters for performance:
+ *
+ * - The compound-assignment operators (`+=`, `-=`, `*=`) mutate the vector in place and allocate
+ *   nothing. Prefer these in per-frame code.
+ * - The binary operators (`+`, `-`, `*`, unary `-`) each return a brand-new [FlixelVector]. They
+ *   read cleanly but allocate, so keep them out of hot loops.
+ *
+ * Destructuring (`val (x, y) = vector`) is also provided and allocates nothing.
+ */
+
+/** Adds [other] into this vector in place. Allocates nothing. */
+operator fun FlixelVector.plusAssign(other: FlixelVector) {
+  add(other)
+}
+
+/** Subtracts [other] from this vector in place. Allocates nothing. */
+operator fun FlixelVector.minusAssign(other: FlixelVector) {
+  subtract(other)
+}
+
+/** Scales this vector in place by [factor]. Allocates nothing. */
+operator fun FlixelVector.timesAssign(factor: Float) {
+  scale(factor)
+}
+
+/**
+ * Returns a new vector equal to this one plus [other].
+ *
+ * This allocates a new [FlixelVector]; use [plusAssign] in per-frame code.
+ */
+operator fun FlixelVector.plus(other: FlixelVector): FlixelVector = FlixelVector(x + other.x, y + other.y)
+
+/**
+ * Returns a new vector equal to this one minus [other].
+ *
+ * This allocates a new [FlixelVector]; use [minusAssign] in per-frame code.
+ */
+operator fun FlixelVector.minus(other: FlixelVector): FlixelVector = FlixelVector(x - other.x, y - other.y)
+
+/**
+ * Returns a new vector equal to this one scaled by [factor].
+ *
+ * This allocates a new [FlixelVector]; use [timesAssign] in per-frame code.
+ */
+operator fun FlixelVector.times(factor: Float): FlixelVector = FlixelVector(x * factor, y * factor)
+
+/**
+ * Returns a new vector pointing in the opposite direction.
+ *
+ * This allocates a new [FlixelVector]; call `negate()` to flip in place instead.
+ */
+operator fun FlixelVector.unaryMinus(): FlixelVector = FlixelVector(-x, -y)
+
+/** The x component, enabling `val (x, y) = vector`. */
+operator fun FlixelVector.component1(): Float = x
+
+/** The y component, enabling `val (x, y) = vector`. */
+operator fun FlixelVector.component2(): Float = y

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/signal/FlixelSignals.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/signal/FlixelSignals.kt
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelSignals")
+
+package org.flixelgdx.ktx.signal
+
+import org.flixelgdx.util.signal.FlixelSignal
+import org.flixelgdx.util.signal.FlixelSignal.SignalHandler
+
+/**
+ * Idiomatic Kotlin operators for [FlixelSignal].
+ *
+ * Adding a listener with a lambda already works, since [SignalHandler] has a single method. This
+ * file adds `+=`/`-=` for registering listeners and the `invoke` operator so a signal can be fired
+ * by calling it directly, as in `onDeath(player)` or `onTick()`.
+ */
+
+/** Registers [handler] as a permanent listener, so `signal += { ... }` reads naturally. */
+operator fun <T> FlixelSignal<T>.plusAssign(handler: SignalHandler<T>) = add(handler)
+
+/** Removes a previously registered [handler], mirroring [plusAssign]. */
+operator fun <T> FlixelSignal<T>.minusAssign(handler: SignalHandler<T>) = remove(handler)
+
+/** Fires the signal with no data, so `signal()` reads like a function call. */
+operator fun <T> FlixelSignal<T>.invoke() = dispatch()
+
+/** Fires the signal with [data], so `signal(value)` reads like a function call. */
+operator fun <T> FlixelSignal<T>.invoke(data: T) = dispatch(data)

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/tween/FlixelTweens.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/tween/FlixelTweens.kt
@@ -1,0 +1,137 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelTweens")
+
+package org.flixelgdx.ktx.tween
+
+import org.flixelgdx.tween.FlixelTween
+import org.flixelgdx.tween.FlixelTweenCallback
+import org.flixelgdx.tween.ease.FlixelEaseFunction
+import org.flixelgdx.tween.settings.FlixelTweenSettings
+import org.flixelgdx.tween.settings.FlixelTweenSettings.FlixelTweenGoal.FlixelTweenGoalGetter
+import org.flixelgdx.tween.settings.FlixelTweenSettings.FlixelTweenGoal.FlixelTweenGoalSetter
+import org.flixelgdx.tween.settings.FlixelTweenType
+
+import java.util.function.Supplier
+
+/**
+ * A Kotlin builder DSL for [FlixelTween].
+ *
+ * The Java API drives a tween through a chained-setter [FlixelTweenSettings] object. This DSL
+ * collapses those setters into named parameters and moves the property goals into a small builder
+ * block, so a tween reads top to bottom:
+ *
+ * ```
+ * sprite.tween(duration = 2f, ease = FlixelEase::quadOut, onComplete = { it.destroy() }) {
+ *   goal({ sprite.x }, 100f) { sprite.x = it }
+ *   goal({ sprite.y }, 0f) { sprite.y = it }
+ * }
+ * ```
+ *
+ * The getter and setter passed to [FlixelTweenGoalScope.goal] map straight to FlixelGDX's primitive
+ * `float` goal interfaces, so they run without boxing while the tween updates every frame.
+ */
+
+/**
+ * The receiver of a [tween] builder block, used to register property goals.
+ *
+ * @property settings The settings object the enclosing [tween] call is assembling.
+ */
+class FlixelTweenGoalScope(val settings: FlixelTweenSettings) {
+
+  /**
+   * Registers a goal that eases a single `float` property from its current value toward [to].
+   *
+   * @param getter Reads the property's starting value once, when the tween begins.
+   * @param to The value to ease the property toward.
+   * @param setter Receives the interpolated value on every update.
+   */
+  fun goal(getter: FlixelTweenGoalGetter, to: Float, setter: FlixelTweenGoalSetter) {
+    settings.addGoal(getter, to, setter)
+  }
+}
+
+/**
+ * Creates and starts a tween on this object using an idiomatic Kotlin builder.
+ *
+ * Every setting has a sensible default, so only the goals block is required. See
+ * [FlixelTweenGoalScope] for the goal syntax and a full example.
+ *
+ * @param duration How long the tween runs, in seconds.
+ * @param ease The easing function, or `null` to keep the default linear ease.
+ * @param type The tween type (one-shot, looping, ping-pong, and so on).
+ * @param startDelay Seconds to wait before the tween begins.
+ * @param loopDelay Seconds to wait between loops.
+ * @param framerate The step rate for frame-based tweens, or `0` for smooth interpolation.
+ * @param onStart Called when the tween starts, or `null` for none.
+ * @param onUpdate Called on every update, or `null` for none.
+ * @param onComplete Called when the tween finishes, or `null` for none.
+ * @param goals Registers the property goals to ease; must add at least one.
+ * @return The newly created and started tween.
+ */
+fun Any.tween(
+  duration: Float = 1f,
+  ease: FlixelEaseFunction? = null,
+  type: FlixelTweenType = FlixelTweenType.ONESHOT,
+  startDelay: Float = 0f,
+  loopDelay: Float = 0f,
+  framerate: Float = 0f,
+  onStart: FlixelTweenCallback? = null,
+  onUpdate: FlixelTweenCallback? = null,
+  onComplete: FlixelTweenCallback? = null,
+  goals: FlixelTweenGoalScope.() -> Unit,
+): FlixelTween {
+  val settings = FlixelTweenSettings(type)
+  settings.setDuration(duration)
+  settings.setStartDelay(startDelay)
+  settings.setLoopDelay(loopDelay)
+  settings.setFramerate(framerate)
+  if (ease != null) {
+    settings.setEase(ease)
+  }
+  if (onStart != null) {
+    settings.setOnStart(onStart)
+  }
+  if (onUpdate != null) {
+    settings.setOnUpdate(onUpdate)
+  }
+  if (onComplete != null) {
+    settings.setOnComplete(onComplete)
+  }
+  FlixelTweenGoalScope(settings).goals()
+  return FlixelTween.tween(this, settings)
+}
+
+/**
+ * Chains [next] to run after this tween finishes, so the callback reads as a trailing lambda.
+ *
+ * ```
+ * sprite.tween(duration = 1f) { goal({ sprite.x }, 100f) { sprite.x = it } }
+ *   .then { sprite.tween(duration = 1f) { goal({ sprite.x }, 0f) { sprite.x = it } } }
+ * ```
+ *
+ * @param next Supplies the tween to start once this one completes.
+ * @return This tween, for further chaining.
+ */
+inline fun FlixelTween.then(crossinline next: () -> FlixelTween): FlixelTween = then(Supplier { next() })

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/tween/FlixelTweens.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/tween/FlixelTweens.kt
@@ -103,21 +103,21 @@ fun Any.tween(
   goals: FlixelTweenGoalScope.() -> Unit,
 ): FlixelTween {
   val settings = FlixelTweenSettings(type)
-  settings.setDuration(duration)
-  settings.setStartDelay(startDelay)
-  settings.setLoopDelay(loopDelay)
-  settings.setFramerate(framerate)
+  settings.duration = duration
+  settings.startDelay = startDelay
+  settings.loopDelay = loopDelay
+  settings.framerate = framerate
   if (ease != null) {
-    settings.setEase(ease)
+    settings.ease = ease
   }
   if (onStart != null) {
-    settings.setOnStart(onStart)
+    settings.onStart = onStart
   }
   if (onUpdate != null) {
-    settings.setOnUpdate(onUpdate)
+    settings.onUpdate = onUpdate
   }
   if (onComplete != null) {
-    settings.setOnComplete(onComplete)
+    settings.onComplete = onComplete
   }
   FlixelTweenGoalScope(settings).goals()
   return FlixelTween.tween(this, settings)
@@ -134,4 +134,4 @@ fun Any.tween(
  * @param next Supplies the tween to start once this one completes.
  * @return This tween, for further chaining.
  */
-inline fun FlixelTween.then(crossinline next: () -> FlixelTween): FlixelTween = then(Supplier { next() })
+inline fun FlixelTween.then(crossinline next: () -> FlixelTween): FlixelTween = then { next() }

--- a/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/util/FlixelColors.kt
+++ b/flixelgdx-ktx/src/main/kotlin/org/flixelgdx/ktx/util/FlixelColors.kt
@@ -1,0 +1,62 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+@file:JvmName("FlixelColors")
+
+package org.flixelgdx.ktx.util
+
+import org.flixelgdx.util.FlixelColor
+
+/**
+ * Idiomatic Kotlin helpers for [FlixelColor].
+ *
+ * These cover the two things Kotlin users reach for most: unpacking a color into its channels with
+ * destructuring, and building a color inline from a packed integer or a hex string. The factory
+ * helpers each allocate a new [FlixelColor], so build colors up front rather than in per-frame code.
+ */
+
+/** The red channel, enabling `val (r, g, b, a) = color`. */
+operator fun FlixelColor.component1(): Float = r
+
+/** The green channel, enabling `val (r, g, b, a) = color`. */
+operator fun FlixelColor.component2(): Float = g
+
+/** The blue channel, enabling `val (r, g, b, a) = color`. */
+operator fun FlixelColor.component3(): Float = b
+
+/** The alpha channel, enabling `val (r, g, b, a) = color`. */
+operator fun FlixelColor.component4(): Float = a
+
+/**
+ * Builds a color from this packed `RGBA8888` integer, as in `0xFF00FFFF.toInt().toFlixelColor()`.
+ *
+ * This allocates a new [FlixelColor].
+ */
+fun Int.toFlixelColor(): FlixelColor = FlixelColor(this)
+
+/**
+ * Builds a color from this hex string, as in `"#ff00ff".toFlixelColor()`.
+ *
+ * This allocates a new [FlixelColor].
+ */
+fun String.toFlixelColor(): FlixelColor = FlixelColor().apply { setColor(this@toFlixelColor) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ graalvm = "24.2.0"
 jansi = "2.4.2"
 jetbrainsAnnotations = "26.1.0"
 junit = "5.10.0"
+kotlin = "2.2.20"
 lwjgl = "3.4.2"
 multidex = "2.0.1"
 spotless = "8.6.0"
@@ -33,6 +34,7 @@ teavm-gradle-plugin = { module = "org.teavm:teavm-gradle-plugin", version.ref = 
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 teavm = { id = "org.teavm", version.ref = "teavm" }
 vanniktech = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,6 +58,7 @@ rootProject.name = "flixelgdx"
 
 include(
   "flixelgdx-core",
+  "flixelgdx-ktx",
   "flixelgdx-jvm",
   "flixelgdx-desktop",
   "flixelgdx-ios",


### PR DESCRIPTION
## Description

Adds a new optional `flixelgdx-ktx` module that layers idiomatic Kotlin syntax on top of `flixelgdx-core` for Kotlin users. It contains only Kotlin extension functions and operators, touches no Java in core, and is deliberately allocation-free so it stays safe in per-frame code (Kotlin stdlib `map`/`filter`/`+` are intentionally not wrapped, since they allocate).

Areas covered:

- **Collections** (`FlixelArray`, primitive arrays, `FlixelMap`): `+=`/`-=`, `in`, `isNotEmpty()`, `indices`/`lastIndex`, primitive-array `iterator()`/inline `forEach`, `map[key] = value`, and `for ((k, v) in map)` destructuring.
- **Groups** (`FlixelGroupable`): `group += member`, `group -= member`, `group[i]`, `for (m in group)`, and a `size` accessor for allocation-free indexed loops.
- **Signals** (`FlixelSignal`): `signal += handler`, `signal -= handler`, and `invoke` so a signal fires with `signal(data)` / `signal()`.
- **Tweening**: a builder DSL, `object.tween(duration = ..., ease = ..., onComplete = ...) { goal({ sprite.x }, 100f) { sprite.x = it } }`, with named/default settings and property goals that map to the primitive `float` goal interfaces (no boxing while the tween runs), plus a `then { }` chaining helper.
- **Math** (`FlixelVector`, `FlixelRect`, `FlixelColor`): allocation-free in-place `+=`/`-=`/`*=`, allocating `+`/`-`/`*`/unary `-` (each documented as returning a new object for use outside hot loops), destructuring, and `Int`/`String` -> `FlixelColor` factories.
- **Pooling** (`FlixelPool`): a `flixelPool { Bullet() }` builder that skips the abstract-subclass ceremony, and an inline `pool.use { }` scoped borrow that frees automatically.

Build wiring: a `flixelgdx.kotlin-library` convention plugin (mirrors `flixelgdx.java-library` without the Javadoc/doclint setup), the Kotlin JVM plugin added to the version catalog and root classpath scope (same `apply false` pattern already used for Spotless/Vanniktech to avoid classloader conflicts), and the module registered in `settings.gradle.kts`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

`./gradlew :flixelgdx-ktx:assemble` builds cleanly. No unit tests were added for this slice (the module is pure syntax sugar over already-tested core APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
