### PR TITLE
Fixed EXTEND and STRETCH viewports not filling the window on resize

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
@@ -279,9 +279,15 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
 
   /**
    * When {@code true}, {@link #update(int, int, boolean)} fits this camera into the screen
-   * rectangle {@code (x, y, width, height)} instead of the full window. When {@code false},
-   * placement is inferred when {@link Flixel#game} has multiple cameras
-   * (horizontal/vertical strips, picture-in-picture, etc.).
+   * rectangle defined by {@code (x, y, width, height)} instead of the full window.
+   *
+   * <p>Set this to {@code true} for split-screen, picture-in-picture, or any camera that
+   * occupies only part of the window. A camera positioned at a non-zero {@link #x} or
+   * {@link #y} is also automatically treated as a sub-screen viewport without needing this flag.
+   *
+   * <p>A camera whose design dimensions are smaller than the current window but that sits at
+   * the window origin (x = 0, y = 0) is still treated as a full-window camera; this flag
+   * must be set explicitly if sub-screen behavior is desired for such a camera.
    */
   public boolean useSubScreenViewport = false;
 
@@ -551,8 +557,12 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
    * Called automatically each frame by {@link #update(float)}.
    */
   public void updateScroll() {
-    float vw = getViewWidth();
-    float vh = getViewHeight();
+    // Use the viewport's actual visible world size so that EXTEND viewports (whose worldWidth
+    // grows beyond the design width when the window is wider) clamp scroll bounds correctly.
+    // For FIT and STRETCH, viewport.getWorldWidth() equals the design width, so this is
+    // equivalent to the old getViewWidth() call.
+    float vw = viewport.getWorldWidth() / zoom;
+    float vh = viewport.getWorldHeight() / zoom;
     // Max is applied before min so that when the level is smaller than the view, the min
     // (left/top) edge wins and the camera stays pinned to the start of the level instead
     // of oscillating between minScroll and maxScroll - vw.
@@ -1287,14 +1297,18 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
     if (game == null || game.getCameras() == null || game.getCameras().getSize() <= 1) {
       return false;
     }
-    boolean coversFullWindow = x <= 0f && y <= 0f && width >= screenWidth && height >= screenHeight;
-    if (coversFullWindow) {
+    // Only treat a camera as a sub-screen viewport when it is explicitly positioned off the
+    // window origin. A camera whose design dimensions are smaller than the current window
+    // (e.g. because the user widened or maximized the window) is still a full-window camera;
+    // it must not be routed through the sub-screen path just because width < screenWidth or
+    // height < screenHeight happens to be true after a resize.
+    //
+    // Cameras that are genuinely sub-screen (split-screen, picture-in-picture) should set
+    // useSubScreenViewport = true, a custom pixel/normalized region, or a non-zero x/y position.
+    if (x <= 0f && y <= 0f && width >= screenWidth && height >= screenHeight) {
       return false;
     }
-    boolean horizontalStrip = width < screenWidth && Math.abs(height - screenHeight) <= 1;
-    boolean verticalStrip = height < screenHeight && Math.abs(width - screenWidth) <= 1;
-    boolean positioned = x != 0f || y != 0f;
-    return horizontalStrip || verticalStrip || positioned;
+    return x != 0f || y != 0f;
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
@@ -34,6 +34,7 @@ import org.flixelgdx.math.FlixelMath;
 import org.flixelgdx.math.FlixelMatrix;
 import org.flixelgdx.math.FlixelRect;
 import org.flixelgdx.math.FlixelVector;
+import org.flixelgdx.text.FlixelText;
 import org.flixelgdx.util.FlixelAxes;
 import org.flixelgdx.util.FlixelBlendMode;
 import org.flixelgdx.util.FlixelColor;
@@ -53,15 +54,15 @@ import org.jetbrains.annotations.Nullable;
  * <p>Every camera wraps a {@link FlixelViewport} internally. By default, a letterboxing
  * ({@link FlixelViewport.Scaling#FIT}) viewport is used. The viewport type is controlled by
  * the static {@link #viewportFactory}; platform launchers override it to supply a different
- * viewport (for example, the Android launcher installs an
- * an extend-style viewport so the game fills the screen without
- * letterboxing). Custom types can also be provided directly via the constructor overloads.
+ * viewport (for example, the Android launcher installs an extend-style viewport so the game fills
+ * the screen without letterboxing). Custom types can also be provided directly via the constructor
+ * overloads.
  *
- * <p>{@link FlixelViewport.Scaling#FIT} scales the game world to the window, so the world-to-screen factor is often
- * not a whole number when the window is larger than the camera's internal size (e.g. fullscreen).
- * integer-snapped glyph quads can look blocky under that scaling; prefer smooth text filtering
- * you draw through this pipeline (FlixelGDX does this for {@link org.flixelgdx.text.FlixelText FlixelText}
- * and registry fonts automatically).
+ * <p>{@link FlixelViewport.Scaling#FIT} scales the game world to the window, so the world-to-screen
+ * factor is often not a whole number when the window is larger than the camera's internal size
+ * (e.g. fullscreen). Integer-snapped glyph quads can look blocky under that scaling; prefer smooth text
+ * filtering you draw through this pipeline (FlixelGDX does this for {@link FlixelText} and registry
+ * fonts automatically).
  */
 public class FlixelCamera extends FlixelBasic implements FlixelColorable, FlixelShaderable {
 
@@ -559,10 +560,9 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
   public void updateScroll() {
     // Use the viewport's actual visible world size so that EXTEND viewports (whose worldWidth
     // grows beyond the design width when the window is wider) clamp scroll bounds correctly.
-    // For FIT and STRETCH, viewport.getWorldWidth() equals the design width, so this is
-    // equivalent to the old getViewWidth() call.
     float vw = viewport.getWorldWidth() / zoom;
     float vh = viewport.getWorldHeight() / zoom;
+
     // Max is applied before min so that when the level is smaller than the view, the min
     // (left/top) edge wins and the camera stays pinned to the start of the level instead
     // of oscillating between minScroll and maxScroll - vw.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.graphics;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.math.FlixelMatrix;
 import org.flixelgdx.math.FlixelRect;
 import org.flixelgdx.math.FlixelVector;
@@ -327,6 +328,7 @@ public class FlixelViewport {
 
   /** How a viewport maps its world onto a window whose shape does not match. */
   public enum Scaling {
+
     /** Scale the world uniformly and letterbox the leftover space. The classic default. */
     FIT,
 
@@ -334,7 +336,7 @@ public class FlixelViewport {
      * Scale uniformly and grow the visible world to fill the screen (no bars, more world shown).
      *
      * <p>This policy works as described when the game renders directly to the window (render
-     * resolution disabled via {@link org.flixelgdx.FlixelGame.Config.Builder#disableRenderResolution()}).
+     * resolution disabled via {@link FlixelGame.Config.Builder#disableRenderResolution()}).
      * When a fixed render resolution is active (the default), the scene surface is a fixed size and
      * cannot extend, so this policy behaves the same as {@link #FIT} within that surface.
      */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
@@ -329,9 +329,24 @@ public class FlixelViewport {
   public enum Scaling {
     /** Scale the world uniformly and letterbox the leftover space. The classic default. */
     FIT,
-    /** Scale uniformly and grow the visible world to fill the screen (no bars, more world). */
+
+    /**
+     * Scale uniformly and grow the visible world to fill the screen (no bars, more world shown).
+     *
+     * <p>This policy works as described when the game renders directly to the window (render
+     * resolution disabled via {@link org.flixelgdx.FlixelGame.Config.Builder#disableRenderResolution()}).
+     * When a fixed render resolution is active (the default), the scene surface is a fixed size and
+     * cannot extend, so this policy behaves the same as {@link #FIT} within that surface.
+     */
     EXTEND,
-    /** Stretch each axis independently to fill the screen, distorting the art. */
+
+    /**
+     * Stretch each axis independently to fill the screen, distorting the art.
+     *
+     * <p>Like {@link #EXTEND}, this policy only fills the full window when the game renders
+     * directly to the window (render resolution disabled). With a fixed render resolution active,
+     * the distortion is applied to the fixed surface, which is then upscaled by the compositor.
+     */
     STRETCH
   }
 }


### PR DESCRIPTION
## Description

When using the `EXTEND` or `STRETCH` viewport scaling mode with render resolution disabled, dragging the window wider (while keeping the same height) produced a black bar on the right side instead of filling the new area. Maximizing worked correctly because both dimensions changed at once; only single-axis resizes were broken.

**Root cause:** `shouldUseSubScreenViewport()` in `FlixelCamera` used `horizontalStrip` / `verticalStrip` heuristics to auto-detect split-screen cameras. The `horizontalStrip` condition (`width < screenWidth && |height - screenHeight| <= 1`) fired whenever only the window's width changed (height was close to the design height), incorrectly routing the camera through `updateSubScreenViewport()`. That path locks the viewport to the camera's design dimensions, leaving the widened portion blank.

Additionally, `updateScroll()` clamped scroll bounds using `getViewWidth()` (design-width divided by zoom) rather than the viewport's actual world width, producing wrong bounds for `EXTEND` viewports whose visible world is wider than the design size.

**Fixes:**
- Removed the `horizontalStrip` / `verticalStrip` heuristics from `shouldUseSubScreenViewport()`. The method now only routes through the sub-screen path when the camera is explicitly configured for it (`useSubScreenViewport = true`, a custom pixel/normalized region, or a non-zero `x`/`y` position).
- Changed `updateScroll()` to read `viewport.getWorldWidth()` / `viewport.getWorldHeight()` so EXTEND viewports clamp to the actual visible world bounds.
- Documented the `useSubScreenViewport` field more clearly, explaining when to set it for split-screen or picture-in-picture cameras.
- Updated the `EXTEND` and `STRETCH` Javadoc in `FlixelViewport.Scaling` to note the render resolution limitation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Verified against the "Multiverse Mayhem" test project with render resolution disabled. Before the fix: dragging the window wider left a black bar on the right edge. After the fix: the viewport fills the full window correctly for both `EXTEND` (more world visible) and `STRETCH` (distorted to fill) modes.