### PR TITLE
Added GraalVM native-image support to the desktop backend via FlixelGraalFeature

### DIFF
--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graal/FlixelGraalFeature.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graal/FlixelGraalFeature.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.desktop.graal;
+
+import org.flixelgdx.backend.desktop.audio.FlixelMiniAudio;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+
+/**
+ * GraalVM {@link Feature} that prepares the desktop backend for native-image compilation.
+ *
+ * <p>GraalVM's closed-world assumption strips out classes, methods, and resources that are not
+ * reachable through static analysis. This feature explicitly registers two things that the
+ * static analyzer cannot see on its own:
+ *
+ * <ul>
+ *   <li><b>JNI methods</b> - {@link FlixelMiniAudio} declares all its methods as {@code native},
+ *       meaning the JVM resolves them through JNI at run time. Without explicit registration,
+ *       GraalVM removes those method descriptors and the native library cannot bind to them.</li>
+ *   <li><b>Bundled platform natives</b> - the miniaudio shared libraries
+ *       ({@code libflixel_miniaudio.so}, {@code flixel_miniaudio.dll},
+ *       {@code libflixel_miniaudio.dylib}) are embedded as classpath resources and extracted to a
+ *       temp file at run time by {@link FlixelMiniAudio#ensureLoaded()}. GraalVM excludes
+ *       resources unless they are explicitly declared; each platform variant is registered
+ *       individually so the correct binary ships inside the native image.</li>
+ * </ul>
+ *
+ * <p>LWJGL (SDL3, bgfx, stb, zstd) ships its own native-image support inside each module JAR, so
+ * those libraries do not need to be handled here.
+ *
+ * <p>This feature is wired in automatically by the {@code META-INF/native-image} properties file
+ * bundled with the desktop module JAR; game projects do not need to reference it directly.
+ */
+public class FlixelGraalFeature implements Feature {
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    // Register FlixelMiniAudio so GraalVM keeps every native method descriptor in the JNI table.
+    // Without this, the miniaudio shared library cannot bind its C symbols to Java at run time.
+    RuntimeJNIAccess.register(FlixelMiniAudio.class);
+    RuntimeJNIAccess.register(FlixelMiniAudio.class.getDeclaredMethods());
+
+    // Include the bundled platform natives so FlixelMiniAudio.ensureLoaded() can extract and
+    // load them from a temp file at run time.
+    Module module = FlixelGraalFeature.class.getModule();
+    RuntimeResourceAccess.addResource(module, "org/flixelgdx/natives/libflixel_miniaudio.so");
+    RuntimeResourceAccess.addResource(module, "org/flixelgdx/natives/flixel_miniaudio.dll");
+    RuntimeResourceAccess.addResource(module, "org/flixelgdx/natives/libflixel_miniaudio.dylib");
+  }
+}

--- a/flixelgdx-desktop/src/main/resources/META-INF/native-image/org.flixelgdx/native-image.properties
+++ b/flixelgdx-desktop/src/main/resources/META-INF/native-image/org.flixelgdx/native-image.properties
@@ -1,5 +1,4 @@
-# GraalVM native image configuration for the FlixelGDX LWJGL3 backend.
+# GraalVM native image configuration for the FlixelGDX desktop backend.
 # These arguments are merged automatically when the framework JAR is on the native-image classpath.
 
-Args = --features=org.flixelgdx.backend.lwjgl3.graal.FlixelGraalFeature \
-       --initialize-at-run-time=imgui.ImGui,imgui.ImFontAtlas,imgui.ImGuiPlatformIO
+Args = --features=org.flixelgdx.backend.desktop.graal.FlixelGraalFeature


### PR DESCRIPTION
## Description

Adds proper GraalVM native-image support to the `flixelgdx-desktop` module, which was previously pointing to a stale LWJGL3 class that no longer exists.

**What changed:**
- Added `FlixelGraalFeature` in a new `graal` sub-package under `org.flixelgdx.backend.desktop`. The feature runs at `native-image` build time and:
  - Registers `FlixelMiniAudio` and all its `native` method descriptors with `RuntimeJNIAccess`, so GraalVM's closed-world analysis does not strip the JNI symbol table entries the miniaudio shared library binds to at run time.
  - Registers each of the three bundled platform natives (`libflixel_miniaudio.so`, `flixel_miniaudio.dll`, `libflixel_miniaudio.dylib`) with `RuntimeResourceAccess`, so they survive the image build and can be extracted to a temp file by `FlixelMiniAudio.ensureLoaded()`.
- Updated `META-INF/native-image/org.flixelgdx/native-image.properties` to point to the correct feature class and removed the dead `--initialize-at-run-time` flags that referenced imgui (not part of this backend).

LWJGL (SDL3, bgfx, stb, zstd) already ships its own `native-image.properties` and feature inside each module JAR, so those are handled upstream and not touched here.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

No runtime test possible here - GraalVM features only execute during `native-image` compilation. The feature compiles and passes Javadoc lint cleanly against GraalVM SDK 24.2.0.