### PR TITLE
Reworked the entire rendering pipeline to use a Y-down coordinate system, matching modern graphics APIs and HaxeFlixel

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
@@ -198,7 +198,7 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
   public FlixelColor color = new FlixelColor(FlixelColor.WHITE);
 
   /**
-   * The dead zone rectangle, measured from the camera's bottom-left corner in game pixels.
+   * The dead zone rectangle, measured from the camera's top-left corner in game pixels.
    *
    * <p>The camera always keeps the follow target inside this zone, unless bumping against scroll
    * bounds. For rapid prototyping, use the preset styles via
@@ -1519,7 +1519,7 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
    * extended area are not incorrectly culled.
    *
    * @param viewX Left edge of the rectangle in view space.
-   * @param viewY Bottom edge of the rectangle in view space.
+   * @param viewY Top edge of the rectangle in view space (view Y increases downward).
    * @param width Width of the rectangle.
    * @param height Height of the rectangle.
    * @return {@code true} if the rectangle is at least partially visible.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -617,9 +617,10 @@ public abstract class FlixelGame implements FlixelUpdatable, FlixelDrawable, Fli
           if (camera.width != fboOrthoW || camera.height != fboOrthoH) {
             fboOrthoW = camera.width;
             fboOrthoH = camera.height;
-            // Match the active backend's depth range; the 4-arg overload assumes OpenGL's [-1, 1],
-            // which depth-clips the composite quad to black on Vulkan, Metal, and Direct3D.
-            fboOrtho.setToOrtho2D(0, 0, fboOrthoW, fboOrthoH, Flixel.graphics.isDepthZeroToOne());
+            // Y-down composite ortho so the blit matches the batch's Y-down vertex layout and the
+            // camera FBO draws upright. Match the active backend's depth range too; the [-1, 1]
+            // default depth-clips the composite quad to black on Vulkan, Metal, and Direct3D.
+            fboOrtho.setToOrtho2DYDown(0, 0, fboOrthoW, fboOrthoH, Flixel.graphics.isDepthZeroToOne());
           }
           batch.setProjection(fboOrtho);
           batch.setShader(cameraShader);
@@ -1026,9 +1027,10 @@ public abstract class FlixelGame implements FlixelUpdatable, FlixelDrawable, Fli
       if (w != fboOrthoW || h != fboOrthoH) {
         fboOrthoW = w;
         fboOrthoH = h;
-        // Same depth-range caveat as the per-camera composite: without the backend flag this quad
-        // is clipped to black on the [0, 1] depth backends (Vulkan, Metal, Direct3D).
-        fboOrtho.setToOrtho2D(0, 0, w, h, Flixel.graphics.isDepthZeroToOne());
+        // Y-down composite ortho (see the per-camera pass) so each chained shader draws upright.
+        // Same depth-range caveat: without the backend flag this quad is clipped to black on the
+        // [0, 1] depth backends (Vulkan, Metal, Direct3D).
+        fboOrtho.setToOrtho2DYDown(0, 0, w, h, Flixel.graphics.isDepthZeroToOne());
       }
       batch.setProjection(fboOrtho);
       batch.setShader(gs);

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
@@ -1031,25 +1031,25 @@ public class FlixelObject extends FlixelBasic implements FlixelDebugDrawable, Fl
     float maxOverlap = checkMaxOverlap ? (obj1deltaAbs + obj2deltaAbs + SEPARATE_BIAS) : 0;
     float overlap;
 
-    // Y-up: positive delta = moving up -> object1's top hits object2's bottom.
+    // Y-down: positive delta = moving down -> object1's bottom hits object2's top.
     if (obj1delta > obj2delta) {
       overlap = object1.y + object1.height - object2.y;
       if (checkMaxOverlap && overlap > maxOverlap)
-        return 0;
-      if ((object1.allowCollisions & FlixelDirectionFlags.UP) == 0
-          || (object2.allowCollisions & FlixelDirectionFlags.DOWN) == 0)
-        return 0;
-      object1.touching |= FlixelDirectionFlags.UP;
-      object2.touching |= FlixelDirectionFlags.DOWN;
-    } else {
-      overlap = object1.y - object2.height - object2.y;
-      if (checkMaxOverlap && -overlap > maxOverlap)
         return 0;
       if ((object1.allowCollisions & FlixelDirectionFlags.DOWN) == 0
           || (object2.allowCollisions & FlixelDirectionFlags.UP) == 0)
         return 0;
       object1.touching |= FlixelDirectionFlags.DOWN;
       object2.touching |= FlixelDirectionFlags.UP;
+    } else {
+      overlap = object1.y - object2.height - object2.y;
+      if (checkMaxOverlap && -overlap > maxOverlap)
+        return 0;
+      if ((object1.allowCollisions & FlixelDirectionFlags.UP) == 0
+          || (object2.allowCollisions & FlixelDirectionFlags.DOWN) == 0)
+        return 0;
+      object1.touching |= FlixelDirectionFlags.UP;
+      object2.touching |= FlixelDirectionFlags.DOWN;
     }
 
     return overlap;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -572,7 +572,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     float wy = cam.worldToViewY(getY(), scrollY);
 
     float drawLeft = wx + offsetX;
-    float drawBottom = wy + offsetY;
+    float drawTop = wy + offsetY;
     // Use the actual graphic dimensions for culling rather than the hitbox, since the hitbox may
     // have been shrunk independently (e.g. via setSize()) while the visible sprite remains larger.
     float cullW = f.originalWidth * Math.abs(scaleX);
@@ -584,11 +584,11 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       float rotW = cos * cullW + sin * cullH;
       float rotH = sin * cullW + cos * cullH;
       drawLeft -= (rotW - cullW) * 0.5f;
-      drawBottom -= (rotH - cullH) * 0.5f;
+      drawTop -= (rotH - cullH) * 0.5f;
       cullW = rotW;
       cullH = rotH;
     }
-    if (!cam.isInView(drawLeft, drawBottom, cullW, cullH)) {
+    if (!cam.isInView(drawLeft, drawTop, cullW, cullH)) {
       return;
     }
 
@@ -626,7 +626,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     float drawX = wx + offsetX + insetX + srcW * (scaleX - 1) * 0.5f;
     float drawY = wy + offsetY + insetY + srcH * (scaleY - 1) * 0.5f;
 
-    // Rotate/scale around the source box's center, expressed relative to the region's bottom-left
+    // Rotate/scale around the source box's center, expressed relative to the region's top-left
     // corner (the origin that the batch.draw(...) overload below measures from).
     float originXParam = srcW / 2f - insetX;
     float originYParam = srcH / 2f - insetY;
@@ -922,8 +922,8 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   /**
-   * Sets the pivot point used for rotation and scale, measured from the sprite's bottom-left draw
-   * corner in pixels. Default is {@code (0, 0)}, which rotates and scales around the bottom-left
+   * Sets the pivot point used for rotation and scale, measured from the sprite's top-left draw
+   * corner in pixels. Default is {@code (0, 0)}, which rotates and scales around the top-left
    * corner. Call {@link #setOriginCenter()} to rotate around the center instead.
    *
    * @param originX Horizontal pivot offset in pixels.
@@ -1211,7 +1211,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    *
    * <p>Only the region inside the rectangle is drawn; pixels outside are discarded by the GPU
    * scissor. Coordinates are in the same units as {@link #getWidth()}/{@link #getHeight()} - that
-   * is, they already account for scale, so {@code x=0, y=0} anchors to the drawn bottom-left
+   * is, they already account for scale, so {@code x=0, y=0} anchors to the drawn top-left
    * corner and {@code width=getWidth()} covers the full drawn width regardless of scale.
    *
    * <p>For example, to show only the left half of a sprite regardless of its current scale:

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -165,7 +165,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   private float clipRectX;
 
   /**
-   * Y offset of the clip rectangle's bottom edge, in screen pixels from the sprite's drawn bottom edge.
+   * Y offset of the clip rectangle's top edge, in screen pixels from the sprite's drawn bottom edge.
    * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(float, float, float, float)}.
    */
   private float clipRectY;
@@ -1224,7 +1224,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * }</pre>
    *
    * @param x Left edge of the visible region, in screen pixels from the sprite's drawn left edge.
-   * @param y Bottom edge of the visible region, in screen pixels from the sprite's drawn bottom edge.
+   * @param y Top edge of the visible region, in screen pixels from the sprite's drawn bottom edge.
    * @param width Width of the visible region, in screen pixels.
    * @param height Height of the visible region, in screen pixels.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
@@ -48,9 +48,9 @@ import java.util.Objects;
  * <ul>
  *   <li>An integer index into {@link #atlas} selecting which bitmap slice to draw.</li>
  *   <li>A fully baked {@link FlixelAffine} that already contains (a) the Flash {@code MX} or {@code M3D}
- *   matrix chain from the root symbol or stage down to the leaf bitmap, (b) a Y-axis flip that converts
- *   Adobe Animate's Y-down bitmap space into the renderer's Y-up texture-region space, and (c) an anchor translation
- *   that shifts the whole rig so the anchor-clip bounding box starts at {@code (0, 0)}.</li>
+ *   matrix chain from the root symbol or stage down to the leaf bitmap and (b) an anchor translation
+ *   that shifts the whole rig so the anchor-clip bounding box starts at {@code (0, 0)}. No Y-axis flip
+ *   is needed: Adobe Animate's Y-down bitmap space already matches the renderer's Y-down space.</li>
  * </ul>
  *
  * <p>Because every matrix is baked at load time, the per-frame draw path is reduced to one translate, one

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
@@ -79,23 +79,14 @@ import java.util.Objects;
  *   m10 = b;   m11 = d;   m12 = ty;
  * </pre>
  *
- * <h2>Coordinate flip</h2>
- * Adobe Animate uses Y-down pixel space (the top-left of a bitmap is {@code (0, 0)}). The
- * renderer draws a frame with its bottom-left
- * at the supplied local origin when a Y-up projection is active (which is the FlixelGDX default). The
- * loader bakes two Y-flips into every part so the draw path can stay a simple
- * {@code translate * scale * part}:
- * <ol>
- *   <li>A <strong>per-bitmap flip</strong> {@code [1, 0, 0; 0, -1, origH]} that turns the
- *   renderer's local-space Y-up rectangle into Adobe's Y-down rectangle, applied on the <em>right</em> so that
- *   the existing {@code MX} chain keeps interpreting its input as Flash-local. Parts packed rotated
- *   90 degrees clockwise use an extended matrix {@code [0, -1, origW; -1, 0, origH]} that
- *   simultaneously un-rotates and Y-flips.</li>
- *   <li>A <strong>rig-wide flip</strong> {@code [1, 0, -anchorMinX; 0, -1, anchorMinY + anchorHeight]}
- *   that turns Flash-world coordinates back into Y-up world coordinates after all Flash matrices have
- *   been composed, and simultaneously shifts the anchor bounding box so its bottom-left corner sits at
- *   the sprite's origin.</li>
- * </ol>
+ * <h2>Coordinate space</h2>
+ * Adobe Animate uses Y-down pixel space (the top-left of a bitmap is {@code (0, 0)}), which is exactly
+ * the space the FlixelGDX renderer draws in. No coordinate flips are needed: a frame is drawn with its
+ * top-left at the supplied local origin, so the loader only slides the composed Flash-world coordinates
+ * so that the anchor bounding box's top-left corner sits at the sprite's origin. The per-part bake is a
+ * simple {@code anchorShift * P_flash}, where {@code anchorShift = translate(-anchorMinX, -anchorMinY)}.
+ * Parts packed rotated 90 degrees clockwise are un-rotated by swapping the affine's two linear columns
+ * (see {@link #bakePartAffine}).
  *
  * <h2>Layer z-order</h2>
  * In Flash (and in Adobe Animate's exported JSON), the <strong>first</strong> layer in {@code TL.L} is
@@ -304,7 +295,7 @@ final class FlixelAnimateRigLoader {
     float anchorHeight = anchorBox[3] - anchorMinY;
 
     FlixelMap<String, FlixelAnimateRig.Clip> clips = new FlixelMap<>();
-    bakeClipsInto(parsed, fps, atlas, nameToIndex, anchorMinX, anchorMinY, anchorHeight, controller, clips);
+    bakeClipsInto(parsed, fps, atlas, nameToIndex, anchorMinX, anchorMinY, controller, clips);
 
     String resolvedAnchorName = parsed.clipDefs.get(anchorClipIndex).name;
     FlixelAnimateRig rig = new FlixelAnimateRig(
@@ -397,7 +388,6 @@ final class FlixelAnimateRigLoader {
         nameToIndex,
         existing.anchorMinX,
         existing.anchorMinY,
-        existing.anchorHeight,
         controller,
         existing.clips);
   }
@@ -419,8 +409,6 @@ final class FlixelAnimateRigLoader {
    * @param nameToIndex Sprite name to atlas index lookup, already offset to point into {@code atlas}.
    * @param anchorMinX Anchor bounding-box minimum X in Flash Y-down world space.
    * @param anchorMinY Anchor bounding-box minimum Y in Flash Y-down world space.
-   * @param anchorHeight Anchor bounding-box height in pixels (used by the Y-flip in
-   *   {@link #bakePartAffine}).
    * @param controller The controller to register clip durations on (one
    *   {@link FlixelAnimation} per clip name).
    * @param clipsOut The map to populate. Existing entries with the same name are overwritten.
@@ -432,7 +420,6 @@ final class FlixelAnimateRigLoader {
       @NotNull FlixelObjectIntMap<String> nameToIndex,
       float anchorMinX,
       float anchorMinY,
-      float anchorHeight,
       @NotNull FlixelAnimationController controller,
       @NotNull FlixelMap<String, FlixelAnimateRig.Clip> clipsOut) {
     FlixelArray<RawPart> scratchRaw = new FlixelArray<>(32);
@@ -457,10 +444,7 @@ final class FlixelAnimateRigLoader {
           RawPart raw = scratchRaw.get(p);
           FlixelFrame frame = atlas.get(raw.atlasIndex);
           FlixelAnimateRig.Part part = new FlixelAnimateRig.Part(raw.atlasIndex);
-          bakePartAffine(
-              part.local, raw.flashMatrix,
-              frame.originalWidth, frame.originalHeight, frame.rotated,
-              anchorMinX, anchorMinY, anchorHeight);
+          bakePartAffine(part.local, raw.flashMatrix, frame.rotated, anchorMinX, anchorMinY);
           parts[p] = part;
         }
         kfs[t] = new FlixelAnimateRig.Keyframe(parts);
@@ -1024,38 +1008,31 @@ final class FlixelAnimateRigLoader {
   /**
    * Bakes the final draw-ready affine for a single part.
    *
-   * <p>For a non-rotated part the result equals {@code anchorShift * flipRig * P_flash * flipBitmap},
-   * where {@code flipBitmap = [1, 0, 0; 0, -1, origH]} converts Y-up local bitmap coordinates
-   * to Flash Y-down, and {@code anchorShift * flipRig} converts the resulting Flash-world point back
-   * to Y-up while sliding the anchor bounding box's bottom-left corner onto the sprite origin.
+   * <p>Adobe Animate authors in Y-down pixel space with each bitmap's origin at its top-left corner,
+   * which is exactly the space the Y-down renderer draws in. The only work left is therefore to slide
+   * the anchor bounding box's top-left corner onto the sprite origin, so the result equals
+   * {@code anchorShift * P_flash}, where {@code anchorShift = translate(-anchorMinX, -anchorMinY)}.
    *
-   * <p>For a part that was packed rotated 90 degrees clockwise in the atlas, Adobe Animate stores
-   * the sprite sideways: the atlas footprint is {@code origH} pixels wide and {@code origW} pixels
-   * tall. The draw call therefore produces a quad in {@code [0, origH] x [0, origW]} local space, so
-   * a different per-bitmap matrix {@code rotFlipBitmap = [0, -1, origW; -1, 0, origH]} is substituted
-   * for {@code flipBitmap}. This matrix un-rotates and Y-flips in one step, mapping each atlas-local
-   * coordinate back to the correct Flash-local position.
+   * <p>For a part that was packed rotated 90 degrees clockwise in the atlas, Adobe stores the sprite
+   * sideways: the atlas footprint is {@code origH} pixels wide and {@code origW} pixels tall, so the
+   * draw call produces a quad in {@code [0, origH] x [0, origW]} local space. Composing the un-rotation
+   * with the identical Y-down bitmap and world spaces reduces to swapping the affine's two linear
+   * columns; no dimension or sign terms survive.
    *
    * <p>Exposed as package-private so the geometry can be unit-tested without a GPU texture.
    *
    * @param out The destination affine; overwritten.
    * @param flashWorld The accumulated Flash-world matrix for this part.
-   * @param origW The logical width of the part in Flash space ({@link FlixelFrame#originalWidth}).
-   * @param origH The logical height of the part in Flash space ({@link FlixelFrame#originalHeight}).
    * @param rotated Whether this part was packed rotated 90 degrees clockwise in the atlas.
    * @param anchorMinX The minimum X of the anchor bounding box in Flash-world space.
    * @param anchorMinY The minimum Y of the anchor bounding box in Flash-world space.
-   * @param anchorHeight The height of the anchor bounding box.
    */
   static void bakePartAffine(
       @NotNull FlixelAffine out,
       @NotNull FlixelAffine flashWorld,
-      float origW,
-      float origH,
       boolean rotated,
       float anchorMinX,
-      float anchorMinY,
-      float anchorHeight) {
+      float anchorMinY) {
     float p00 = flashWorld.m00;
     float p01 = flashWorld.m01;
     float p02 = flashWorld.m02;
@@ -1063,30 +1040,22 @@ final class FlixelAnimateRigLoader {
     float p11 = flashWorld.m11;
     float p12 = flashWorld.m12;
 
-    float shiftY = anchorMinY + anchorHeight;
-
     if (rotated) {
-      // rotFlipBitmap = [0, -1, origW; -1, 0, origH].
-      // P_flash * rotFlipBitmap then anchorShift * flipRig on the left:
-      out.m00 = -p01;
-      out.m01 = -p00;
-      out.m02 = p00 * origW + p01 * origH + p02 - anchorMinX;
+      // Un-rotating the 90-degrees-CW packing in Y-down space swaps the two linear columns.
+      out.m00 = p01;
+      out.m01 = p00;
+      out.m02 = p02 - anchorMinX;
       out.m10 = p11;
       out.m11 = p10;
-      out.m12 = shiftY - p10 * origW - p11 * origH - p12;
+      out.m12 = p12 - anchorMinY;
     } else {
-      // flipBitmap = [1, 0, 0; 0, -1, origH].
-      // P_flash * flipBitmap then anchorShift * flipRig on the left:
-      float fw01 = -p01;
-      float fw02 = p01 * origH + p02;
-      float fw11 = -p11;
-      float fw12 = p11 * origH + p12;
+      // Flash bitmap space is already Y-down with a top-left origin, so only the anchor shift remains.
       out.m00 = p00;
-      out.m01 = fw01;
-      out.m02 = fw02 - anchorMinX;
-      out.m10 = -p10;
-      out.m11 = -fw11;
-      out.m12 = shiftY - fw12;
+      out.m01 = p01;
+      out.m02 = p02 - anchorMinX;
+      out.m10 = p10;
+      out.m11 = p11;
+      out.m12 = p12 - anchorMinY;
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelBatch.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelBatch.java
@@ -101,7 +101,7 @@ public interface FlixelBatch extends FlixelDestroyable {
    *
    * @param frame The frame to draw.
    * @param x Left edge in world units.
-   * @param y Bottom edge in world units.
+   * @param y Top edge in world units (world Y increases downward).
    * @param width Drawn width in world units.
    * @param height Drawn height in world units.
    */
@@ -111,18 +111,18 @@ public interface FlixelBatch extends FlixelDestroyable {
    * Draws a frame with scaling, rotation, and mirroring around an origin point.
    *
    * <p>This is the workhorse overload sprites render through. The origin is measured from the
-   * quad's bottom-left corner in unscaled pixels; scaling and rotation happen around it.
+   * quad's top-left corner in unscaled pixels; scaling and rotation happen around it.
    *
    * @param frame The frame to draw.
    * @param x Left edge of the unscaled quad in world units.
-   * @param y Bottom edge of the unscaled quad in world units.
+   * @param y Top edge of the unscaled quad in world units (world Y increases downward).
    * @param originX Origin x, relative to {@code x}.
    * @param originY Origin y, relative to {@code y}.
    * @param width Unscaled quad width.
    * @param height Unscaled quad height.
    * @param scaleX Horizontal scale factor around the origin.
    * @param scaleY Vertical scale factor around the origin.
-   * @param rotation Rotation in degrees, counter-clockwise around the origin.
+   * @param rotation Rotation in degrees, clockwise around the origin on screen.
    * @param flipX {@code true} to mirror horizontally.
    * @param flipY {@code true} to mirror vertically.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelFrame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelFrame.java
@@ -161,23 +161,23 @@ public final class FlixelFrame {
   }
 
   /**
-   * Computes where the trimmed region's bottom edge sits inside the source box, in pixels measured
-   * <strong>upward</strong> from the box's bottom edge.
+   * Computes where the trimmed region's top edge sits inside the source box, in pixels measured
+   * <strong>downward</strong> from the box's top edge.
    *
-   * <p>The renderer works in a y-up space (larger y is higher on screen), so a region is positioned
-   * by its bottom-left corner. The unflipped bottom inset is the empty space below the art inside
-   * the source box ({@code sourceHeight - regionHeight - offsetY}); keeping it constant across an
-   * animation's frames is exactly what plants a character's feet. A vertical flip swaps the top and
-   * bottom gaps, leaving {@link #offsetY} as the new bottom inset.
+   * <p>The renderer works in a y-down space (larger y is lower on screen), so a region is positioned
+   * by its top-left corner. The unflipped top inset is simply the empty space above the art inside
+   * the source box ({@link #offsetY}); keeping it constant across an animation's frames is exactly
+   * what keeps a character steady. A vertical flip swaps the top and bottom gaps, leaving
+   * {@code sourceHeight - regionHeight - offsetY} as the new top inset.
    *
    * @param sourceHeight The untrimmed frame height ({@link #originalHeight}).
    * @param regionHeight The trimmed region height ({@link #getRegionHeight()}).
    * @param offsetY The top trim offset ({@link #offsetY}).
    * @param flipY Whether the frame is drawn mirrored vertically.
-   * @return The bottom inset of the region inside the source box, in pixels.
+   * @return The top inset of the region inside the source box, in pixels.
    */
   public static int regionInsetY(int sourceHeight, int regionHeight, int offsetY, boolean flipY) {
-    return flipY ? offsetY : (sourceHeight - regionHeight - offsetY);
+    return flipY ? (sourceHeight - regionHeight - offsetY) : offsetY;
   }
 
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
@@ -209,8 +209,8 @@ public class FlixelViewport {
     float visibleH = worldHeight * viewScale;
     float left = cameraX - visibleW / 2f;
     // The framebuffer scissor is measured from the window's bottom-left, but the world is Y-down and
-    // {@code worldY} is the rectangle's top edge. Its framebuffer-bottom therefore lines up with the
-    // clip's world bottom edge ({@code worldY + worldH}), measured down from the view's bottom.
+    // worldY is the rectangle's top edge. Its framebuffer-bottom therefore lines up with the clip's
+    // world bottom edge (worldY + worldH), measured down from the view's bottom.
     float worldBottomOfView = cameraY + visibleH / 2f;
     float sx = screenX + ((worldX - left) / visibleW) * screenWidth;
     float sy = screenY + ((worldBottomOfView - (worldY + worldH)) / visibleH) * screenHeight;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
@@ -182,7 +182,9 @@ public class FlixelViewport {
     float visibleW = worldWidth * viewScale;
     float visibleH = worldHeight * viewScale;
     screenCoords.x = cameraX + (relX - 0.5f) * visibleW;
-    screenCoords.y = cameraY + (relY - 0.5f) * visibleH;
+    // Y-down world: window top (smaller Y) maps to the smaller world Y, so the vertical term is
+    // negated relative to a Y-up projection.
+    screenCoords.y = cameraY - (relY - 0.5f) * visibleH;
     return screenCoords;
   }
 
@@ -195,7 +197,7 @@ public class FlixelViewport {
    * Rotation is ignored, which is fine for the axis-aligned clip rectangles game code sets.
    *
    * @param worldX Left edge in world coordinates.
-   * @param worldY Bottom edge in world coordinates.
+   * @param worldY Top edge in world coordinates (world Y increases downward).
    * @param worldW Width in world units.
    * @param worldH Height in world units.
    * @param out Reused output rectangle: {@code (x, y, width, height)} in framebuffer pixels.
@@ -206,9 +208,12 @@ public class FlixelViewport {
     float visibleW = worldWidth * viewScale;
     float visibleH = worldHeight * viewScale;
     float left = cameraX - visibleW / 2f;
-    float bottom = cameraY - visibleH / 2f;
+    // The framebuffer scissor is measured from the window's bottom-left, but the world is Y-down and
+    // {@code worldY} is the rectangle's top edge. Its framebuffer-bottom therefore lines up with the
+    // clip's world bottom edge ({@code worldY + worldH}), measured down from the view's bottom.
+    float worldBottomOfView = cameraY + visibleH / 2f;
     float sx = screenX + ((worldX - left) / visibleW) * screenWidth;
-    float sy = screenY + ((worldY - bottom) / visibleH) * screenHeight;
+    float sy = screenY + ((worldBottomOfView - (worldY + worldH)) / visibleH) * screenHeight;
     float sw = (worldW / visibleW) * screenWidth;
     float sh = (worldH / visibleH) * screenHeight;
     return out.set(sx, sy, sw, sh);
@@ -225,11 +230,17 @@ public class FlixelViewport {
       matrixDirty = false;
       float visibleW = worldWidth * viewScale;
       float visibleH = worldHeight * viewScale;
-      combined.setToOrtho2D(cameraX - visibleW / 2f, cameraY - visibleH / 2f, visibleW, visibleH,
-          Flixel.graphics.isDepthZeroToOne());
+      float halfW = visibleW / 2f;
+      float halfH = visibleH / 2f;
+      // Y-down projection: the bottom clipping plane sits at the larger world Y and the top plane
+      // at the smaller one, so world Y increases downward on screen. This puts world (0, 0) at the
+      // top-left corner, matching most graphics APIs and the framework's top-left origin convention.
+      combined.setToOrtho(cameraX - halfW, cameraX + halfW, cameraY + halfH, cameraY - halfH,
+          0f, 1f, Flixel.graphics.isDepthZeroToOne());
       if (rotation != 0f) {
+        // Positive rotation turns clockwise on screen (matching sprite angles) under the Y-down axis.
         combined.translate(cameraX, cameraY, 0f);
-        combined.rotateZ(-rotation);
+        combined.rotateZ(rotation);
         combined.translate(-cameraX, -cameraY, 0f);
       }
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputDevice.java
@@ -45,9 +45,9 @@ import org.flixelgdx.input.mouse.FlixelMouseButton;
  * implements what its platform actually supports.
  *
  * <p>Screen coordinates are in pixels with the origin at the top-left corner: X grows to the right
- * and Y grows downward. This matches raw window coordinates and is <i>not</i> the same as FlixelGDX
- * world coordinates, whose origin is bottom-left; convert through a {@code FlixelCamera} when you
- * need world space.
+ * and Y grows downward. This matches raw window coordinates; FlixelGDX world coordinates share the
+ * same top-left origin and downward Y but are offset and scaled by the camera, so convert through a
+ * {@code FlixelCamera} when you need world space.
  *
  * <p>Example:
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
@@ -161,7 +161,7 @@ public interface FlixelDigitalBinding {
 
   /**
    * World-space region binding. Fires when any active touch pointer's unprojected world position
-   * falls inside the rectangle. Coordinates use the bottom-left origin (Y increases upward),
+   * falls inside the rectangle. Coordinates use the top-left origin (Y increases downward),
    * matching the standard game-world convention used by cameras and game objects.
    *
    * <p>World coordinates are taken from {@link FlixelTouch#worldX} and {@link FlixelTouch#worldY},

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/package-info.java
@@ -59,7 +59,7 @@
  * {@link org.flixelgdx.input.mouse.FlixelMouseInputManager#getWorldY() getWorldY()}) is the
  * result of unprojecting the screen position through the active
  * {@link org.flixelgdx.FlixelCamera FlixelCamera} and uses the standard FlixelGDX origin at the
- * bottom-left: X increases right, Y increases up. Use this to test whether the cursor is over a
+ * top-left: X increases right, Y increases down. Use this to test whether the cursor is over a
  * game object.
  *
  * <p>By default, the first camera in {@link org.flixelgdx.Flixel#cameras Flixel.cameras} is used

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/package-info.java
@@ -89,8 +89,8 @@
  *
  * <p>All raw pointer positions (mouse, touch, the getters on {@link org.flixelgdx.input.FlixelInputDevice}) use
  * screen-space pixels with the origin in the top-left corner: X grows right, Y grows down.
- * This matches raw window coordinates and differs from FlixelGDX world coordinates, whose origin
- * is bottom-left. Convert between the two through a
+ * This matches raw window coordinates. FlixelGDX world coordinates share the same top-left origin
+ * and downward Y but are offset and scaled by the camera. Convert between the two through a
  * {@link org.flixelgdx.FlixelCamera FlixelCamera}; the mouse and touch managers do this
  * automatically when you read {@code getWorldX()} or
  * {@link org.flixelgdx.input.touch.FlixelTouch#worldX FlixelTouch.worldX}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouch.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouch.java
@@ -37,8 +37,8 @@ package org.flixelgdx.input.touch;
  * }</pre>
  *
  * <p>Screen coordinates use a top-left origin (Y increases downward). World coordinates are
- * unprojected via the touch manager's active camera and use the standard bottom-left origin
- * (Y increases upward), matching the rest of the scene.
+ * unprojected via the touch manager's active camera and use the standard top-left origin
+ * (Y increases downward), matching the rest of the scene.
  *
  * <p>State fields ({@link #screenX}, {@link #screenY}, {@link #worldX}, {@link #worldY},
  * {@link #pointer}) are public for zero-overhead reads. The boolean state is exposed through

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouchManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouchManager.java
@@ -67,7 +67,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Each {@link FlixelTouch} carries both screen and world coordinates. Screen coordinates use the
  * top-left origin (Y increases downward). World coordinates are unprojected via the
- * manager's active camera and use the standard bottom-left origin (Y increases upward), matching
+ * manager's active camera and use the standard top-left origin (Y increases downward), matching
  * the rest of the scene. Set a custom camera with {@link #setWorldCamera(FlixelCamera)};
  * otherwise the first camera in {@link Flixel#cameras} is used.
  *
@@ -406,7 +406,7 @@ public class FlixelTouchManager implements FlixelInputManager, FlixelTouchListen
   /**
    * Returns {@code true} while any active pointer is inside the given world-space rectangle.
    *
-   * <p>Coordinates use the bottom-left origin (Y increases upward), matching the game world.
+   * <p>Coordinates use the top-left origin (Y increases downward), matching the game world.
    * Use this to track a finger held inside an area. For detecting the moment a finger lands,
    * use {@link #justTouchedWorld(float, float, float, float)} instead.
    *
@@ -476,7 +476,7 @@ public class FlixelTouchManager implements FlixelInputManager, FlixelTouchListen
   /**
    * Returns {@code true} on the single frame any pointer first touches the given world-space rectangle.
    *
-   * <p>Coordinates use the bottom-left origin (Y increases upward), matching the game world.
+   * <p>Coordinates use the top-left origin (Y increases downward), matching the game world.
    * Clears to {@code false} after the frame ends, matching the timing of
    * {@link FlixelTouch#justPressed()}.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/package-info.java
@@ -100,7 +100,7 @@
  * ({@link org.flixelgdx.input.touch.FlixelTouch#worldX FlixelTouch.worldX},
  * {@link org.flixelgdx.input.touch.FlixelTouch#worldY FlixelTouch.worldY}) are unprojected
  * through the active {@link org.flixelgdx.FlixelCamera FlixelCamera} and use the standard
- * FlixelGDX bottom-left origin: X increases right, Y increases up. These match the positions of
+ * FlixelGDX top-left origin: X increases right, Y increases down. These match the positions of
  * game objects in the scene. By default, the first camera in
  * {@link org.flixelgdx.Flixel#cameras Flixel.cameras} is used; call
  * {@link org.flixelgdx.input.touch.FlixelTouchManager#setWorldCamera(org.flixelgdx.FlixelCamera)

--- a/flixelgdx-core/src/main/java/org/flixelgdx/math/FlixelMatrix.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/math/FlixelMatrix.java
@@ -196,6 +196,26 @@ public class FlixelMatrix {
   }
 
   /**
+   * Sets this matrix to a 2D orthographic projection with a Y-down (top-left) origin: {@code y} is
+   * the top edge of the projected region and {@code y + height} is the bottom edge.
+   *
+   * <p>This matches the framework's Y-down world convention and the batch's vertex layout, so a
+   * screen-space composite pass (a render-target blit or a post-processing shader chain) draws its
+   * texture upright. Use the plain {@link #setToOrtho2D(float, float, float, float, boolean)} only
+   * where a legacy bottom-left origin is genuinely wanted.
+   *
+   * @param x The left edge of the projected region.
+   * @param y The top edge of the projected region.
+   * @param width The width of the projected region.
+   * @param height The height of the projected region.
+   * @param zeroToOne {@code true} for {@code [0, 1]} depth range, {@code false} for {@code [-1, 1]}.
+   * @return This matrix, for chaining.
+   */
+  public @NotNull FlixelMatrix setToOrtho2DYDown(float x, float y, float width, float height, boolean zeroToOne) {
+    return setToOrtho(x, x + width, y + height, y, 0f, 1f, zeroToOne);
+  }
+
+  /**
    * Sets this matrix to a general orthographic projection using the OpenGL NDC depth convention
    * ({@code [-1, 1]}).
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -955,7 +955,7 @@ public class FlixelText extends FlixelSprite {
     batch.setColor(borderColor);
 
     switch (borderStyle) {
-      case SHADOW -> layout.draw(batch, x + borderSize, y - borderSize);
+      case SHADOW -> layout.draw(batch, x + borderSize, y + borderSize);
 
       case OUTLINE_FAST -> {
         layout.draw(batch, x - borderSize, y);

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -703,8 +703,8 @@ public class FlixelText extends FlixelSprite {
     float rotation = getAngle();
     boolean needsTransform = rotation != 0 || scaleX != 1 || scaleY != 1;
 
-    float textTop = getHeight();
-
+    // The object's (x, y) is its top-left corner in the Y-down world, so the text block's top edge
+    // is drawn directly at wy with no vertical offset.
     if (needsTransform) {
       savedTransform.set(batch.getTransform());
 
@@ -717,11 +717,11 @@ public class FlixelText extends FlixelSprite {
       textTransform.translate(-ox, -oy, 0);
       batch.setTransform(textTransform);
 
-      drawTextContent(batch, 0, textTop);
+      drawTextContent(batch, 0, 0);
 
       batch.setTransform(savedTransform);
     } else {
-      drawTextContent(batch, wx, wy + textTop);
+      drawTextContent(batch, wx, wy);
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelTextLayout.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelTextLayout.java
@@ -39,8 +39,8 @@ import org.jetbrains.annotations.NotNull;
  * rendered cheaply.
  *
  * <p>All output coordinates are in game pixels, measured from the text block's top-left
- * corner: {@code x} grows right, and glyph positions are stored as the distance from the top
- * so the draw call can flip them into the renderer's y-up space.
+ * corner: {@code x} grows right and {@code y} grows down, matching the renderer's y-down space,
+ * so the draw call adds the stored top offsets directly to the block's top edge.
  */
 public final class FlixelTextLayout {
 
@@ -50,9 +50,9 @@ public final class FlixelTextLayout {
   @NotNull
   private final FlixelFloatArray xs = new FlixelFloatArray(64);
 
-  /** Distance from the text block's top edge down to each glyph's bottom edge. */
+  /** Distance from the text block's top edge down to each glyph's top edge. */
   @NotNull
-  private final FlixelFloatArray bottoms = new FlixelFloatArray(64);
+  private final FlixelFloatArray tops = new FlixelFloatArray(64);
 
   @NotNull
   private final FlixelFloatArray widths = new FlixelFloatArray(64);
@@ -82,7 +82,7 @@ public final class FlixelTextLayout {
       float fieldWidth, boolean wrap, int align, float letterSpacing) {
     frames.clear();
     xs.clear();
-    bottoms.clear();
+    tops.clear();
     widths.clear();
     heights.clear();
     lineStarts.clear();
@@ -130,7 +130,7 @@ public final class FlixelTextLayout {
           lineTop += lineHeight;
           for (int j = lastSpaceIndex; j < frames.getSize(); j++) {
             xs.set(j, xs.get(j) - shift);
-            bottoms.set(j, bottoms.get(j) + lineHeight);
+            tops.set(j, tops.get(j) + lineHeight);
           }
           penX -= shift;
           lineStart = lastSpaceIndex;
@@ -151,7 +151,7 @@ public final class FlixelTextLayout {
         float gh = glyph.height * scale;
         frames.add(glyph.frame);
         xs.add(penX + glyph.xOffset * scale);
-        bottoms.add(lineTop + glyph.yOffset * scale + gh);
+        tops.add(lineTop + glyph.yOffset * scale);
         widths.add(gw);
         heights.add(gh);
       }
@@ -172,12 +172,12 @@ public final class FlixelTextLayout {
    *
    * @param batch The batch to draw through.
    * @param x The text block's left edge in world units.
-   * @param y The text block's <em>top</em> edge in world units (y-up space).
+   * @param y The text block's <em>top</em> edge in world units (y-down space).
    */
   public void draw(@NotNull FlixelBatch batch, float x, float y) {
     FlixelFrame[] items = frames.getItems();
     for (int i = 0, n = frames.getSize(); i < n; i++) {
-      batch.draw(items[i], x + xs.get(i), y - bottoms.get(i), widths.get(i), heights.get(i));
+      batch.draw(items[i], x + xs.get(i), y + tops.get(i), widths.get(i), heights.get(i));
     }
   }
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxBatch.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxBatch.java
@@ -155,7 +155,8 @@ public class FlixelBgfxBatch implements FlixelBatch {
     float sin = (float) Math.sin(Math.toRadians(rotation));
     float px = x + originX;
     float py = y + originY;
-    // Local corner offsets from the origin (bottom-left based, y-up).
+    // Local corner offsets from the origin. The quad spans (x, y) to (x + width, y + height); under
+    // the Y-down projection (x, y) is the top-left corner and +Y runs downward on screen.
     float lx0 = -originX * scaleX;
     float ly0 = -originY * scaleY;
     float lx1 = (width - originX) * scaleX;
@@ -220,11 +221,13 @@ public class FlixelBgfxBatch implements FlixelBatch {
       float u, float v, float u2, float v2) {
     float packed = Float.intBitsToFloat(packAbgr());
     int base = quadCount * VERTICES_PER_QUAD * FLOATS_PER_VERTEX;
-    // Bottom-left, bottom-right, top-right, top-left. UVs: v at bottom, v2 at top.
-    set(base, x0, y0, u, v2, packed);
-    set(base + FLOATS_PER_VERTEX, x1, y1, u2, v2, packed);
-    set(base + 2 * FLOATS_PER_VERTEX, x2, y2, u2, v, packed);
-    set(base + 3 * FLOATS_PER_VERTEX, x3, y3, u, v, packed);
+    // Corners 0-1 have the smaller Y and corners 2-3 the larger Y. Under the Y-down projection the
+    // smaller Y renders at the top of the screen, so the texture's top row (v) maps to corners 0-1
+    // and its bottom row (v2) to corners 2-3, keeping the art upright.
+    set(base, x0, y0, u, v, packed);
+    set(base + FLOATS_PER_VERTEX, x1, y1, u2, v, packed);
+    set(base + 2 * FLOATS_PER_VERTEX, x2, y2, u2, v2, packed);
+    set(base + 3 * FLOATS_PER_VERTEX, x3, y3, u, v2, packed);
     quadCount++;
   }
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
@@ -573,7 +573,8 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
     viewportY = 0;
     viewportWidth = Math.max(1, backBufferWidth);
     viewportHeight = Math.max(1, backBufferHeight);
-    compositeOrtho.setToOrtho2D(0, 0, backBufferWidth, backBufferHeight, isDepthZeroToOne());
+    // Y-down composite ortho so the upscale blit matches the batch's Y-down vertex layout.
+    compositeOrtho.setToOrtho2DYDown(0, 0, backBufferWidth, backBufferHeight, isDepthZeroToOne());
 
     FlixelTexture texture = sceneTarget.getTexture();
     batch.setProjection(compositeOrtho);

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimateRigBakeTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimateRigBakeTest.java
@@ -32,8 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Covers the pure geometry of {@link FlixelAnimateRigLoader#bakePartAffine} for both the standard
  * (non-rotated) and the 90-degree-CW-rotated atlas packing cases.
  *
- * <p>Coordinate space primer: the baked affine maps from <strong>libGDX atlas local space</strong>
- * (Y-up, bottom-left at the origin) to <strong>rig local space</strong> (also Y-up, bottom-left of
+ * <p>Coordinate space primer: the baked affine maps from <strong>atlas local space</strong>
+ * (Y-down, top-left at the origin) to <strong>rig local space</strong> (also Y-down, top-left of
  * the anchor box at the origin). For a non-rotated part the atlas quad is {@code (0..origW) x (0..origH)}.
  * For a 90-degree-CW packed part the atlas region has its width and height swapped, so the quad is
  * {@code (0..origH) x (0..origW)} - that is, atlas width = origH, atlas height = origW.
@@ -60,26 +60,27 @@ class FlixelAnimateRigBakeTest {
     FlixelAffine identity = new FlixelAffine();
     FlixelAffine out = new FlixelAffine();
 
-    FlixelAnimateRigLoader.bakePartAffine(out, identity, origW, origH, false, 0f, 0f, origH);
+    FlixelAnimateRigLoader.bakePartAffine(out, identity, false, 0f, 0f);
 
-    float[] bl = apply(out, 0f, 0f);
-    assertEquals(0f, bl[0], DELTA, "bottom-left x");
-    assertEquals(0f, bl[1], DELTA, "bottom-left y");
+    float[] tl = apply(out, 0f, 0f);
+    assertEquals(0f, tl[0], DELTA, "top-left x");
+    assertEquals(0f, tl[1], DELTA, "top-left y");
 
-    float[] tr = apply(out, origW, origH);
-    assertEquals(origW, tr[0], DELTA, "top-right x");
-    assertEquals(origH, tr[1], DELTA, "top-right y");
+    float[] br = apply(out, origW, origH);
+    assertEquals(origW, br[0], DELTA, "bottom-right x");
+    assertEquals(origH, br[1], DELTA, "bottom-right y");
   }
 
   /**
    * Rotated (90 degrees CW) part at the anchor origin. The atlas quad has width = origH and
-   * height = origW, so local space is {@code (0..origH) x (0..origW)}. The baked affine must
-   * map each atlas corner to the rig corner that holds the same pixel:
+   * height = origW, so local space is {@code (0..origH) x (0..origW)}. Un-rotating the packing in
+   * Y-down space is a reflection across the main diagonal, so the baked affine maps each atlas corner
+   * to the rig corner that holds the same pixel:
    * <ul>
-   *   <li>Atlas bottom-left (0, 0) - holds the original bottom-right pixel - must land at rig (origW, 0).</li>
-   *   <li>Atlas bottom-right (origH, 0) - original top-right pixel - must land at rig (origW, origH).</li>
-   *   <li>Atlas top-right (origH, origW) - original top-left pixel - must land at rig (0, origH).</li>
-   *   <li>Atlas top-left (0, origW) - original bottom-left pixel - must land at rig (0, 0).</li>
+   *   <li>Atlas top-left (0, 0) must land at rig top-left (0, 0).</li>
+   *   <li>Atlas top-right (origH, 0) must land at rig bottom-left (0, origH).</li>
+   *   <li>Atlas bottom-right (origH, origW) must land at rig bottom-right (origW, origH).</li>
+   *   <li>Atlas bottom-left (0, origW) must land at rig top-right (origW, 0).</li>
    * </ul>
    */
   @Test
@@ -89,34 +90,29 @@ class FlixelAnimateRigBakeTest {
     FlixelAffine identity = new FlixelAffine();
     FlixelAffine out = new FlixelAffine();
 
-    FlixelAnimateRigLoader.bakePartAffine(out, identity, origW, origH, true, 0f, 0f, origH);
+    FlixelAnimateRigLoader.bakePartAffine(out, identity, true, 0f, 0f);
 
-    // Atlas bottom-left (0, 0) holds the original bottom-right pixel; should land at rig bottom-right.
-    float[] bl = apply(out, 0f, 0f);
-    assertEquals(origW, bl[0], DELTA, "atlas bottom-left x -> rig bottom-right x");
-    assertEquals(0f, bl[1], DELTA, "atlas bottom-left y -> rig bottom-right y");
+    float[] tl = apply(out, 0f, 0f);
+    assertEquals(0f, tl[0], DELTA, "atlas top-left x -> rig top-left x");
+    assertEquals(0f, tl[1], DELTA, "atlas top-left y -> rig top-left y");
 
-    // Atlas bottom-right (origH, 0) holds the original top-right; should land at rig top-right.
-    float[] br = apply(out, origH, 0f);
-    assertEquals(origW, br[0], DELTA, "atlas bottom-right x -> rig top-right x");
-    assertEquals(origH, br[1], DELTA, "atlas bottom-right y -> rig top-right y");
+    float[] tr = apply(out, origH, 0f);
+    assertEquals(0f, tr[0], DELTA, "atlas top-right x -> rig bottom-left x");
+    assertEquals(origH, tr[1], DELTA, "atlas top-right y -> rig bottom-left y");
 
-    // Atlas top-right (origH, origW) holds the original top-left; should land at rig top-left.
-    float[] tr = apply(out, origH, origW);
-    assertEquals(0f, tr[0], DELTA, "atlas top-right x -> rig top-left x");
-    assertEquals(origH, tr[1], DELTA, "atlas top-right y -> rig top-left y");
+    float[] br = apply(out, origH, origW);
+    assertEquals(origW, br[0], DELTA, "atlas bottom-right x -> rig bottom-right x");
+    assertEquals(origH, br[1], DELTA, "atlas bottom-right y -> rig bottom-right y");
 
-    // Atlas top-left (0, origW) holds the original bottom-left; should land at rig bottom-left.
-    float[] tl = apply(out, 0f, origW);
-    assertEquals(0f, tl[0], DELTA, "atlas top-left x -> rig bottom-left x");
-    assertEquals(0f, tl[1], DELTA, "atlas top-left y -> rig bottom-left y");
+    float[] bl = apply(out, 0f, origW);
+    assertEquals(origW, bl[0], DELTA, "atlas bottom-left x -> rig top-right x");
+    assertEquals(0f, bl[1], DELTA, "atlas bottom-left y -> rig top-right y");
   }
 
   /**
    * Non-zero anchor offsets are applied identically to both rotated and non-rotated parts. With a
-   * Flash translate that positions the sprite at the anchor's top-left corner and {@code anchorHeight
-   * == origH}, both cases must produce a translation-only affine with the same offset, confirming
-   * that the anchor shift cancels the Flash translation symmetrically.
+   * Flash translate that positions the sprite at the anchor's top-left corner, both cases must
+   * produce a translation that cancels the Flash translation symmetrically.
    */
   @Test
   void anchorOffsetAppliedToBothCases() {
@@ -132,33 +128,31 @@ class FlixelAnimateRigBakeTest {
     flashAtAnchor.m12 = anchorMinY;
 
     FlixelAffine outNormal = new FlixelAffine();
-    FlixelAnimateRigLoader.bakePartAffine(
-        outNormal, flashAtAnchor, origW, origH, false, anchorMinX, anchorMinY, origH);
+    FlixelAnimateRigLoader.bakePartAffine(outNormal, flashAtAnchor, false, anchorMinX, anchorMinY);
 
     // With the sprite exactly at the anchor, the non-rotated baked affine must be identity.
-    float[] blNormal = apply(outNormal, 0f, 0f);
-    assertEquals(0f, blNormal[0], DELTA, "non-rotated: bottom-left x at anchor");
-    assertEquals(0f, blNormal[1], DELTA, "non-rotated: bottom-left y at anchor");
+    float[] tlNormal = apply(outNormal, 0f, 0f);
+    assertEquals(0f, tlNormal[0], DELTA, "non-rotated: top-left x at anchor");
+    assertEquals(0f, tlNormal[1], DELTA, "non-rotated: top-left y at anchor");
 
-    float[] trNormal = apply(outNormal, origW, origH);
-    assertEquals(origW, trNormal[0], DELTA, "non-rotated: top-right x at anchor");
-    assertEquals(origH, trNormal[1], DELTA, "non-rotated: top-right y at anchor");
+    float[] brNormal = apply(outNormal, origW, origH);
+    assertEquals(origW, brNormal[0], DELTA, "non-rotated: bottom-right x at anchor");
+    assertEquals(origH, brNormal[1], DELTA, "non-rotated: bottom-right y at anchor");
 
-    // The rotated case with the same Flash translate and anchor should also cancel to a known result.
-    // Atlas quad is (0..origH) x (0..origW); atlas top-left (0, origW) holds the bottom-left pixel.
+    // The rotated case with the same Flash translate and anchor should also cancel the anchor shift.
+    // Atlas quad is (0..origH) x (0..origW).
     FlixelAffine outRotated = new FlixelAffine();
-    FlixelAnimateRigLoader.bakePartAffine(
-        outRotated, flashAtAnchor, origW, origH, true, anchorMinX, anchorMinY, origH);
+    FlixelAnimateRigLoader.bakePartAffine(outRotated, flashAtAnchor, true, anchorMinX, anchorMinY);
 
-    // Atlas top-left (0, origW) -> sprite bottom-left -> should land at rig (0, 0).
-    float[] blRotated = apply(outRotated, 0f, origW);
-    assertEquals(0f, blRotated[0], DELTA, "rotated: bottom-left pixel x at anchor");
-    assertEquals(0f, blRotated[1], DELTA, "rotated: bottom-left pixel y at anchor");
+    // Atlas top-left (0, 0) -> rig top-left (0, 0).
+    float[] tlRotated = apply(outRotated, 0f, 0f);
+    assertEquals(0f, tlRotated[0], DELTA, "rotated: top-left x at anchor");
+    assertEquals(0f, tlRotated[1], DELTA, "rotated: top-left y at anchor");
 
-    // Atlas bottom-right (origH, 0) -> sprite top-right -> should land at rig (origW, origH).
-    float[] trRotated = apply(outRotated, origH, 0f);
-    assertEquals(origW, trRotated[0], DELTA, "rotated: top-right pixel x at anchor");
-    assertEquals(origH, trRotated[1], DELTA, "rotated: top-right pixel y at anchor");
+    // Atlas bottom-right (origH, origW) -> rig bottom-right (origW, origH).
+    float[] brRotated = apply(outRotated, origH, origW);
+    assertEquals(origW, brRotated[0], DELTA, "rotated: bottom-right x at anchor");
+    assertEquals(origH, brRotated[1], DELTA, "rotated: bottom-right y at anchor");
   }
 
   /**
@@ -178,10 +172,10 @@ class FlixelAnimateRigBakeTest {
     flashTranslate.m12 = 15f;
 
     FlixelAffine outNormal = new FlixelAffine();
-    FlixelAnimateRigLoader.bakePartAffine(outNormal, flashTranslate, origW, origH, false, 0f, 0f, origH);
+    FlixelAnimateRigLoader.bakePartAffine(outNormal, flashTranslate, false, 0f, 0f);
 
     FlixelAffine outRotated = new FlixelAffine();
-    FlixelAnimateRigLoader.bakePartAffine(outRotated, flashTranslate, origW, origH, true, 0f, 0f, origH);
+    FlixelAnimateRigLoader.bakePartAffine(outRotated, flashTranslate, true, 0f, 0f);
 
     // 4 corners of the non-rotated quad: (0..origW) x (0..origH)
     float[][] normalCorners = {


### PR DESCRIPTION
## Description

Reworks the framework from a Y-up projection to a **Y-down** coordinate system, so world `(0, 0)` is the top-left corner and Y grows downward. This matches most graphics APIs (and HaxeFlixel), and it matches what the camera, `FlixelObject`, and the docs already assumed: the camera follow/deadzone logic and the object model were already written top-left / Y-down, while the actual bgfx projection rendered Y-up. That mismatch is what previously forced consumers to hand-convert coordinates; this change makes the whole pipeline consistent.

### What changed

- **Projection** (`FlixelViewport`): builds a Y-down orthographic matrix; `unproject` and `projectToScissor` updated to match.
- **Batch** (`FlixelBgfxBatch`): swaps the vertex UV mapping so textures stay upright under the flipped projection (single choke point, so every draw path stays consistent).
- **Frame** (`FlixelFrame.regionInsetY`): a trimmed region's vertical inset is now measured from the top edge (symmetric with X).
- **Animate rig** (`FlixelAnimateRigLoader`): both baked Y-flips are removed. Adobe Animate authors in Y-down with a top-left bitmap origin, which now matches the renderer, so the per-part bake reduces to `anchorShift * P_flash` (a linear-column swap for 90-degree-CW atlas packing). This also simplifies the loader (no `origW`/`origH`/`anchorHeight` needed in the bake).
- **Collision** (`FlixelObject.separateY`): the `touching` UP/DOWN flags are inverted so a downward-moving object registers a floor hit, matching HaxeFlixel.
- **Text** (`FlixelText` / `FlixelTextLayout`): glyphs are laid out and drawn top-down.
- **Camera**: no functional change (it was already Y-down); doc wording corrected.
- **Docs**: swept every Y-up javadoc/comment across the batch, sprite, rig, and input packages to describe the Y-down world convention.

### Verification

- All **506** unit tests pass (`:flixelgdx-test:test`), including the rewritten `FlixelAnimateRigBakeTest` geometry.
- `spotlessApply` and `:flixelgdx-core:javadoc` are clean; the desktop backend compiles.
- On-device GPU rendering (sprites upright and correctly positioned) still needs a visual pass in a consuming project, since this repo has no runtime render path.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactor / Optimization

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

`:flixelgdx-test:test` -> 506 tests, 0 failures, 0 errors. `spotlessApply` and `:flixelgdx-core:javadoc` succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)