### PR TITLE
Reimplemented the Dear ImGui debug overlay on the bgfx + SDL3 desktop backend, with full bgfx render diagnostics

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -478,10 +478,10 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    * their work, so clicking inside (for example) a Dear ImGui window does not bleed through
    * into the game logic. Defaults to {@code false}.
    *
-   * <p>The debug overlay's own mouse-driven tools (sprite picker, camera pan) read
-   * {@link FlixelMouseInputManager#rawPressed(int) FlixelMouseInputManager.rawPressed(int)} so they
-   * can opt in to "ignore the suppression" while still respecting this hook for the early-exit
-   * gate.
+   * <p>The overlay's own mouse tools (sprite picker, camera pan) use the regular
+   * {@link FlixelMouseInputManager#pressed(int) FlixelMouseInputManager.pressed(int)} helpers, which
+   * already report {@code false} while the cursor is over a debug panel, so a click there never grabs
+   * a sprite or pans the camera.
    *
    * @return {@code true} if a foreground UI element is consuming mouse input this frame.
    */
@@ -544,10 +544,10 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     }
     cam.applyCameraTransform();
 
-    if (!uiCapturedMouse && Flixel.mouse.rawPressed(cameraPanButton)) {
+    if (!uiCapturedMouse && Flixel.mouse.pressed(cameraPanButton)) {
       int sx = Flixel.mouse.getScreenX();
       int sy = Flixel.mouse.getScreenY();
-      if (!Flixel.mouse.rawJustPressed(cameraPanButton)) {
+      if (!Flixel.mouse.justPressed(cameraPanButton)) {
         panUnprojectA.set(lastPanScreenX, lastPanScreenY);
         cam.unproject(panUnprojectA);
         panUnprojectB.set(sx, sy);
@@ -605,12 +605,11 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     float worldX = viewPickX + cam.scrollX + cam.getViewMarginX();
     float worldY = viewPickY + cam.scrollY + cam.getViewMarginY();
 
-    // Use the raw* helpers so the picker keeps reading the actual mouse state (Flixel.mouse.pressed(...)
-    // is suppressed when the cursor is over an imgui window, and we still want the uncovered
-    // viewport area to drive picking). The early-exit gate above already guards the imgui case.
-    boolean justPressed = Flixel.mouse.rawJustPressed(FlixelMouseButton.LEFT);
-    boolean pressed = Flixel.mouse.rawPressed(FlixelMouseButton.LEFT);
-    boolean justReleased = Flixel.mouse.rawJustReleased(FlixelMouseButton.LEFT);
+    // The early-exit gate above already returned when the cursor is over a debug panel, so here the
+    // regular mouse helpers report the real state and drive picking over the uncovered viewport.
+    boolean justPressed = Flixel.mouse.justPressed(FlixelMouseButton.LEFT);
+    boolean pressed = Flixel.mouse.pressed(FlixelMouseButton.LEFT);
+    boolean justReleased = Flixel.mouse.justReleased(FlixelMouseButton.LEFT);
 
     FlixelObject dragged = Flixel.debug.getDraggedSprite();
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -292,9 +292,9 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     handleToggleKeys();
 
     if (Flixel.isDebugMode()) {
-      // Raw* so the game loop pause toggle keeps working even while an imgui text field is focused,
-      // unless a backend suppresses typable keys while a command field is active (see LWJGL ImGui overlay).
-      if (Flixel.keys.rawJustPressed(pauseKey) && !shouldSuppressDebugRawKeybind(pauseKey)) {
+      // The keyboard manager already reports the pause key as not pressed while an imgui text field
+      // has focus (isKeyboardCapturedByUI), so a plain justPressed does not fire mid-typing.
+      if (Flixel.keys.justPressed(pauseKey)) {
         Flixel.game.setGamePaused(!Flixel.game.isGamePaused());
       }
       if (Flixel.game.isGamePaused()) {
@@ -424,27 +424,15 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   protected void onUpdateUI(float elapsed) {}
 
   private void handleToggleKeys() {
-    // Use the raw* variants so the toggle keys still work even while a Dear ImGui text field
-    // (for example, the debug command line) has keyboard focus and the regular justPressed
-    // helpers are intentionally suppressed.
-    if (Flixel.keys.rawJustPressed(toggleKey) && !shouldSuppressDebugRawKeybind(toggleKey)) {
+    // The overlay's own input reaches Dear ImGui through a dedicated platform listener, so the
+    // keyboard manager can suppress these toggles while a debug text field is focused
+    // (isKeyboardCapturedByUI) and they still work any other time.
+    if (Flixel.keys.justPressed(toggleKey)) {
       toggleVisible();
     }
-    if (Flixel.keys.rawJustPressed(drawDebugKey) && !shouldSuppressDebugRawKeybind(drawDebugKey)) {
+    if (Flixel.keys.justPressed(drawDebugKey)) {
       toggleDrawDebug();
     }
-  }
-
-  /**
-   * Backends that render a command-line {@code InputText} can override this to skip debug hotkeys for keys that would
-   * normally type into that field (letters, punctuation, arrows, Enter, and so on). Return {@code false} by default so
-   * {@link org.flixelgdx.input.keyboard.FlixelKeyInputManager#rawJustPressed(int) FlixelKeyInputManager.rawJustPressed(int)} shortcuts keep working.
-   *
-   * @param keycode FlixelGDX {@link FlixelKey} key code being handled by a debug binding.
-   * @return {@code true} to skip handling this key for debug shortcuts this frame.
-   */
-  protected boolean shouldSuppressDebugRawKeybind(int keycode) {
-    return false;
   }
 
   private void refreshWatchEntries() {
@@ -510,9 +498,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    * cannot also capture game input and activate game-level actions like {@code ui_accept}.
    * Defaults to {@code false}.
    *
-   * <p>The debug overlay's own toggle keys (debug overlay toggle, hitbox toggle, pause) read
-   * {@link FlixelKeyInputManager#rawJustPressed(int) FlixelKeyInputManager.rawJustPressed(int)}
-   * so they keep working even when this returns {@code true}.
+   * <p>The debug overlay's own toggle keys use the regular {@code justPressed} helpers, so they are
+   * suppressed while a debug text field is focused and respond normally the rest of the time.
    *
    * @return {@code true} if a foreground UI element is consuming keyboard input this frame.
    */
@@ -531,17 +518,14 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (debugInspectCameraIndex < 0 || debugInspectCameraIndex >= cams.getSize()) {
       debugInspectCameraIndex = 0;
     }
-    // Use the raw* helpers throughout so the inspect camera tools keep responding while the
-    // imgui debugger is focused (otherwise our own debug controls would be filtered out by the
-    // input suppression we set up to protect the game's regular input).
-    boolean alt = Flixel.keys.rawPressed(FlixelKey.ALT_LEFT) || Flixel.keys.rawPressed(FlixelKey.ALT_RIGHT)
-        || Flixel.input.isKeyPressed(FlixelKey.ALT_LEFT) || Flixel.input.isKeyPressed(FlixelKey.ALT_RIGHT);
-    if (alt && Flixel.keys.rawJustPressed(cameraCycleLeftKey)
-        && !shouldSuppressDebugRawKeybind(cameraCycleLeftKey)) {
+    // Alt is read straight off the input device so it still registers while the keyboard manager is
+    // suppressing game input; the camera-cycle keys use the regular justPressed helper, which keeps
+    // the arrow keys editing text (instead of cycling cameras) while the command line is focused.
+    boolean alt = Flixel.input.isKeyPressed(FlixelKey.ALT_LEFT) || Flixel.input.isKeyPressed(FlixelKey.ALT_RIGHT);
+    if (alt && Flixel.keys.justPressed(cameraCycleLeftKey)) {
       debugInspectCameraIndex = (debugInspectCameraIndex - 1 + cams.getSize()) % cams.getSize();
     }
-    if (alt && Flixel.keys.rawJustPressed(cameraCycleRightKey)
-        && !shouldSuppressDebugRawKeybind(cameraCycleRightKey)) {
+    if (alt && Flixel.keys.justPressed(cameraCycleRightKey)) {
       debugInspectCameraIndex = (debugInspectCameraIndex + 1) % cams.getSize();
     }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -112,6 +112,24 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    */
   public static final int PERF_HISTORY_SIZE = 120;
 
+  /**
+   * Effective stats refresh interval. Initialized to {@link #STATS_UPDATE_INTERVAL}; subclasses may
+   * change this field to raise or lower the refresh frequency without overriding {@link #update(float)}.
+   */
+  protected float statsUpdateInterval = STATS_UPDATE_INTERVAL;
+
+  /**
+   * Effective watch-entry and tracker-block refresh interval. Initialized to
+   * {@link #WATCH_REFRESH_INTERVAL}; subclasses may change it freely.
+   */
+  protected float watchRefreshInterval = WATCH_REFRESH_INTERVAL;
+
+  /**
+   * Effective performance ring-buffer sample interval. Initialized to {@link #PERF_SAMPLE_INTERVAL};
+   * subclasses may change it freely.
+   */
+  protected float perfSampleInterval = PERF_SAMPLE_INTERVAL;
+
   /** Fallback color used when a {@link FlixelDebugDrawable} returns a {@code null} or undersized array. */
   private static final float[] FALLBACK_BOUNDING_BOX_COLOR = { 1f, 0.2f, 0.2f, 0.6f };
 
@@ -313,8 +331,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     // of an empty graph for the first several seconds.
     if (Flixel.isDebugMode()) {
       perfSampleTimer += elapsed;
-      if (perfSampleTimer >= PERF_SAMPLE_INTERVAL) {
-        perfSampleTimer = 0f;
+      if (perfSampleTimer >= perfSampleInterval) {
+        perfSampleTimer -= perfSampleInterval;
         pushPerfSample(elapsed);
       }
     }
@@ -326,7 +344,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     statsTimer += elapsed;
     watchRefreshTimer += elapsed;
 
-    if (statsTimer >= STATS_UPDATE_INTERVAL) {
+    if (statsTimer >= statsUpdateInterval) {
       statsTimer = 0f;
       cachedFps = Flixel.graphics.getFps();
       cachedHeapMegabytes = Flixel.runtime.getJavaHeap() / (1024f * 1024f);
@@ -335,7 +353,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
       cachedAssetCount = Flixel.assets != null ? Flixel.assets.getLoadedAssetCount() : 0;
     }
 
-    if (watchRefreshTimer >= WATCH_REFRESH_INTERVAL) {
+    if (watchRefreshTimer >= watchRefreshInterval) {
       watchRefreshTimer = 0f;
       refreshWatchEntries();
       rebuildCachedTrackerBlocks();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -117,30 +117,11 @@ public class FlixelKeyInputManager implements FlixelInputManager, FlixelKeyboard
    * capturing keyboard input, so typing in a debug text field cannot leak into game-side input
    * (e.g. an {@code ui_accept} action bound to {@code ENTER}).
    *
-   * <p>Use {@link #rawPressed(int)} when you specifically need the raw, unsuppressed state
-   * (the debug overlay itself uses this for its toggle keys so they keep working even when a
-   * text field is focused).
-   *
    * @param key The key to check if it is pressed (for example {@link FlixelKey#A}).
    * @return {@code true} if the key is pressed and input is enabled and not suppressed by UI.
    */
   public boolean pressed(int key) {
-    if (isCapturedByDebugUI()) {
-      return false;
-    }
-    return rawPressed(key);
-  }
-
-  /**
-   * Same as {@link #pressed(int)} but bypasses the "captured by debug UI" check. Intended for
-   * the debug overlay's own toggle keys and tools, which must keep responding even while a
-   * Dear ImGui text input has focus.
-   *
-   * @param key The key to check if it is pressed.
-   * @return {@code true} if the key is pressed and input is enabled, regardless of UI capture.
-   */
-  public boolean rawPressed(int key) {
-    if (!enabled) {
+    if (!enabled || isCapturedByDebugUI()) {
       return false;
     }
     if (key == FlixelKey.ANY) {
@@ -163,21 +144,7 @@ public class FlixelKeyInputManager implements FlixelInputManager, FlixelKeyboard
    * @return {@code true} if the key was just pressed and input is enabled and not suppressed by UI.
    */
   public boolean justPressed(int key) {
-    if (isCapturedByDebugUI()) {
-      return false;
-    }
-    return rawJustPressed(key);
-  }
-
-  /**
-   * Same as {@link #justPressed(int)} but bypasses the "captured by debug UI" check. Use this
-   * for input that must keep working regardless of UI capture.
-   *
-   * @param key key code
-   * @return {@code true} if the key was just pressed and input is enabled, regardless of UI capture.
-   */
-  public boolean rawJustPressed(int key) {
-    if (!enabled) {
+    if (!enabled || isCapturedByDebugUI()) {
       return false;
     }
     if (key == FlixelKey.ANY) {
@@ -204,20 +171,7 @@ public class FlixelKeyInputManager implements FlixelInputManager, FlixelKeyboard
    *   enabled and not suppressed by UI.
    */
   public boolean justReleased(int key) {
-    if (isCapturedByDebugUI()) {
-      return false;
-    }
-    return rawJustReleased(key);
-  }
-
-  /**
-   * Same as {@link #justReleased(int)} but bypasses the "captured by debug UI" check.
-   *
-   * @param key The key code to check if it was just released.
-   * @return {@code true} if the key was just released and input is enabled, regardless of UI capture.
-   */
-  public boolean rawJustReleased(int key) {
-    if (!enabled) {
+    if (!enabled || isCapturedByDebugUI()) {
       return false;
     }
     if (key == FlixelKey.ANY) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/package-info.java
@@ -92,16 +92,6 @@
  * all return {@code false} automatically. This prevents debug-console typing from leaking into
  * game controls.
  *
- * <p>If you need the raw, unsuppressed state (for example, the debug overlay itself uses this for
- * its toggle shortcut), call the {@code raw} variants instead:
- *
- * <pre>{@code
- * // Always responds, even when a debug text field is focused.
- * if (Flixel.keys.rawJustPressed(FlixelKey.F3)) {
- *   Flixel.debug.overlay.toggle();
- * }
- * }</pre>
- *
  * <h2>FlixelKey reference</h2>
  *
  * <p>{@link org.flixelgdx.input.keyboard.FlixelKey FlixelKey} holds integer constants for every

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseInputManager.java
@@ -223,28 +223,12 @@ public class FlixelMouseInputManager implements FlixelInputManager, FlixelMouseL
    * debug overlay reports that another UI layer (typically the imgui debugger) is capturing
    * mouse input, so clicking inside an imgui window cannot leak into game logic.
    *
-   * <p>Use {@link #rawPressed(int)} when you specifically need the raw, unsuppressed state.
-   * The debug overlay's own sprite picker / camera tools use the raw variants so they can opt
-   * in to "ignore the suppression" when needed.
-   *
    * @param button Button index (e.g. {@code 0} for left mouse button).
    * @return {@code true} if the button is pressed and input is enabled and not suppressed by UI.
    */
   public boolean pressed(int button) {
-    if (isCapturedByDebugUI()) {
-      return false;
-    }
-    return rawPressed(button);
-  }
-
-  /**
-   * Same as {@link #pressed(int)} but bypasses the "captured by debug UI" check.
-   *
-   * @param button Button index.
-   * @return {@code true} if the button is pressed and input is enabled, regardless of UI capture.
-   */
-  public boolean rawPressed(int button) {
-    return enabled && button >= 0 && button <= MAX_BUTTON && Flixel.input.isButtonPressed(button);
+    return enabled && !isCapturedByDebugUI() && button >= 0 && button <= MAX_BUTTON
+        && Flixel.input.isButtonPressed(button);
   }
 
   /**
@@ -255,20 +239,7 @@ public class FlixelMouseInputManager implements FlixelInputManager, FlixelMouseL
    * @return {@code true} if the button was just pressed and input is enabled and not suppressed.
    */
   public boolean justPressed(int button) {
-    if (isCapturedByDebugUI()) {
-      return false;
-    }
-    return rawJustPressed(button);
-  }
-
-  /**
-   * Same as {@link #justPressed(int)} but bypasses the "captured by debug UI" check.
-   *
-   * @param button Button index.
-   * @return {@code true} if the button was just pressed and input is enabled, regardless of UI capture.
-   */
-  public boolean rawJustPressed(int button) {
-    return enabled && button >= 0 && button <= MAX_BUTTON && justPressed[button];
+    return enabled && !isCapturedByDebugUI() && button >= 0 && button <= MAX_BUTTON && justPressed[button];
   }
 
   /**
@@ -279,20 +250,7 @@ public class FlixelMouseInputManager implements FlixelInputManager, FlixelMouseL
    * @return {@code true} if the button was just released and input is enabled and not suppressed.
    */
   public boolean justReleased(int button) {
-    if (isCapturedByDebugUI()) {
-      return false;
-    }
-    return rawJustReleased(button);
-  }
-
-  /**
-   * Same as {@link #justReleased(int)} but bypasses the "captured by debug UI" check.
-   *
-   * @param button Button index.
-   * @return {@code true} if the button was just released and input is enabled, regardless of UI capture.
-   */
-  public boolean rawJustReleased(int button) {
-    return enabled && button >= 0 && button <= MAX_BUTTON && justReleased[button];
+    return enabled && !isCapturedByDebugUI() && button >= 0 && button <= MAX_BUTTON && justReleased[button];
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/package-info.java
@@ -108,14 +108,7 @@
  * {@link org.flixelgdx.input.mouse.FlixelMouseInputManager#justPressed(int) justPressed()}, and
  * {@link org.flixelgdx.input.mouse.FlixelMouseInputManager#justReleased(int) justReleased()}
  * return {@code false} automatically. This prevents clicks inside a debug panel from triggering
- * game behavior at the same time. Use the {@code raw} variants to opt out of this suppression:
- *
- * <pre>{@code
- * // Always responds, even when a debug panel is open.
- * if (Flixel.mouse.rawJustPressed(FlixelMouseButton.LEFT)) {
- *   debugTool.pick(Flixel.mouse.getWorldX(), Flixel.mouse.getWorldY());
- * }
- * }</pre>
+ * game behavior at the same time.
  *
  * <h2>Cursor styling</h2>
  *

--- a/flixelgdx-desktop/build.gradle.kts
+++ b/flixelgdx-desktop/build.gradle.kts
@@ -35,6 +35,15 @@ dependencies {
     runtimeOnly("org.lwjgl:lwjgl-zstd:$lwjglVersion:$classifier")
   }
 
+  // Dear ImGui (via the SpaiR imgui-java binding) powers the debug overlay and is exposed as api so
+  // games can add their own ImGui panels through the overlay's onDrawImGui hook. Only the core
+  // binding is used; the project ships its own bgfx renderer and SDL3 platform layer instead of
+  // imgui-java's bundled GLFW/OpenGL backends.
+  api(libs.imgui.binding)
+  runtimeOnly(libs.imgui.natives.linux)
+  runtimeOnly(libs.imgui.natives.macos)
+  runtimeOnly(libs.imgui.natives.windows)
+
   implementation(libs.jetbrains.annotations)
   implementation(libs.jansi)
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopLauncher.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopLauncher.java
@@ -28,6 +28,7 @@ import org.flixelgdx.FlixelGame;
 import org.flixelgdx.backend.FlixelGameRunner;
 import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.flixelgdx.backend.desktop.audio.FlixelMiniAudioFactory;
+import org.flixelgdx.backend.desktop.debug.FlixelImGuiDebugOverlay;
 import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
 import org.flixelgdx.backend.desktop.graphics.FlixelKtx2Loader;
 import org.flixelgdx.backend.desktop.input.FlixelDesktopInputDevice;
@@ -65,13 +66,50 @@ public final class FlixelDesktopLauncher {
   private FlixelDesktopLauncher() {}
 
   /**
-   * Launches the game in {@link FlixelRuntimeMode#RELEASE RELEASE} mode. This is the call almost
-   * every game uses.
+   * Launches the game, choosing the runtime mode from the {@code flixel.mode} system property so the
+   * same code path serves development and release without a code change.
+   *
+   * <p>This is the call almost every game uses. The mode is resolved as follows:
+   *
+   * <ul>
+   *   <li>{@code -Dflixel.mode=debug} (or {@code -Dflixel.debug=true}) starts in
+   *       {@link FlixelRuntimeMode#DEBUG DEBUG}, which enables the debug overlay and diagnostics.</li>
+   *   <li>{@code -Dflixel.mode=test} starts in {@link FlixelRuntimeMode#TEST TEST}.</li>
+   *   <li>No property (the default, and how packaged/published builds run) starts in
+   *       {@link FlixelRuntimeMode#RELEASE RELEASE}.</li>
+   * </ul>
+   *
+   * <p>Because the flag lives in the launch command (for example a Gradle {@code debug} run task) and
+   * not in code, there is nothing to remember to remove before publishing: a shipped build simply runs
+   * without the property and lands in release mode. To force a specific mode regardless of the
+   * property, call {@link #launch(FlixelGame, FlixelRuntimeMode)} directly.
    *
    * @param game The game instance to run.
    */
   public static void launch(@NotNull FlixelGame game) {
-    launch(game, FlixelRuntimeMode.RELEASE);
+    launch(game, resolveRuntimeMode());
+  }
+
+  /**
+   * Resolves the runtime mode from the {@code flixel.mode} (or legacy {@code flixel.debug}) system
+   * property, defaulting to {@link FlixelRuntimeMode#RELEASE RELEASE}.
+   *
+   * @return The runtime mode requested on the command line, or {@code RELEASE} when none was.
+   */
+  private static FlixelRuntimeMode resolveRuntimeMode() {
+    String mode = System.getProperty("flixel.mode", "").trim().toLowerCase();
+    if (mode.isEmpty() && "true".equalsIgnoreCase(System.getProperty("flixel.debug", ""))) {
+      return FlixelRuntimeMode.DEBUG;
+    }
+    return switch (mode) {
+      case "debug" -> FlixelRuntimeMode.DEBUG;
+      case "test" -> FlixelRuntimeMode.TEST;
+      case "", "release" -> FlixelRuntimeMode.RELEASE;
+      default -> {
+        Flixel.warn("Desktop", "Unknown flixel.mode '" + mode + "'; defaulting to RELEASE.");
+        yield FlixelRuntimeMode.RELEASE;
+      }
+    };
   }
 
   /**
@@ -123,6 +161,11 @@ public final class FlixelDesktopLauncher {
       Flixel.gamepads.addMappingResolver(gamepads);
       Flixel.mouse.setMouseIconManager(iconManager);
     });
+
+    // Install the Dear ImGui debug overlay factory. It is only instantiated when debug mode is on
+    // (FlixelGame.create gates on it), so this is inert in release builds while still letting a game
+    // flip debug mode on at runtime and get the full overlay.
+    Flixel.setDebugOverlay(FlixelImGuiDebugOverlay::new);
 
     Flixel.setRuntimeMode(runtimeMode);
     Flixel.setDebugMode(runtimeMode == FlixelRuntimeMode.DEBUG);

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -36,6 +36,7 @@ import org.lwjgl.bgfx.BGFX;
 import org.lwjgl.bgfx.BGFXInit;
 import org.lwjgl.sdl.SDLEvents;
 import org.lwjgl.sdl.SDLInit;
+import org.lwjgl.sdl.SDLKeyboard;
 import org.lwjgl.sdl.SDLMouse;
 import org.lwjgl.sdl.SDLVideo;
 import org.lwjgl.sdl.SDL_Event;
@@ -156,6 +157,13 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
     graphics.onInitialized(width, height, transparentFramebuffer);
     graphics.setVSync(vsync);
     gamepads.openConnected();
+
+    // The debug overlay's command line needs SDL text-input events (which carry composed characters,
+    // separate from raw key events). Only debug builds have that overlay, so keep text input off
+    // otherwise to avoid triggering an IME where it is not wanted.
+    if (Flixel.isDebugMode()) {
+      SDLKeyboard.SDL_StartTextInput(windowHandle);
+    }
 
     game.create();
 
@@ -343,6 +351,17 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
         }
         case SDLEvents.SDL_EVENT_KEY_UP ->
           input.onKeyUp(FlixelSdlKeyMap.toFlixelKey(event.key().scancode()));
+        case SDLEvents.SDL_EVENT_TEXT_INPUT -> {
+          // Composed text (letters, punctuation, IME output) arrives here as UTF-8, separate from the
+          // physical key events above. Feed each character to listeners so the debug command line and
+          // any future text fields can read typed input.
+          String textInput = event.text().textString();
+          if (textInput != null) {
+            for (int i = 0; i < textInput.length(); i++) {
+              input.onKeyTyped(textInput.charAt(i));
+            }
+          }
+        }
         case SDLEvents.SDL_EVENT_MOUSE_BUTTON_DOWN ->
           input.onMouseDown(mouseButton(event.button().button()), (int) event.button().x(), (int) event.button().y());
         case SDLEvents.SDL_EVENT_MOUSE_BUTTON_UP ->

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelBgfxStatsSampler.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelBgfxStatsSampler.java
@@ -1,0 +1,174 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.desktop.debug;
+
+import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.bgfx.BGFXStats;
+
+/**
+ * Samples bgfx's per-frame render statistics into rolling ring buffers for the debug overlay.
+ *
+ * <p>bgfx tracks a lot of numbers each frame (CPU and GPU frame timings, how long each thread waited
+ * on the other, draw-call counts, transient buffer usage, and VRAM totals). The ones that change
+ * every frame are worth plotting over time, so this class keeps a fixed-size history of each and lets
+ * the overlay draw them as graphs. The remaining one-off counters (resource counts, peak draw calls,
+ * and so on) do not need a history and are read straight off the live {@link BGFXStats} by the panel.
+ *
+ * <p>bgfx reports CPU and GPU times in raw timer ticks against separate frequencies, so this class
+ * also converts them to milliseconds and exposes the two conversion factors it computed, so the panel
+ * can format the instantaneous timing values with the same math.
+ *
+ * <p>Every buffer is a primitive {@code float[]} sized to {@link FlixelDebugOverlay#PERF_HISTORY_SIZE},
+ * and {@link #sample(BGFXStats)} reads from the graphics manager's cached stats object, so collecting
+ * a sample never allocates.
+ */
+public final class FlixelBgfxStatsSampler {
+
+  /** History length of each ring, matched to the core performance graphs for a consistent time window. */
+  private static final int SIZE = FlixelDebugOverlay.PERF_HISTORY_SIZE;
+
+  /** Bytes in one megabyte, used to convert bgfx's byte counters to the megabytes the panel shows. */
+  private static final float BYTES_PER_MB = 1024f * 1024f;
+
+  private double cpuToMs;
+  private double gpuToMs;
+
+  private final float[] cpuFrameMs = new float[SIZE];
+  private final float[] cpuSubmitMs = new float[SIZE];
+  private final float[] gpuMs = new float[SIZE];
+  private final float[] waitSubmitMs = new float[SIZE];
+  private final float[] waitRenderMs = new float[SIZE];
+  private final float[] drawCalls = new float[SIZE];
+  private final float[] gpuMemoryMb = new float[SIZE];
+
+  private int head;
+  private int count;
+
+  /**
+   * Appends one frame of bgfx stats to every ring buffer.
+   *
+   * <p>A {@code null} argument (bgfx not initialized yet) is ignored so the caller does not have to
+   * null-check before sampling.
+   *
+   * @param stats The live, cached bgfx stats for the just-completed frame, or {@code null}.
+   */
+  public void sample(@Nullable BGFXStats stats) {
+    if (stats == null) {
+      return;
+    }
+    // Each timer runs at its own frequency; a GPU frequency of zero means the backend cannot time the
+    // GPU, in which case the GPU series stays flat at zero rather than dividing by zero.
+    cpuToMs = stats.cpuTimerFreq() > 0 ? 1000.0 / stats.cpuTimerFreq() : 0.0;
+    gpuToMs = stats.gpuTimerFreq() > 0 ? 1000.0 / stats.gpuTimerFreq() : 0.0;
+
+    int i = head;
+    cpuFrameMs[i] = (float) (stats.cpuTimeFrame() * cpuToMs);
+    cpuSubmitMs[i] = (float) ((stats.cpuTimeEnd() - stats.cpuTimeBegin()) * cpuToMs);
+    gpuMs[i] = (float) ((stats.gpuTimeEnd() - stats.gpuTimeBegin()) * gpuToMs);
+    waitSubmitMs[i] = (float) (stats.waitSubmit() * cpuToMs);
+    waitRenderMs[i] = (float) (stats.waitRender() * cpuToMs);
+    drawCalls[i] = stats.numDraw();
+    gpuMemoryMb[i] = stats.gpuMemoryUsed() < 0 ? 0f : stats.gpuMemoryUsed() / BYTES_PER_MB;
+
+    head = (i + 1) % SIZE;
+    if (count < SIZE) {
+      count++;
+    }
+  }
+
+  /**
+   * Returns the most recent value written into {@code ring}, accounting for wraparound, or {@code 0}
+   * when no samples have been collected yet.
+   *
+   * @param ring One of this sampler's ring buffers.
+   * @return The latest sample in {@code ring}.
+   */
+  public float latest(float[] ring) {
+    if (count == 0) {
+      return 0f;
+    }
+    int last = (head - 1 + SIZE) % SIZE;
+    return ring[last];
+  }
+
+  /**
+   * The read offset into each ring for a plot covering {@code count} samples.
+   *
+   * <p>While the ring is still filling, the oldest sample is at index {@code 0}; once it is full the
+   * oldest sample is at {@link #getHead()} (the next write position). Graph widgets that read a fixed
+   * number of samples with wraparound use this to start at the oldest one.
+   *
+   * @return The index of the oldest valid sample.
+   */
+  public int getPlotOffset() {
+    return count < SIZE ? 0 : head;
+  }
+
+  public int getHead() {
+    return head;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  /** Milliseconds per CPU timer tick from the most recent {@link #sample(BGFXStats)}. */
+  public double getCpuToMs() {
+    return cpuToMs;
+  }
+
+  /** Milliseconds per GPU timer tick from the most recent {@link #sample(BGFXStats)}, or {@code 0} if untimed. */
+  public double getGpuToMs() {
+    return gpuToMs;
+  }
+
+  public float[] getCpuFrameMs() {
+    return cpuFrameMs;
+  }
+
+  public float[] getCpuSubmitMs() {
+    return cpuSubmitMs;
+  }
+
+  public float[] getGpuMs() {
+    return gpuMs;
+  }
+
+  public float[] getWaitSubmitMs() {
+    return waitSubmitMs;
+  }
+
+  public float[] getWaitRenderMs() {
+    return waitRenderMs;
+  }
+
+  public float[] getDrawCalls() {
+    return drawCalls;
+  }
+
+  public float[] getGpuMemoryMb() {
+    return gpuMemoryMb;
+  }
+}

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
@@ -23,7 +23,6 @@
  */
 package org.flixelgdx.backend.desktop.debug;
 
-import org.flixelgdx.Flixel;
 import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
 import org.flixelgdx.math.FlixelMatrix;
 import org.jetbrains.annotations.NotNull;
@@ -31,10 +30,8 @@ import org.lwjgl.bgfx.BGFX;
 import org.lwjgl.bgfx.BGFXTransientIndexBuffer;
 import org.lwjgl.bgfx.BGFXTransientVertexBuffer;
 import org.lwjgl.bgfx.BGFXVertexLayout;
-import org.lwjgl.system.MemoryUtil;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 import imgui.ImDrawData;
 import imgui.ImVec4;
@@ -69,7 +66,7 @@ public final class FlixelImGuiBgfxRenderer {
 
   /** Point-sampled, clamped filtering so both the bitmap font and inspected pixel-art stay crisp. */
   private static final int SAMPLER_FLAGS =
-      (int) (BGFX.BGFX_SAMPLER_POINT | BGFX.BGFX_SAMPLER_U_CLAMP | BGFX.BGFX_SAMPLER_V_CLAMP);
+      BGFX.BGFX_SAMPLER_POINT | BGFX.BGFX_SAMPLER_U_CLAMP | BGFX.BGFX_SAMPLER_V_CLAMP;
 
   /**
    * Standard straight-alpha "over" blend, matching {@link org.flixelgdx.util.FlixelBlendMode#NORMAL}.
@@ -105,9 +102,6 @@ public final class FlixelImGuiBgfxRenderer {
   private short fontTexture = -1;
 
   private boolean initialized;
-
-  /** Guards a single diagnostic log line describing the draw-data layout on the first rendered frame. */
-  private boolean loggedDiagnostics;
 
   /**
    * Creates a renderer bound to the desktop bgfx graphics manager.
@@ -186,7 +180,7 @@ public final class FlixelImGuiBgfxRenderer {
     // vertices straight to the back buffer. Match the backend's depth range so the geometry is not
     // clipped on the [0, 1] backends (Vulkan, Metal, Direct3D).
     ortho.setToOrtho2DYDown(0, 0, displayWidth, displayHeight, graphics.isDepthZeroToOne());
-    BGFX.bgfx_set_view_transform(view, (float[]) null, ortho.val);
+    BGFX.bgfx_set_view_transform(view, null, ortho.val);
 
     boolean bgra = graphics.isDepthZeroToOne();
     int fbWidth = Math.round(displayWidth);
@@ -209,14 +203,13 @@ public final class FlixelImGuiBgfxRenderer {
 
       BGFX.bgfx_alloc_transient_vertex_buffer(tvb, vertexCount, layout);
       copyVertices(vertexData, tvb.data(), vertexCount, vertexStride, bgra);
-      BGFX.bgfx_alloc_transient_index_buffer(tib, indexCount, index32);
-      MemoryUtil.memCopy(MemoryUtil.memAddress(indexData), MemoryUtil.memAddress(tib.data()),
-          (long) indexCount * indexStride);
 
-      if (!loggedDiagnostics) {
-        loggedDiagnostics = true;
-        logDrawDataDiagnostics(drawData, n, view, vertexStride, indexStride, bgra, cmdListCount);
-      }
+      BGFX.bgfx_alloc_transient_index_buffer(tib, indexCount, index32);
+      ByteBuffer tibData = tib.data();
+      int origIdxLim = indexData.limit();
+      indexData.limit(indexData.position() + indexCount * indexStride);
+      tibData.put(indexData);
+      indexData.limit(origIdxLim);
 
       int cmdCount = drawData.getCmdListCmdBufferSize(n);
       for (int cmd = 0; cmd < cmdCount; cmd++) {
@@ -251,56 +244,19 @@ public final class FlixelImGuiBgfxRenderer {
   }
 
   /**
-   * Logs a single line describing command list {@code n} so a rendering problem can be diagnosed
-   * without a debugger. It reads the first vertex both from Dear ImGui's source buffer and from the
-   * transient buffer this renderer just filled, so a mismatch points at the upload rather than the
-   * draw, plus the first draw command's element count, offsets, clip rectangle, and texture id.
-   *
-   * @param drawData The current frame's draw data.
-   * @param n The command list index that was just uploaded.
-   * @param view The bgfx view the overlay renders into.
-   * @param vertexStride The byte size of one ImGui vertex.
-   * @param indexStride The byte size of one ImGui index.
-   * @param bgra Whether the active backend uses BGRA color order.
-   * @param cmdListCount The number of command lists this frame.
-   */
-  private void logDrawDataDiagnostics(@NotNull ImDrawData drawData, int n, int view, int vertexStride,
-      int indexStride, boolean bgra, int cmdListCount) {
-    ByteBuffer src = drawData.getCmdListVtxBufferData(n).order(ByteOrder.nativeOrder());
-    int sp = src.position();
-    String srcVertex = src.remaining() >= vertexStride ? formatVertex(src, sp) : "(none)";
-    ByteBuffer dst = tvb.data().order(ByteOrder.nativeOrder());
-    String dstVertex = dst.remaining() >= vertexStride ? formatVertex(dst, 0) : "(none)";
-    String firstCmd = "(none)";
-    if (drawData.getCmdListCmdBufferSize(n) > 0) {
-      drawData.getCmdListCmdBufferClipRect(clip, n, 0);
-      firstCmd = "elem=" + drawData.getCmdListCmdBufferElemCount(n, 0)
-          + " idxOff=" + drawData.getCmdListCmdBufferIdxOffset(n, 0)
-          + " vtxOff=" + drawData.getCmdListCmdBufferVtxOffset(n, 0)
-          + " tex=" + drawData.getCmdListCmdBufferTextureId(n, 0)
-          + " clip=[" + clip.x + "," + clip.y + "," + clip.z + "," + clip.w + "]";
-    }
-    Flixel.debug("ImGuiRenderer", "renderer=" + BGFX.bgfx_get_renderer_type() + " view=" + view
-        + " stride=" + vertexStride + "/" + indexStride + " bgra=" + bgra
-        + " program=" + graphics.getSpriteProgram() + " fontTex=" + fontTexture
-        + " cmdLists=" + cmdListCount + " srcV0=" + srcVertex + " dstV0=" + dstVertex + " cmd0=" + firstCmd);
-  }
-
-  /** Formats one ImGui vertex (position, texture coordinate, packed color) for the diagnostic line. */
-  private static String formatVertex(@NotNull ByteBuffer buffer, int base) {
-    return "(" + buffer.getFloat(base) + "," + buffer.getFloat(base + 4) + " uv=" + buffer.getFloat(base + 8)
-        + "," + buffer.getFloat(base + 12) + " col=0x" + Integer.toHexString(buffer.getInt(base + 16)) + ")";
-  }
-
-  /**
    * Copies one command list's vertices into the transient buffer, swapping each vertex color's red
    * and blue bytes when the active backend stores colors in BGRA order.
    *
    * <p>ImGui always packs vertex color as RGBA bytes ({@code IM_COL32}). On OpenGL that matches the
    * color attribute's memory order, so the whole block copies verbatim. On Vulkan, Metal, and
    * Direct3D the sprite layout uses BGRA order (the same convention the sprite batch follows), so the
-   * red and blue bytes are swapped in place after the bulk copy. The swap touches only the overlay's
-   * own vertices, and only while it is visible, so it never runs on the game's render path.
+   * red and blue bytes are swapped in place after the bulk copy.
+   *
+   * <p>The bulk copy uses {@link ByteBuffer#put(ByteBuffer)} rather than a raw address-based copy
+   * because the TVB's backing memory is not reliably accessible through its native address on all
+   * Vulkan/Linux driver and JVM combinations. The JDK's direct-buffer path (the same one the sprite
+   * batch uses for its TVB uploads) is the only path that is guaranteed to reach the GPU-visible
+   * allocation.
    *
    * @param src The ImGui vertex bytes for one command list.
    * @param dst The transient vertex buffer memory to fill.
@@ -310,7 +266,10 @@ public final class FlixelImGuiBgfxRenderer {
    */
   private static void copyVertices(@NotNull ByteBuffer src, @NotNull ByteBuffer dst, int vertexCount,
       int vertexStride, boolean bgra) {
-    MemoryUtil.memCopy(MemoryUtil.memAddress(src), MemoryUtil.memAddress(dst), (long) vertexCount * vertexStride);
+    int origLim = src.limit();
+    src.limit(src.position() + vertexCount * vertexStride);
+    dst.put(src);
+    src.limit(origLim);
     if (!bgra) {
       return;
     }

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
@@ -1,0 +1,272 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.desktop.debug;
+
+import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
+import org.flixelgdx.math.FlixelMatrix;
+import org.jetbrains.annotations.NotNull;
+import org.lwjgl.bgfx.BGFX;
+import org.lwjgl.bgfx.BGFXTransientIndexBuffer;
+import org.lwjgl.bgfx.BGFXTransientVertexBuffer;
+import org.lwjgl.bgfx.BGFXVertexLayout;
+import org.lwjgl.system.MemoryUtil;
+
+import java.nio.ByteBuffer;
+
+import imgui.ImDrawData;
+import imgui.ImVec4;
+
+/**
+ * Renders Dear ImGui draw data through bgfx.
+ *
+ * <p>Dear ImGui is renderer-agnostic: each frame it produces an {@link ImDrawData} object, which is
+ * just a list of vertex buffers, index buffers, and draw commands (a clip rectangle, a texture, and
+ * a slice of indices). A renderer backend walks that list and submits it to a graphics API. imgui-java
+ * ships backends for raw OpenGL and Vulkan, but this project renders everything through bgfx, so this
+ * class is the bespoke bgfx backend.
+ *
+ * <p>The ImGui vertex format is identical to the framework's sprite vertex format: two floats of
+ * position, two floats of texture coordinate, then four bytes of packed color. The sprite fragment
+ * shader already outputs {@code texture * vertexColor}, which is exactly what ImGui needs, so this
+ * renderer reuses {@link FlixelBgfxGraphics#getSpriteProgram() the sprite program} instead of
+ * compiling a dedicated ImGui shader for every backend.
+ *
+ * <p>Everything is uploaded through bgfx transient buffers (the same short-lived, per-frame geometry
+ * path the sprite batch uses), so no GPU buffers are retained between frames. The only persistent GPU
+ * resource is the font atlas texture, created once in {@link #init(ByteBuffer, int, int)} and
+ * destroyed in {@link #dispose()}.
+ */
+public final class FlixelImGuiBgfxRenderer {
+
+  /** Bytes per ImGui vertex: position (2 floats) + texture coordinate (2 floats) + color (4 bytes). */
+  private static final int VERTEX_STRIDE = 20;
+
+  /** Bytes per ImGui index. imgui-java uses unsigned 16-bit indices. */
+  private static final int INDEX_STRIDE = 2;
+
+  /** Byte offset of the packed color inside each vertex (after the two position and two UV floats). */
+  private static final int COLOR_OFFSET = 16;
+
+  /** Point-sampled, clamped filtering so both the bitmap font and inspected pixel-art stay crisp. */
+  private static final int SAMPLER_FLAGS =
+      (int) (BGFX.BGFX_SAMPLER_POINT | BGFX.BGFX_SAMPLER_U_CLAMP | BGFX.BGFX_SAMPLER_V_CLAMP);
+
+  /**
+   * Standard straight-alpha "over" blend, matching {@link org.flixelgdx.util.FlixelBlendMode#NORMAL}.
+   * Color blends with source alpha; the destination alpha accumulates so the overlay composites
+   * correctly onto an alpha-capable back buffer.
+   */
+  private static final long DRAW_STATE = BGFX.BGFX_STATE_WRITE_RGB | BGFX.BGFX_STATE_WRITE_A
+      | BGFX.BGFX_STATE_BLEND_FUNC_SEPARATE(
+          BGFX.BGFX_STATE_BLEND_SRC_ALPHA, BGFX.BGFX_STATE_BLEND_INV_SRC_ALPHA,
+          BGFX.BGFX_STATE_BLEND_ONE, BGFX.BGFX_STATE_BLEND_INV_SRC_ALPHA);
+
+  @NotNull
+  private final FlixelBgfxGraphics graphics;
+
+  @NotNull
+  private final BGFXVertexLayout layout = BGFXVertexLayout.create();
+
+  @NotNull
+  private final BGFXTransientVertexBuffer tvb = BGFXTransientVertexBuffer.create();
+
+  @NotNull
+  private final BGFXTransientIndexBuffer tib = BGFXTransientIndexBuffer.create();
+
+  /** Reused ortho matrix rebuilt each frame to map ImGui's pixel coordinates onto the back buffer. */
+  @NotNull
+  private final FlixelMatrix ortho = new FlixelMatrix();
+
+  /** Reused clip-rectangle holder filled per draw command (min x, min y, max x, max y). */
+  @NotNull
+  private final ImVec4 clip = new ImVec4();
+
+  /** The font atlas texture handle, or {@code -1} until {@link #init()} uploads it. */
+  private short fontTexture = -1;
+
+  private boolean initialized;
+
+  /**
+   * Creates a renderer bound to the desktop bgfx graphics manager.
+   *
+   * @param graphics The bgfx graphics manager whose sprite program, texture uniform, and view
+   *     allocation the renderer reuses.
+   */
+  public FlixelImGuiBgfxRenderer(@NotNull FlixelBgfxGraphics graphics) {
+    this.graphics = graphics;
+  }
+
+  /**
+   * Builds the ImGui vertex layout and uploads the font atlas texture.
+   *
+   * <p>Call once, after the Dear ImGui context exists and its fonts have been built, but before the
+   * first {@link #render(ImDrawData)}.
+   *
+   * @param fontPixels The RGBA8 font atlas pixels from {@code io.getFonts().getTexDataAsRGBA32(...)}.
+   * @param fontWidth The atlas width in pixels.
+   * @param fontHeight The atlas height in pixels.
+   * @return The bgfx texture handle assigned to the atlas, so the caller can register it as the
+   *     Dear ImGui font texture id, or {@code -1} if the texture could not be created.
+   */
+  public long init(@NotNull ByteBuffer fontPixels, int fontWidth, int fontHeight) {
+    int renderer = BGFX.bgfx_get_renderer_type();
+    BGFX.bgfx_vertex_layout_begin(layout, renderer);
+    BGFX.bgfx_vertex_layout_add(layout, BGFX.BGFX_ATTRIB_POSITION, 2, BGFX.BGFX_ATTRIB_TYPE_FLOAT, false, false);
+    BGFX.bgfx_vertex_layout_add(layout, BGFX.BGFX_ATTRIB_TEXCOORD0, 2, BGFX.BGFX_ATTRIB_TYPE_FLOAT, false, false);
+    BGFX.bgfx_vertex_layout_add(layout, BGFX.BGFX_ATTRIB_COLOR0, 4, BGFX.BGFX_ATTRIB_TYPE_UINT8, true, false);
+    BGFX.bgfx_vertex_layout_end(layout);
+
+    // The atlas is white with per-texel coverage in the alpha channel, so the red/blue swizzle that
+    // some backends need for arbitrary textures does not matter here; upload the pixels as-is.
+    fontTexture = BGFX.bgfx_create_texture_2d(fontWidth, fontHeight, false, 1,
+        BGFX.BGFX_TEXTURE_FORMAT_RGBA8, BGFX.BGFX_TEXTURE_NONE, BGFX.bgfx_copy(fontPixels), 0L);
+    initialized = fontTexture != -1;
+    return fontTexture;
+  }
+
+  /**
+   * Submits one frame of Dear ImGui draw data to bgfx.
+   *
+   * <p>Reuses the sprite program and reserves a fresh top-most view (see
+   * {@link FlixelBgfxGraphics#beginOverlayView()}) so the overlay draws over the finished game frame.
+   * Each ImGui command list is uploaded into a transient vertex and index buffer, then every command
+   * within it becomes one bgfx draw with its own scissor rectangle and bound texture.
+   *
+   * @param drawData The draw data returned by {@code ImGui.getDrawData()} after {@code ImGui.render()}.
+   */
+  public void render(@NotNull ImDrawData drawData) {
+    short program = graphics.getSpriteProgram();
+    short textureUniform = graphics.getTextureUniform();
+    if (!initialized || program == -1 || textureUniform == -1) {
+      return;
+    }
+    int cmdListCount = drawData.getCmdListsCount();
+    if (cmdListCount <= 0) {
+      return;
+    }
+
+    float displayWidth = drawData.getDisplaySizeX();
+    float displayHeight = drawData.getDisplaySizeY();
+    if (displayWidth <= 0f || displayHeight <= 0f) {
+      return;
+    }
+
+    int view = graphics.beginOverlayView();
+    // ImGui works in top-left, y-down pixel space, so a y-down ortho over the display maps its
+    // vertices straight to the back buffer. Match the backend's depth range so the geometry is not
+    // clipped on the [0, 1] backends (Vulkan, Metal, Direct3D).
+    ortho.setToOrtho2DYDown(0, 0, displayWidth, displayHeight, graphics.isDepthZeroToOne());
+    BGFX.bgfx_set_view_transform(view, (float[]) null, ortho.val);
+
+    boolean bgra = graphics.isDepthZeroToOne();
+    int fbWidth = Math.round(displayWidth);
+    int fbHeight = Math.round(displayHeight);
+
+    for (int n = 0; n < cmdListCount; n++) {
+      ByteBuffer vertexData = drawData.getCmdListVtxBufferData(n);
+      ByteBuffer indexData = drawData.getCmdListIdxBufferData(n);
+      int vertexCount = vertexData.remaining() / VERTEX_STRIDE;
+      int indexCount = indexData.remaining() / INDEX_STRIDE;
+      if (vertexCount == 0 || indexCount == 0) {
+        continue;
+      }
+      // bgfx clamps over-allocation and warns; skipping a list that does not fit avoids a partially
+      // uploaded frame if the overlay ever produces more geometry than the transient pool holds.
+      if (BGFX.bgfx_get_avail_transient_vertex_buffer(vertexCount, layout) < vertexCount
+          || BGFX.bgfx_get_avail_transient_index_buffer(indexCount, false) < indexCount) {
+        continue;
+      }
+
+      BGFX.bgfx_alloc_transient_vertex_buffer(tvb, vertexCount, layout);
+      copyVertices(vertexData, tvb.data(), vertexCount, bgra);
+      BGFX.bgfx_alloc_transient_index_buffer(tib, indexCount, false);
+      MemoryUtil.memCopy(MemoryUtil.memAddress(indexData), MemoryUtil.memAddress(tib.data()),
+          (long) indexCount * INDEX_STRIDE);
+
+      int cmdCount = drawData.getCmdListCmdBufferSize(n);
+      for (int cmd = 0; cmd < cmdCount; cmd++) {
+        int elemCount = drawData.getCmdListCmdBufferElemCount(n, cmd);
+        if (elemCount == 0) {
+          continue;
+        }
+        int idxOffset = drawData.getCmdListCmdBufferIdxOffset(n, cmd);
+        int vtxOffset = drawData.getCmdListCmdBufferVtxOffset(n, cmd);
+        drawData.getCmdListCmdBufferClipRect(clip, n, cmd);
+
+        int clipX = Math.max(0, (int) clip.x);
+        int clipY = Math.max(0, (int) clip.y);
+        int clipMaxX = Math.min(fbWidth, (int) clip.z);
+        int clipMaxY = Math.min(fbHeight, (int) clip.w);
+        if (clipMaxX <= clipX || clipMaxY <= clipY) {
+          continue;
+        }
+
+        short texture = (short) drawData.getCmdListCmdBufferTextureId(n, cmd);
+        BGFX.bgfx_set_scissor(clipX, clipY, clipMaxX - clipX, clipMaxY - clipY);
+        BGFX.bgfx_set_transient_vertex_buffer(0, tvb, vtxOffset, vertexCount - vtxOffset);
+        BGFX.bgfx_set_transient_index_buffer(tib, idxOffset, elemCount);
+        BGFX.bgfx_set_texture(0, textureUniform, texture, SAMPLER_FLAGS);
+        BGFX.bgfx_set_state(DRAW_STATE, 0);
+        BGFX.bgfx_submit(view, program, 0, BGFX.BGFX_DISCARD_ALL);
+      }
+    }
+  }
+
+  /**
+   * Copies one command list's vertices into the transient buffer, swapping each vertex color's red
+   * and blue bytes when the active backend stores colors in BGRA order.
+   *
+   * <p>ImGui always packs vertex color as RGBA bytes ({@code IM_COL32}). On OpenGL that matches the
+   * color attribute's memory order, so the whole block copies verbatim. On Vulkan, Metal, and
+   * Direct3D the sprite layout uses BGRA order (the same convention the sprite batch follows), so the
+   * red and blue bytes are swapped in place after the bulk copy. The swap touches only the overlay's
+   * own vertices, and only while it is visible, so it never runs on the game's render path.
+   *
+   * @param src The ImGui vertex bytes for one command list.
+   * @param dst The transient vertex buffer memory to fill.
+   * @param vertexCount The number of vertices to copy.
+   * @param bgra Whether the active backend expects BGRA color byte order.
+   */
+  private static void copyVertices(@NotNull ByteBuffer src, @NotNull ByteBuffer dst, int vertexCount, boolean bgra) {
+    MemoryUtil.memCopy(MemoryUtil.memAddress(src), MemoryUtil.memAddress(dst), (long) vertexCount * VERTEX_STRIDE);
+    if (!bgra) {
+      return;
+    }
+    for (int i = 0; i < vertexCount; i++) {
+      int base = i * VERTEX_STRIDE + COLOR_OFFSET;
+      byte r = dst.get(base);
+      dst.put(base, dst.get(base + 2));
+      dst.put(base + 2, r);
+    }
+  }
+
+  /** Destroys the font atlas texture. Safe to call more than once. */
+  public void dispose() {
+    if (fontTexture != -1) {
+      BGFX.bgfx_destroy_texture(fontTexture);
+      fontTexture = -1;
+    }
+    initialized = false;
+  }
+}

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
@@ -187,10 +187,11 @@ public final class FlixelImGuiBgfxRenderer {
     int fbHeight = Math.round(displayHeight);
 
     for (int n = 0; n < cmdListCount; n++) {
-      ByteBuffer vertexData = drawData.getCmdListVtxBufferData(n);
-      ByteBuffer indexData = drawData.getCmdListIdxBufferData(n);
-      int vertexCount = vertexData.remaining() / vertexStride;
-      int indexCount = indexData.remaining() / indexStride;
+      // Read the element counts from the draw list rather than a buffer's byte size. imgui-java hands
+      // back the same reused ByteBuffer for a command list's vertex and index data (see below), so the
+      // vertex buffer's remaining() cannot be trusted once the index buffer has been fetched.
+      int vertexCount = drawData.getCmdListVtxBufferSize(n);
+      int indexCount = drawData.getCmdListIdxBufferSize(n);
       if (vertexCount == 0 || indexCount == 0) {
         continue;
       }
@@ -201,10 +202,16 @@ public final class FlixelImGuiBgfxRenderer {
         continue;
       }
 
+      // imgui-java returns a single shared ByteBuffer from both getCmdListVtxBufferData and
+      // getCmdListIdxBufferData, re-pointing it at whichever was requested last. The vertices must
+      // therefore be fetched and fully copied into the transient buffer BEFORE the index buffer is
+      // fetched; otherwise the vertex upload reads the index data instead, producing degenerate,
+      // invisible geometry.
       BGFX.bgfx_alloc_transient_vertex_buffer(tvb, vertexCount, layout);
-      copyVertices(vertexData, tvb.data(), vertexCount, vertexStride, bgra);
+      copyVertices(drawData.getCmdListVtxBufferData(n), tvb.data(), vertexCount, vertexStride, bgra);
 
       BGFX.bgfx_alloc_transient_index_buffer(tib, indexCount, index32);
+      ByteBuffer indexData = drawData.getCmdListIdxBufferData(n);
       ByteBuffer tibData = tib.data();
       int origIdxLim = indexData.limit();
       indexData.limit(indexData.position() + indexCount * indexStride);

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.backend.desktop.debug;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
 import org.flixelgdx.math.FlixelMatrix;
 import org.jetbrains.annotations.NotNull;
@@ -59,13 +60,10 @@ import imgui.ImVec4;
  */
 public final class FlixelImGuiBgfxRenderer {
 
-  /** Bytes per ImGui vertex: position (2 floats) + texture coordinate (2 floats) + color (4 bytes). */
-  private static final int VERTEX_STRIDE = 20;
-
-  /** Bytes per ImGui index. imgui-java uses unsigned 16-bit indices. */
-  private static final int INDEX_STRIDE = 2;
-
-  /** Byte offset of the packed color inside each vertex (after the two position and two UV floats). */
+  /**
+   * Byte offset of the packed color inside each vertex (after the two position and two UV floats).
+   * This is fixed by the ImGui vertex format regardless of the total vertex stride.
+   */
   private static final int COLOR_OFFSET = 16;
 
   /** Point-sampled, clamped filtering so both the bitmap font and inspected pixel-art stay crisp. */
@@ -102,10 +100,13 @@ public final class FlixelImGuiBgfxRenderer {
   @NotNull
   private final ImVec4 clip = new ImVec4();
 
-  /** The font atlas texture handle, or {@code -1} until {@link #init()} uploads it. */
+  /** The font atlas texture handle, or {@code -1} until {@link #init(ByteBuffer, int, int)} uploads it. */
   private short fontTexture = -1;
 
   private boolean initialized;
+
+  /** Guards a single diagnostic log line describing the draw-data layout on the first rendered frame. */
+  private boolean loggedDiagnostics;
 
   /**
    * Creates a renderer bound to the desktop bgfx graphics manager.
@@ -172,6 +173,13 @@ public final class FlixelImGuiBgfxRenderer {
       return;
     }
 
+    // ImGui's vertex and index sizes are decided by the native build (16- or 32-bit indices, and the
+    // vertex stride), so read them at runtime rather than assuming, exactly as imgui-java's own
+    // renderers do. Getting either wrong scrambles the geometry into stray triangles.
+    int vertexStride = ImDrawData.sizeOfImDrawVert();
+    int indexStride = ImDrawData.sizeOfImDrawIdx();
+    boolean index32 = indexStride >= 4;
+
     int view = graphics.beginOverlayView();
     // ImGui works in top-left, y-down pixel space, so a y-down ortho over the display maps its
     // vertices straight to the back buffer. Match the backend's depth range so the geometry is not
@@ -183,26 +191,35 @@ public final class FlixelImGuiBgfxRenderer {
     int fbWidth = Math.round(displayWidth);
     int fbHeight = Math.round(displayHeight);
 
+    if (!loggedDiagnostics) {
+      loggedDiagnostics = true;
+      Flixel.debug("ImGuiRenderer", "vertexStride=" + vertexStride + " indexStride=" + indexStride
+          + " renderer=" + BGFX.bgfx_get_renderer_type() + " view=" + view
+          + " display=" + Math.round(displayWidth) + "x" + Math.round(displayHeight)
+          + " bgra=" + bgra + " program=" + graphics.getSpriteProgram() + " fontTex=" + fontTexture
+          + " cmdLists=" + cmdListCount);
+    }
+
     for (int n = 0; n < cmdListCount; n++) {
       ByteBuffer vertexData = drawData.getCmdListVtxBufferData(n);
       ByteBuffer indexData = drawData.getCmdListIdxBufferData(n);
-      int vertexCount = vertexData.remaining() / VERTEX_STRIDE;
-      int indexCount = indexData.remaining() / INDEX_STRIDE;
+      int vertexCount = vertexData.remaining() / vertexStride;
+      int indexCount = indexData.remaining() / indexStride;
       if (vertexCount == 0 || indexCount == 0) {
         continue;
       }
       // bgfx clamps over-allocation and warns; skipping a list that does not fit avoids a partially
       // uploaded frame if the overlay ever produces more geometry than the transient pool holds.
       if (BGFX.bgfx_get_avail_transient_vertex_buffer(vertexCount, layout) < vertexCount
-          || BGFX.bgfx_get_avail_transient_index_buffer(indexCount, false) < indexCount) {
+          || BGFX.bgfx_get_avail_transient_index_buffer(indexCount, index32) < indexCount) {
         continue;
       }
 
       BGFX.bgfx_alloc_transient_vertex_buffer(tvb, vertexCount, layout);
-      copyVertices(vertexData, tvb.data(), vertexCount, bgra);
-      BGFX.bgfx_alloc_transient_index_buffer(tib, indexCount, false);
+      copyVertices(vertexData, tvb.data(), vertexCount, vertexStride, bgra);
+      BGFX.bgfx_alloc_transient_index_buffer(tib, indexCount, index32);
       MemoryUtil.memCopy(MemoryUtil.memAddress(indexData), MemoryUtil.memAddress(tib.data()),
-          (long) indexCount * INDEX_STRIDE);
+          (long) indexCount * indexStride);
 
       int cmdCount = drawData.getCmdListCmdBufferSize(n);
       for (int cmd = 0; cmd < cmdCount; cmd++) {
@@ -246,15 +263,17 @@ public final class FlixelImGuiBgfxRenderer {
    * @param src The ImGui vertex bytes for one command list.
    * @param dst The transient vertex buffer memory to fill.
    * @param vertexCount The number of vertices to copy.
+   * @param vertexStride The byte size of one ImGui vertex.
    * @param bgra Whether the active backend expects BGRA color byte order.
    */
-  private static void copyVertices(@NotNull ByteBuffer src, @NotNull ByteBuffer dst, int vertexCount, boolean bgra) {
-    MemoryUtil.memCopy(MemoryUtil.memAddress(src), MemoryUtil.memAddress(dst), (long) vertexCount * VERTEX_STRIDE);
+  private static void copyVertices(@NotNull ByteBuffer src, @NotNull ByteBuffer dst, int vertexCount,
+      int vertexStride, boolean bgra) {
+    MemoryUtil.memCopy(MemoryUtil.memAddress(src), MemoryUtil.memAddress(dst), (long) vertexCount * vertexStride);
     if (!bgra) {
       return;
     }
     for (int i = 0; i < vertexCount; i++) {
-      int base = i * VERTEX_STRIDE + COLOR_OFFSET;
+      int base = i * vertexStride + COLOR_OFFSET;
       byte r = dst.get(base);
       dst.put(base, dst.get(base + 2));
       dst.put(base + 2, r);

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
@@ -34,6 +34,7 @@ import org.lwjgl.bgfx.BGFXVertexLayout;
 import org.lwjgl.system.MemoryUtil;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import imgui.ImDrawData;
 import imgui.ImVec4;
@@ -191,15 +192,6 @@ public final class FlixelImGuiBgfxRenderer {
     int fbWidth = Math.round(displayWidth);
     int fbHeight = Math.round(displayHeight);
 
-    if (!loggedDiagnostics) {
-      loggedDiagnostics = true;
-      Flixel.debug("ImGuiRenderer", "vertexStride=" + vertexStride + " indexStride=" + indexStride
-          + " renderer=" + BGFX.bgfx_get_renderer_type() + " view=" + view
-          + " display=" + Math.round(displayWidth) + "x" + Math.round(displayHeight)
-          + " bgra=" + bgra + " program=" + graphics.getSpriteProgram() + " fontTex=" + fontTexture
-          + " cmdLists=" + cmdListCount);
-    }
-
     for (int n = 0; n < cmdListCount; n++) {
       ByteBuffer vertexData = drawData.getCmdListVtxBufferData(n);
       ByteBuffer indexData = drawData.getCmdListIdxBufferData(n);
@@ -221,6 +213,11 @@ public final class FlixelImGuiBgfxRenderer {
       MemoryUtil.memCopy(MemoryUtil.memAddress(indexData), MemoryUtil.memAddress(tib.data()),
           (long) indexCount * indexStride);
 
+      if (!loggedDiagnostics) {
+        loggedDiagnostics = true;
+        logDrawDataDiagnostics(drawData, n, view, vertexStride, indexStride, bgra, cmdListCount);
+      }
+
       int cmdCount = drawData.getCmdListCmdBufferSize(n);
       for (int cmd = 0; cmd < cmdCount; cmd++) {
         int elemCount = drawData.getCmdListCmdBufferElemCount(n, cmd);
@@ -228,7 +225,6 @@ public final class FlixelImGuiBgfxRenderer {
           continue;
         }
         int idxOffset = drawData.getCmdListCmdBufferIdxOffset(n, cmd);
-        int vtxOffset = drawData.getCmdListCmdBufferVtxOffset(n, cmd);
         drawData.getCmdListCmdBufferClipRect(clip, n, cmd);
 
         int clipX = Math.max(0, (int) clip.x);
@@ -239,15 +235,61 @@ public final class FlixelImGuiBgfxRenderer {
           continue;
         }
 
+        // Bind the whole command list's vertices (start vertex 0) and let the index buffer address
+        // them, matching bgfx's own Dear ImGui integration. Dear ImGui keeps each command list under
+        // the 16-bit index limit (the RendererHasVtxOffset backend flag is left off), so no per-command
+        // base vertex is needed, and this avoids relying on bgfx's transient base-vertex path.
         short texture = (short) drawData.getCmdListCmdBufferTextureId(n, cmd);
         BGFX.bgfx_set_scissor(clipX, clipY, clipMaxX - clipX, clipMaxY - clipY);
-        BGFX.bgfx_set_transient_vertex_buffer(0, tvb, vtxOffset, vertexCount - vtxOffset);
+        BGFX.bgfx_set_transient_vertex_buffer(0, tvb, 0, vertexCount);
         BGFX.bgfx_set_transient_index_buffer(tib, idxOffset, elemCount);
         BGFX.bgfx_set_texture(0, textureUniform, texture, SAMPLER_FLAGS);
         BGFX.bgfx_set_state(DRAW_STATE, 0);
         BGFX.bgfx_submit(view, program, 0, BGFX.BGFX_DISCARD_ALL);
       }
     }
+  }
+
+  /**
+   * Logs a single line describing command list {@code n} so a rendering problem can be diagnosed
+   * without a debugger. It reads the first vertex both from Dear ImGui's source buffer and from the
+   * transient buffer this renderer just filled, so a mismatch points at the upload rather than the
+   * draw, plus the first draw command's element count, offsets, clip rectangle, and texture id.
+   *
+   * @param drawData The current frame's draw data.
+   * @param n The command list index that was just uploaded.
+   * @param view The bgfx view the overlay renders into.
+   * @param vertexStride The byte size of one ImGui vertex.
+   * @param indexStride The byte size of one ImGui index.
+   * @param bgra Whether the active backend uses BGRA color order.
+   * @param cmdListCount The number of command lists this frame.
+   */
+  private void logDrawDataDiagnostics(@NotNull ImDrawData drawData, int n, int view, int vertexStride,
+      int indexStride, boolean bgra, int cmdListCount) {
+    ByteBuffer src = drawData.getCmdListVtxBufferData(n).order(ByteOrder.nativeOrder());
+    int sp = src.position();
+    String srcVertex = src.remaining() >= vertexStride ? formatVertex(src, sp) : "(none)";
+    ByteBuffer dst = tvb.data().order(ByteOrder.nativeOrder());
+    String dstVertex = dst.remaining() >= vertexStride ? formatVertex(dst, 0) : "(none)";
+    String firstCmd = "(none)";
+    if (drawData.getCmdListCmdBufferSize(n) > 0) {
+      drawData.getCmdListCmdBufferClipRect(clip, n, 0);
+      firstCmd = "elem=" + drawData.getCmdListCmdBufferElemCount(n, 0)
+          + " idxOff=" + drawData.getCmdListCmdBufferIdxOffset(n, 0)
+          + " vtxOff=" + drawData.getCmdListCmdBufferVtxOffset(n, 0)
+          + " tex=" + drawData.getCmdListCmdBufferTextureId(n, 0)
+          + " clip=[" + clip.x + "," + clip.y + "," + clip.z + "," + clip.w + "]";
+    }
+    Flixel.debug("ImGuiRenderer", "renderer=" + BGFX.bgfx_get_renderer_type() + " view=" + view
+        + " stride=" + vertexStride + "/" + indexStride + " bgra=" + bgra
+        + " program=" + graphics.getSpriteProgram() + " fontTex=" + fontTexture
+        + " cmdLists=" + cmdListCount + " srcV0=" + srcVertex + " dstV0=" + dstVertex + " cmd0=" + firstCmd);
+  }
+
+  /** Formats one ImGui vertex (position, texture coordinate, packed color) for the diagnostic line. */
+  private static String formatVertex(@NotNull ByteBuffer buffer, int base) {
+    return "(" + buffer.getFloat(base) + "," + buffer.getFloat(base + 4) + " uv=" + buffer.getFloat(base + 8)
+        + "," + buffer.getFloat(base + 12) + " col=0x" + Integer.toHexString(buffer.getInt(base + 16)) + ")";
   }
 
   /**

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -46,7 +46,6 @@ import imgui.ImGuiInputTextCallbackData;
 import imgui.ImGuiStyle;
 import imgui.ImGuiViewport;
 import imgui.callback.ImGuiInputTextCallback;
-import imgui.flag.ImGuiBackendFlags;
 import imgui.flag.ImGuiCol;
 import imgui.flag.ImGuiCond;
 import imgui.flag.ImGuiConfigFlags;
@@ -516,9 +515,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     // Dear ImGui report WantCaptureKeyboard, which would suppress the F2/F3/F4 toggle keys (they now
     // go through the normal input path). Mouse drives the overlay; the toggles stay reliable.
     io.addConfigFlags(ImGuiConfigFlags.DockingEnable);
-    // The bgfx renderer binds a per-command vertex offset, so let Dear ImGui keep large draw lists in
-    // one buffer instead of forcing 16-bit index limits.
-    io.addBackendFlags(ImGuiBackendFlags.RendererHasVtxOffset);
 
     applyStyle();
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -1,0 +1,1546 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.desktop.debug;
+
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelCamera;
+import org.flixelgdx.FlixelObject;
+import org.flixelgdx.FlixelSprite;
+import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
+import org.flixelgdx.collections.FlixelArray;
+import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.flixelgdx.graphics.FlixelTexture;
+import org.flixelgdx.input.keyboard.FlixelKey;
+import org.flixelgdx.logging.FlixelLogLevel;
+import org.lwjgl.bgfx.BGFX;
+import org.lwjgl.bgfx.BGFXStats;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import imgui.ImFontAtlas;
+import imgui.ImGui;
+import imgui.ImGuiIO;
+import imgui.ImGuiInputTextCallbackData;
+import imgui.ImGuiStyle;
+import imgui.ImGuiViewport;
+import imgui.callback.ImGuiInputTextCallback;
+import imgui.flag.ImGuiBackendFlags;
+import imgui.flag.ImGuiCol;
+import imgui.flag.ImGuiCond;
+import imgui.flag.ImGuiConfigFlags;
+import imgui.flag.ImGuiDockNodeFlags;
+import imgui.flag.ImGuiInputTextFlags;
+import imgui.flag.ImGuiKey;
+import imgui.flag.ImGuiTableFlags;
+import imgui.flag.ImGuiTreeNodeFlags;
+import imgui.flag.ImGuiWindowFlags;
+import imgui.type.ImBoolean;
+import imgui.type.ImInt;
+import imgui.type.ImString;
+
+/**
+ * Dear ImGui based debug overlay for the desktop (bgfx + SDL3) backend.
+ *
+ * <h2>Wiring</h2>
+ *
+ * <p>{@code FlixelDesktopLauncher} registers this class as the default debug overlay factory when
+ * launching in {@link org.flixelgdx.backend.FlixelRuntimeMode#DEBUG DEBUG} mode. You can also
+ * register it manually with {@link Flixel#setDebugOverlay(java.util.function.Supplier)} before the
+ * game starts.
+ *
+ * <p>Initialization (creating the Dear ImGui context, uploading the font atlas as a bgfx texture, and
+ * registering the SDL input listener) happens lazily on the first {@link #draw()} call, so
+ * construction stays cheap and the cost is only paid once debug mode actually shows the overlay.
+ *
+ * <h2>Rendering and input</h2>
+ *
+ * <p>Unlike a typical Dear ImGui integration, nothing here talks to a graphics API directly. Panels
+ * are submitted through {@link FlixelImGuiBgfxRenderer}, which turns Dear ImGui's draw lists into bgfx
+ * draw calls, and input arrives through {@link FlixelImGuiSdlInput}, which forwards the desktop
+ * backend's SDL events into Dear ImGui. Both are bespoke because the project ships its own bgfx and
+ * SDL3 stack instead of the OpenGL and GLFW backends imgui-java bundles.
+ *
+ * <p>Window positions are not persisted across runs: the {@code imgui.ini} file is disabled because
+ * the framework does not own a writable directory on every platform.
+ *
+ * <h2>Extending the overlay</h2>
+ *
+ * <p>Because Dear ImGui is exposed as an api dependency, games can add their own panels by
+ * subclassing this overlay and overriding {@link #onDrawImGui()}; any standard {@code ImGui.*} call is
+ * valid there.
+ */
+public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
+
+  private static final String TAG = "FlixelImGuiDebugOverlay";
+
+  // Component-per-channel color constants. Colored labels use pushStyleColor(ImGuiCol.Text, ...) plus
+  // textUnformatted so dynamic strings are never passed through printf-style formatting.
+  private static final float[] COLOR_INFO = { 0.85f, 0.85f, 0.85f, 1f };
+  private static final float[] COLOR_WARN = { 1.00f, 0.80f, 0.20f, 1f };
+  private static final float[] COLOR_ERROR = { 1.00f, 0.30f, 0.30f, 1f };
+  private static final float[] COLOR_DEBUG = { 0.30f, 0.30f, 1.0f, 1f };
+  private static final float[] COLOR_KEY = { 0.9f, 0.2f, 0.2f, 1f };
+  private static final float[] COLOR_VALUE = { 0.95f, 0.95f, 0.95f, 1f };
+  private static final float[] COLOR_HEADER = { 0.9f, 0.2f, 0.2f, 1f };
+  private static final float[] COLOR_OK = { 0.30f, 0.95f, 0.55f, 1f };
+  private static final float[] COLOR_PAUSED = { 1.00f, 0.70f, 0.20f, 1f };
+  private static final float[] COLOR_HINT = { 0.65f, 0.65f, 0.65f, 1f };
+
+  // Widget color constants (red theme replacing the default ImGui blue).
+  private static final float[] COLOR_TITLE_BG = { 0.45f, 0.07f, 0.07f, 1f };
+  private static final float[] COLOR_TITLE_BG_ACTIVE = { 0.72f, 0.10f, 0.10f, 1f };
+  private static final float[] COLOR_TITLE_BG_COLLAPSED = { 0.30f, 0.05f, 0.05f, 0.75f };
+  private static final float[] COLOR_FRAME_BG = { 0.28f, 0.05f, 0.05f, 0.54f };
+  private static final float[] COLOR_FRAME_BG_HOVERED = { 0.50f, 0.08f, 0.08f, 0.40f };
+  private static final float[] COLOR_FRAME_BG_ACTIVE = { 0.62f, 0.10f, 0.10f, 0.67f };
+  private static final float[] COLOR_CHECK_MARK = { 1.00f, 0.60f, 0.60f, 1f };
+  private static final float[] COLOR_BUTTON = { 0.65f, 0.10f, 0.10f, 0.60f };
+  private static final float[] COLOR_BUTTON_HOVERED = { 0.80f, 0.15f, 0.15f, 1f };
+  private static final float[] COLOR_BUTTON_ACTIVE = { 0.92f, 0.20f, 0.20f, 1f };
+  private static final float[] COLOR_COLLAPSING_HEADER = { 0.55f, 0.08f, 0.08f, 0.31f };
+  private static final float[] COLOR_COLLAPSING_HEADER_HOVERED = { 0.68f, 0.11f, 0.11f, 0.80f };
+  private static final float[] COLOR_COLLAPSING_HEADER_ACTIVE = { 0.78f, 0.13f, 0.13f, 1f };
+  private static final float[] COLOR_RESIZE_GRIP = { 0.65f, 0.10f, 0.10f, 0.20f };
+  private static final float[] COLOR_RESIZE_GRIP_HOVERED = { 0.80f, 0.15f, 0.15f, 0.67f };
+  private static final float[] COLOR_RESIZE_GRIP_ACTIVE = { 0.92f, 0.20f, 0.20f, 0.95f };
+  private static final float[] COLOR_SLIDER_GRAB = { 0.92f, 0.20f, 0.20f, 0.95f };
+  private static final float[] COLOR_SLIDER_GRAB_ACTIVE = { 0.92f, 0.30f, 0.30f, 0.95f };
+
+  /** Empty-state copy for the Watch panel. */
+  private static final String WATCH_EMPTY_HINT = "No watches registered. Use Flixel.watch.add(...) to track values.";
+
+  /** Empty-state copy for the Tracker panel. */
+  private static final String TRACKER_EMPTY_HINT =
+      "No trackers registered. Use Flixel.debug.addTrackerEntry(...) to show grouped values here.";
+
+  /** Number of bgfx time-series graphs, used to size the per-series Y-axis scale array. */
+  private static final int BGFX_GRAPH_COUNT = 7;
+
+  private final FlixelImGuiSdlInput imguiInput = new FlixelImGuiSdlInput();
+  private final FlixelBgfxStatsSampler statsSampler = new FlixelBgfxStatsSampler();
+
+  private FlixelBgfxGraphics graphics;
+  private FlixelImGuiBgfxRenderer renderer;
+
+  // Snapshot of the log buffer taken once per frame to avoid holding logBuffer during draw.
+  private final FlixelArray<FlixelDebugOverlay.BufferedLogLine> logSnapshot = new FlixelArray<>();
+
+  // Window visibility flags (toggled from the debug menu).
+  private final ImBoolean showStatsWindow = new ImBoolean(true);
+  private final ImBoolean showPerformanceWindow = new ImBoolean(true);
+  private final ImBoolean showRenderWindow = new ImBoolean(true);
+  private final ImBoolean showControlsWindow = new ImBoolean(true);
+  private final ImBoolean showWatchWindow = new ImBoolean(true);
+  private final ImBoolean showLogWindow = new ImBoolean(true);
+  private final ImBoolean showTrackerWindow = new ImBoolean(true);
+  private final ImBoolean showCommandWindow = new ImBoolean(true);
+  private final ImBoolean showTextureWindow = new ImBoolean(false);
+
+  // Log level filters. Toggled in the log window's menu bar.
+  private final ImBoolean logShowInfo = new ImBoolean(true);
+  private final ImBoolean logShowWarn = new ImBoolean(true);
+  private final ImBoolean logShowError = new ImBoolean(true);
+  private final ImBoolean logShowDebug = new ImBoolean(true);
+  private final ImBoolean logAutoScroll = new ImBoolean(true);
+
+  private final ImString commandInputBuffer = new ImString(256);
+
+  /**
+   * Dear ImGui consumes Up/Down on a focused {@code InputText} for caret movement before the game
+   * sees them. {@link ImGuiInputTextFlags#CallbackHistory} runs inside the widget so command history
+   * still works while the field stays focused.
+   */
+  private final ImGuiInputTextCallback commandHistoryCallback = new ImGuiInputTextCallback() {
+    @Override
+    public void accept(ImGuiInputTextCallbackData data) {
+      if (!data.hasEventFlag(ImGuiInputTextFlags.CallbackHistory)) {
+        return;
+      }
+      int key = data.getEventKey();
+      if (key == ImGuiKey.UpArrow) {
+        applyHistoryKeyInInputCallback(data, -1);
+      } else if (key == ImGuiKey.DownArrow) {
+        applyHistoryKeyInInputCallback(data, 1);
+      }
+    }
+  };
+
+  /** Last non-empty UTF-8 bytes from the command field (ImGui may clear the buffer when Run is pressed). */
+  private final byte[] commandLineUtf8Scratch = new byte[512];
+
+  // Reused float buffers fed to ImGui.sliderFloat() so the controls stay allocation-free.
+  private final float[] textureViewerZoomBuf = new float[1];
+  private final float[] timeScaleSliderBuf = new float[1];
+
+  // Watch caches mirroring cachedWatchKeys / cachedWatchValues as java String.
+  private String[] watchKeyStr = new String[0];
+  private String[] watchValueStr = new String[0];
+
+  // Tracker caches mirroring cachedTrackerBlocks as String arrays.
+  private String[] trackerNameStr = new String[0];
+  private String[][] trackerKeyStrs = new String[0][];
+  private String[][] trackerValueStrs = new String[0][];
+  private int[] trackerPairCounts = new int[0];
+
+  private String keybindToggleLabel;
+  private String keybindHitboxLabel;
+  private String keybindPauseLabel;
+  private String keybindCycleLeftLabel;
+  private String keybindCycleRightLabel;
+
+  private int watchCount;
+  private int trackerBlockCount;
+  private int commandHistoryCursor = -1;
+  private int commandLineUtf8ScratchLen;
+  private int cachedToggleKey = -1;
+  private int cachedHitboxKey = -1;
+  private int cachedPauseKey = -1;
+  private int cachedCycleLeftKey = -1;
+  private int cachedCycleRightKey = -1;
+
+  // Per-window default rectangles (work-area coordinates). Filled by computeDefaultLayoutRects()
+  // each frame; applyWindowLayout() consumes them right before each begin().
+  private float layoutStatsX;
+  private float layoutStatsY;
+  private float layoutStatsW;
+  private float layoutStatsH;
+  private float layoutPerfX;
+  private float layoutPerfY;
+  private float layoutPerfW;
+  private float layoutPerfH;
+  private float layoutLogX;
+  private float layoutLogY;
+  private float layoutLogW;
+  private float layoutLogH;
+  private float layoutWatchX;
+  private float layoutWatchY;
+  private float layoutWatchW;
+  private float layoutWatchH;
+  private float layoutControlsX;
+  private float layoutControlsY;
+  private float layoutControlsW;
+  private float layoutControlsH;
+  private float layoutTextureX;
+  private float layoutTextureY;
+  private float layoutTextureW;
+  private float layoutTextureH;
+  private float layoutTrackerX;
+  private float layoutTrackerY;
+  private float layoutTrackerW;
+  private float layoutTrackerH;
+  private float layoutCommandX;
+  private float layoutCommandY;
+  private float layoutCommandW;
+  private float layoutCommandH;
+  private float layoutRenderX;
+  private float layoutRenderY;
+  private float layoutRenderW;
+  private float layoutRenderH;
+  private float textureViewerZoom = 1f;
+
+  // Per-series Y-axis scale maxima for the core performance graphs. Each grows immediately when a new
+  // peak appears and decays slowly toward the ring-buffer max so the graphs stay stable.
+  private float perfScaleMaxFps = 1f;
+  private float perfScaleMaxFrameMs = 1f;
+  private float perfScaleMaxHeapMb = 1f;
+  private float perfScaleMaxNativeMb = 1f;
+  private float perfScaleMaxRenderCalls = 1f;
+
+  /** Per-series Y-axis scale maxima for the bgfx render graphs, one per graph. */
+  private final float[] bgfxScaleMax = new float[BGFX_GRAPH_COUNT];
+
+  private boolean imguiInitialized;
+  private boolean imguiShutdown;
+  private boolean scrollLogToBottom;
+
+  /**
+   * One-shot flag that swaps the layout condition to {@link ImGuiCond#Always} for the next frame
+   * (used the first time the overlay is shown and after {@code Reset Layout}).
+   */
+  private boolean forceLayoutNextFrame = true;
+
+  /** When true, the Texture Inspector uses {@link ImGuiCond#Always} once so it snaps under Controls. */
+  private boolean textureInspectorSnapNextFrame;
+
+  /** Previous frame's Texture Inspector visibility (edge-detect open). */
+  private boolean textureInspectorOpenPrev;
+
+  private boolean focusCommandLine;
+
+  /** Whether the command {@code InputText} had focus at the end of the last {@link #drawUI()} pass. */
+  private boolean commandInputFocusedLastFrame;
+
+  /** When true, the next {@link #drawUI()} pass clears the Dear ImGui IO input queues once. */
+  private boolean sanitizeImGuiInputBeforeNextDraw;
+
+  @Override
+  public void draw() {
+    if (!isVisible() || imguiShutdown) {
+      return;
+    }
+    if (!imguiInitialized) {
+      initImGui();
+      if (!imguiInitialized) {
+        // Initialization could not complete (no bgfx graphics yet, for example). Skip rendering and
+        // try again next frame so the overlay degrades gracefully instead of crashing.
+        return;
+      }
+    }
+    super.draw();
+  }
+
+  @Override
+  public void resize(int width, int height) {
+    super.resize(width, height);
+    if (!imguiInitialized || imguiShutdown) {
+      return;
+    }
+    ImGui.getIO().setDisplaySize(width, height);
+    forceLayoutNextFrame = true;
+  }
+
+  /**
+   * Tears down the Dear ImGui resources in a safe order: deactivate input (which clears queued IO
+   * while the context is still valid) and unregister the SDL listener, destroy the renderer's font
+   * texture, then destroy the context. Each step is guarded because desktop shutdown is already partway
+   * through when this runs.
+   */
+  @Override
+  public void destroy() {
+    if (!imguiShutdown && imguiInitialized) {
+      imguiShutdown = true;
+      try {
+        imguiInput.setActive(false);
+        if (Flixel.input != null) {
+          Flixel.input.removeKeyboardListener(imguiInput);
+          Flixel.input.removeMouseListener(imguiInput);
+        }
+      } catch (Throwable t) {
+        // Ignore.
+      }
+      try {
+        renderer.dispose();
+      } catch (Throwable t) {
+        // Ignore.
+      }
+      try {
+        ImGui.destroyContext();
+      } catch (Throwable t) {
+        // Ignore.
+      }
+    }
+    super.destroy();
+  }
+
+  @Override
+  public void setVisible(boolean visible) {
+    boolean wasVisible = isVisible();
+    super.setVisible(visible);
+    onVisibilityChanged(wasVisible, isVisible());
+  }
+
+  @Override
+  public void toggleVisible() {
+    boolean wasVisible = isVisible();
+    super.toggleVisible();
+    onVisibilityChanged(wasVisible, isVisible());
+  }
+
+  @Override
+  public boolean isMouseCapturedByUI() {
+    if (!isVisible() || !imguiInitialized) {
+      return false;
+    }
+    return ImGui.getIO().getWantCaptureMouse();
+  }
+
+  @Override
+  public boolean isKeyboardCapturedByUI() {
+    if (!isVisible() || !imguiInitialized) {
+      return false;
+    }
+    return ImGui.getIO().getWantCaptureKeyboard();
+  }
+
+  @Override
+  protected void drawUI() {
+    if (!imguiInitialized || imguiShutdown) {
+      return;
+    }
+    snapshotLogBuffer();
+    statsSampler.sample(graphics.getBgfxStats());
+
+    if (sanitizeImGuiInputBeforeNextDraw) {
+      sanitizeImGuiInputBeforeNextDraw = false;
+      ImGuiIO io = ImGui.getIO();
+      io.clearInputKeys();
+      io.clearEventsQueue();
+      io.clearInputMouse();
+    }
+
+    imguiInput.newFrame(graphics.getBackBufferWidth(), graphics.getBackBufferHeight(), Flixel.getRawElapsed());
+    ImGui.newFrame();
+
+    // Passthrough dockspace covers the whole viewport with a transparent central node so the game
+    // keeps rendering through the empty space between and around docked windows.
+    ImGui.dockSpaceOverViewport(0, ImGui.getMainViewport(), ImGuiDockNodeFlags.PassthruCentralNode);
+
+    drawMainMenuBar();
+    computeDefaultLayoutRects();
+
+    if (forceLayoutNextFrame && showTextureWindow.get()) {
+      textureInspectorSnapNextFrame = true;
+    }
+    boolean texInspectorOpen = showTextureWindow.get();
+    if (texInspectorOpen && !textureInspectorOpenPrev) {
+      textureInspectorSnapNextFrame = true;
+    }
+    textureInspectorOpenPrev = texInspectorOpen;
+
+    drawStatsWindow();
+    drawPerformanceWindow();
+    drawRenderWindow();
+    drawWatchWindow();
+    drawControlsWindow();
+    drawLogWindow();
+    drawTrackerWindow();
+    drawCommandWindow();
+    drawTextureWindow();
+    onDrawImGui();
+
+    // The forced-layout pass only lasts one frame; later frames use FirstUseEver so manual moves stick.
+    if (forceLayoutNextFrame) {
+      forceLayoutNextFrame = false;
+    }
+
+    ImGui.render();
+    renderer.render(ImGui.getDrawData());
+  }
+
+  @Override
+  protected boolean shouldSuppressDebugRawKeybind(int keycode) {
+    if (!commandInputFocusedLastFrame) {
+      return false;
+    }
+    return !isNonTypableSystemDebugKey(keycode);
+  }
+
+  @Override
+  protected void onWatchEntriesRefreshed() {
+    int n = cachedWatchKeys.getSize();
+    if (watchKeyStr.length < n) {
+      watchKeyStr = new String[Math.max(n, watchKeyStr.length * 2)];
+      watchValueStr = new String[watchKeyStr.length];
+    }
+    for (int i = 0; i < n; i++) {
+      watchKeyStr[i] = cachedWatchKeys.get(i).toString();
+      watchValueStr[i] = cachedWatchValues.get(i).toString();
+    }
+    watchCount = n;
+  }
+
+  @Override
+  protected void onTrackerBlocksRebuilt() {
+    int n = cachedTrackerBlocks.getSize();
+    if (trackerNameStr.length < n) {
+      trackerNameStr = new String[Math.max(n, trackerNameStr.length * 2)];
+      trackerKeyStrs = new String[trackerNameStr.length][];
+      trackerValueStrs = new String[trackerNameStr.length][];
+      trackerPairCounts = new int[trackerNameStr.length];
+    }
+    for (int i = 0; i < n; i++) {
+      CachedTrackerBlock block = cachedTrackerBlocks.get(i);
+      trackerNameStr[i] = block.name.toString();
+      int pairN = block.pairCount;
+      String[] keys = trackerKeyStrs[i];
+      String[] vals = trackerValueStrs[i];
+      if (keys == null || keys.length < pairN) {
+        keys = new String[Math.max(pairN, 4)];
+        trackerKeyStrs[i] = keys;
+      }
+      if (vals == null || vals.length < pairN) {
+        vals = new String[Math.max(pairN, 4)];
+        trackerValueStrs[i] = vals;
+      }
+      for (int p = 0; p < pairN; p++) {
+        keys[p] = block.keys[p].toString();
+        vals[p] = block.values[p].toString();
+      }
+      trackerPairCounts[i] = pairN;
+    }
+    trackerBlockCount = n;
+  }
+
+  @Override
+  protected void onLogEntryAppended(BufferedLogLine line) {
+    if (logAutoScroll.get()) {
+      scrollLogToBottom = true;
+    }
+  }
+
+  /**
+   * Hook for subclasses that want to add custom Dear ImGui content to the overlay.
+   *
+   * <p>Called once per frame from {@link #drawUI()} after all built-in panels have been submitted but
+   * before {@code ImGui.render()}. The Dear ImGui frame is fully open, so any standard {@code ImGui.*}
+   * call is valid here. Because Dear ImGui is immediate mode, calling {@code ImGui.begin()} with the
+   * title of an existing panel appends to it instead of creating a new window, so one override can
+   * both add new windows and inject rows into the built-in panels.
+   */
+  protected void onDrawImGui() {}
+
+  private void initImGui() {
+    if (!(Flixel.graphics instanceof FlixelBgfxGraphics bgfx)) {
+      Flixel.warn(TAG, "Desktop graphics are not bgfx; the ImGui debug overlay will not run.");
+      imguiShutdown = true;
+      return;
+    }
+    graphics = bgfx;
+    renderer = new FlixelImGuiBgfxRenderer(bgfx);
+
+    ImGui.createContext();
+    ImGuiIO io = ImGui.getIO();
+    io.setIniFilename(null);
+    io.addConfigFlags(ImGuiConfigFlags.NavEnableKeyboard);
+    io.addConfigFlags(ImGuiConfigFlags.DockingEnable);
+    // The bgfx renderer binds a per-command vertex offset, so let Dear ImGui keep large draw lists in
+    // one buffer instead of forcing 16-bit index limits.
+    io.addBackendFlags(ImGuiBackendFlags.RendererHasVtxOffset);
+
+    applyStyle();
+
+    ImFontAtlas fonts = io.getFonts();
+    fonts.addFontDefault();
+    ImInt fontWidth = new ImInt();
+    ImInt fontHeight = new ImInt();
+    ByteBuffer pixels = fonts.getTexDataAsRGBA32(fontWidth, fontHeight);
+    long texId = renderer.init(pixels, fontWidth.get(), fontHeight.get());
+    if (texId == -1) {
+      Flixel.warn(TAG, "Could not upload the ImGui font atlas; the debug overlay is disabled.");
+      ImGui.destroyContext();
+      imguiShutdown = true;
+      return;
+    }
+    fonts.setTexID(texId);
+
+    Flixel.input.addKeyboardListener(imguiInput);
+    Flixel.input.addMouseListener(imguiInput);
+
+    imguiInitialized = true;
+    imguiInput.setActive(isVisible());
+    forceRefreshOnNextUpdate();
+  }
+
+  /** Applies the red-themed Dear ImGui style, replacing the default blue accents. */
+  private static void applyStyle() {
+    ImGuiStyle style = ImGui.getStyle();
+    setStyleColor(style, ImGuiCol.TitleBg, COLOR_TITLE_BG);
+    setStyleColor(style, ImGuiCol.TitleBgActive, COLOR_TITLE_BG_ACTIVE);
+    setStyleColor(style, ImGuiCol.TitleBgCollapsed, COLOR_TITLE_BG_COLLAPSED);
+    setStyleColor(style, ImGuiCol.FrameBg, COLOR_FRAME_BG);
+    setStyleColor(style, ImGuiCol.FrameBgHovered, COLOR_FRAME_BG_HOVERED);
+    setStyleColor(style, ImGuiCol.FrameBgActive, COLOR_FRAME_BG_ACTIVE);
+    setStyleColor(style, ImGuiCol.CheckMark, COLOR_CHECK_MARK);
+    setStyleColor(style, ImGuiCol.Button, COLOR_BUTTON);
+    setStyleColor(style, ImGuiCol.ButtonHovered, COLOR_BUTTON_HOVERED);
+    setStyleColor(style, ImGuiCol.ButtonActive, COLOR_BUTTON_ACTIVE);
+    setStyleColor(style, ImGuiCol.Header, COLOR_COLLAPSING_HEADER);
+    setStyleColor(style, ImGuiCol.HeaderHovered, COLOR_COLLAPSING_HEADER_HOVERED);
+    setStyleColor(style, ImGuiCol.HeaderActive, COLOR_COLLAPSING_HEADER_ACTIVE);
+    setStyleColor(style, ImGuiCol.ResizeGrip, COLOR_RESIZE_GRIP);
+    setStyleColor(style, ImGuiCol.ResizeGripHovered, COLOR_RESIZE_GRIP_HOVERED);
+    setStyleColor(style, ImGuiCol.ResizeGripActive, COLOR_RESIZE_GRIP_ACTIVE);
+    setStyleColor(style, ImGuiCol.SliderGrab, COLOR_SLIDER_GRAB);
+    setStyleColor(style, ImGuiCol.SliderGrabActive, COLOR_SLIDER_GRAB_ACTIVE);
+  }
+
+  private static void setStyleColor(ImGuiStyle style, int target, float[] color) {
+    style.setColor(target, color[0], color[1], color[2], color[3]);
+  }
+
+  /**
+   * Runs when the overlay visibility actually changes. Dear ImGui does not receive {@link #drawUI()}
+   * while hidden, so the input backend is toggled and, on show, a one-shot IO sanitize is scheduled so
+   * keys typed while hidden do not flush into a text field.
+   */
+  private void onVisibilityChanged(boolean wasVisible, boolean nowVisible) {
+    if (wasVisible == nowVisible || !imguiInitialized) {
+      return;
+    }
+    imguiInput.setActive(nowVisible);
+    if (nowVisible) {
+      sanitizeImGuiInputBeforeNextDraw = true;
+    }
+  }
+
+  /**
+   * Fills the per-window layout rectangles from the main viewport work area. Call only after
+   * {@link ImGui#beginMainMenuBar()} / {@link ImGui#endMainMenuBar()} for this frame so work
+   * coordinates exclude the menu bar.
+   */
+  private void computeDefaultLayoutRects() {
+    ImGuiViewport viewport = ImGui.getMainViewport();
+    float ox = viewport.getWorkPosX();
+    float oy = viewport.getWorkPosY();
+    float workW = viewport.getWorkSizeX();
+    float workBottom = viewport.getWorkPosY() + viewport.getWorkSizeY();
+    if (oy <= viewport.getPosY() + 0.5f) {
+      oy = viewport.getPosY() + ImGui.getFrameHeight() + ImGui.getStyle().getFramePadding().y + 2f;
+    }
+    float workH = workBottom - oy;
+
+    final float gap = 8f;
+    float cmdH = 76f;
+
+    float colW = Math.min(Math.max(workW * 0.175f, 220f), 338f);
+    colW = Math.min(colW, Math.max(200f, (workW - 3f * gap) * 0.48f));
+
+    float rightX = ox + workW - colW;
+    float logW = Math.min(colW * 1.75f, Math.max(colW, rightX - gap - ox));
+
+    float yCmd = oy + workH - cmdH;
+    float availH = yCmd - oy - gap;
+    while (availH < 200f && cmdH > 52f) {
+      cmdH -= 6f;
+      yCmd = oy + workH - cmdH;
+      availH = yCmd - oy - gap;
+    }
+    availH = Math.max(96f, availH);
+
+    float statsH = Math.min(172f, Math.max(96f, availH * 0.19f));
+    float perfH = Math.min(380f, Math.max(148f, availH * 0.43f));
+    float logHBase = availH - statsH - perfH - 2f * gap;
+    if (logHBase < 100f) {
+      float need = 100f - logHBase;
+      float fromPerf = Math.min(need, Math.max(0f, perfH - 128f));
+      perfH -= fromPerf;
+      need -= fromPerf;
+      if (need > 0f) {
+        float fromStats = Math.min(need, Math.max(0f, statsH - 88f));
+        statsH -= fromStats;
+      }
+      logHBase = availH - statsH - perfH - 2f * gap;
+    }
+
+    float usedLeft = statsH + perfH + logHBase + 2f * gap;
+    if (usedLeft > availH && usedLeft > 1f) {
+      float scale = (availH - 2f * gap) / (statsH + perfH + logHBase);
+      statsH *= scale;
+      perfH *= scale;
+      logHBase = availH - statsH - perfH - 2f * gap;
+    }
+
+    float logSlotTop = oy + statsH + gap + perfH + gap;
+    float logSlotBottom = oy + availH;
+    float logSlotH = Math.max(0f, logSlotBottom - logSlotTop);
+    float logH = Math.min(logHBase * 1.35f, logSlotH);
+
+    float watchH = Math.min(statsH * 1.25f, availH * 0.28f);
+    final float minTextureStripe = 96f;
+    final float minControlsH = 400f;
+    float controlsTarget = Math.min(540f, Math.max(minControlsH, availH * 0.46f));
+    float maxControlsFit = availH - watchH - 2f * gap - minTextureStripe;
+    float controlsH = Math.min(controlsTarget, maxControlsFit);
+    if (controlsH < 260f) {
+      controlsH = Math.min(maxControlsFit, Math.max(220f, availH * 0.38f));
+    }
+
+    float textureHBase = availH - watchH - controlsH - 2f * gap;
+    if (textureHBase < 72f) {
+      float need = 72f - textureHBase;
+      float fromControls = Math.min(need, Math.max(0f, controlsH - minControlsH));
+      controlsH -= fromControls;
+      need -= fromControls;
+      if (need > 0f) {
+        float fromWatch = Math.min(need, Math.max(0f, watchH - 56f));
+        watchH -= fromWatch;
+      }
+      textureHBase = availH - watchH - controlsH - 2f * gap;
+    }
+
+    float rightColMaxW = workW - logW - gap;
+    float watchW = Math.min(colW * 1.4f, rightColMaxW);
+    float controlsW = Math.min(Math.max(watchW, colW * 1.25f), rightColMaxW);
+
+    float textureTop = oy + watchH + gap + controlsH + gap;
+    float textureBottomLimit = oy + availH + 120;
+    float maxTextureH = Math.max(72f, textureBottomLimit - textureTop);
+    float textureW = Math.min(colW * 1.8f, workW - colW - gap);
+    float textureHDesired = Math.min(480f, Math.max(140f, textureHBase * 1.75f));
+    float textureH = Math.min(textureHDesired, maxTextureH);
+
+    layoutStatsX = ox;
+    layoutStatsY = oy;
+    layoutStatsW = colW;
+    layoutStatsH = statsH;
+
+    layoutPerfX = ox;
+    layoutPerfY = oy + statsH + gap;
+    layoutPerfW = colW;
+    layoutPerfH = perfH;
+
+    layoutLogX = ox;
+    layoutLogY = logSlotTop + (logSlotH - logH) * 0.5f;
+    layoutLogW = logW;
+    layoutLogH = logH;
+
+    layoutWatchX = ox + workW - watchW;
+    layoutWatchY = oy;
+    layoutWatchW = watchW;
+    layoutWatchH = watchH;
+
+    layoutControlsX = ox + workW - controlsW;
+    layoutControlsY = oy + watchH + gap;
+    layoutControlsW = controlsW;
+    layoutControlsH = controlsH;
+
+    layoutTextureX = ox + workW - textureW;
+    layoutTextureY = textureTop;
+    layoutTextureW = textureW;
+    layoutTextureH = textureH;
+
+    layoutTrackerX = ox + workW - controlsW;
+    layoutTrackerY = textureTop;
+    layoutTrackerW = controlsW;
+    layoutTrackerH = Math.max(72f, textureHBase);
+
+    layoutCommandX = ox;
+    layoutCommandY = yCmd;
+    layoutCommandW = workW;
+    layoutCommandH = cmdH;
+
+    // The bgfx render panel defaults to a floating window just right of the left column; docking lets
+    // the user move it wherever they like afterward.
+    layoutRenderW = Math.min(430f, Math.max(320f, workW * 0.26f));
+    layoutRenderH = Math.min(620f, Math.max(320f, availH * 0.8f));
+    layoutRenderX = Math.min(ox + colW + gap, ox + workW - layoutRenderW - gap);
+    layoutRenderY = oy;
+  }
+
+  /** Returns the imgui condition flag to use for the next window's default position / size hint. */
+  private int nextLayoutCond() {
+    return forceLayoutNextFrame ? ImGuiCond.Always : ImGuiCond.FirstUseEver;
+  }
+
+  private void applyWindowLayout(float x, float y, float w, float h) {
+    applyWindowLayout(x, y, w, h, nextLayoutCond());
+  }
+
+  private void applyWindowLayout(float x, float y, float w, float h, int cond) {
+    ImGui.setNextWindowPos(x, y, cond);
+    ImGui.setNextWindowSize(w, h, cond);
+  }
+
+  private void snapshotLogBuffer() {
+    copyLogBuffer(logSnapshot);
+  }
+
+  private void drawMainMenuBar() {
+    if (!ImGui.beginMainMenuBar()) {
+      return;
+    }
+    if (ImGui.beginMenu("Debug")) {
+      ImGui.menuItem("Stats", null, showStatsWindow);
+      ImGui.menuItem("Performance", null, showPerformanceWindow);
+      ImGui.menuItem("Render (bgfx)", null, showRenderWindow);
+      ImGui.menuItem("Controls", null, showControlsWindow);
+      ImGui.menuItem("Tracker", null, showTrackerWindow);
+      ImGui.menuItem("Watch", null, showWatchWindow);
+      ImGui.menuItem("Log", null, showLogWindow);
+      ImGui.menuItem("Command Line", null, showCommandWindow);
+      ImGui.menuItem("Texture Inspector", null, showTextureWindow);
+      ImGui.separator();
+      if (ImGui.menuItem("Reset Layout")) {
+        forceLayoutNextFrame = true;
+      }
+      if (ImGui.menuItem("Hide Overlay")) {
+        setVisible(false);
+      }
+      ImGui.endMenu();
+    }
+    if (ImGui.beginMenu("Game")) {
+      boolean drawDebug = isDrawDebug();
+      if (ImGui.menuItem("Show Hitboxes", null, drawDebug)) {
+        toggleDrawDebug();
+      }
+      boolean paused = Flixel.game.isGamePaused();
+      if (ImGui.menuItem("Pause Game", null, paused)) {
+        Flixel.game.setGamePaused(!paused);
+      }
+      if (ImGui.menuItem("Reset State")) {
+        Flixel.resetState();
+      }
+      ImGui.endMenu();
+    }
+    ImGui.endMainMenuBar();
+  }
+
+  private void drawStatsWindow() {
+    if (!showStatsWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutStatsX, layoutStatsY, layoutStatsW, layoutStatsH);
+    if (!ImGui.begin("Stats", showStatsWindow)) {
+      ImGui.end();
+      return;
+    }
+    drawStatRow("FPS", cachedFps);
+    drawStatRow("Heap (MB)", cachedHeapMegabytes);
+    drawStatRow("Native (MB)", cachedNativeMegabytes);
+    drawStatRow("Active members", cachedObjectCount);
+    drawStatRow("Assets loaded", cachedAssetCount);
+    drawStatRow("Render calls", cachedRenderCalls);
+
+    ImGui.separator();
+    boolean paused = Flixel.game.isGamePaused();
+    text(COLOR_KEY, "Update");
+    ImGui.sameLine();
+    if (paused) {
+      text(COLOR_PAUSED, "PAUSED");
+    } else {
+      text(COLOR_OK, "RUNNING");
+    }
+
+    FlixelArray<FlixelCamera> cams = Flixel.cameras;
+    int camCount = cams != null ? cams.getSize() : 0;
+    int inspect = getInspectCameraIndex();
+    text(COLOR_KEY, "Cameras");
+    ImGui.sameLine();
+    if (camCount == 0) {
+      text(COLOR_VALUE, "0 (none)");
+    } else {
+      text(COLOR_VALUE, (inspect + 1) + " / " + camCount);
+      FlixelCamera cam = cams.get(inspect);
+      drawStatRow("  Scroll X", cam.scrollX);
+      drawStatRow("  Scroll Y", cam.scrollY);
+      drawStatRow("  Zoom", cam.getZoom());
+    }
+    ImGui.end();
+  }
+
+  private void drawStatRow(String label, int value) {
+    text(COLOR_KEY, label);
+    ImGui.sameLine();
+    text(COLOR_VALUE, Integer.toString(value));
+  }
+
+  private void drawStatRow(String label, float value) {
+    text(COLOR_KEY, label);
+    ImGui.sameLine();
+    text(COLOR_VALUE, formatOneDecimal(value));
+  }
+
+  /**
+   * Real-time graphs of the platform-agnostic performance ring buffers owned by
+   * {@link FlixelDebugOverlay} (FPS, frame time, Java and native heap, and render calls). Each series
+   * plots directly against the parent's primitive arrays, so no temporary buffer is copied.
+   */
+  private void drawPerformanceWindow() {
+    if (!showPerformanceWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutPerfX, layoutPerfY, layoutPerfW, layoutPerfH);
+    if (!ImGui.begin("Performance", showPerformanceWindow)) {
+      ImGui.end();
+      return;
+    }
+    int count = getPerfCount();
+    int offset = (count < PERF_HISTORY_SIZE) ? 0 : getPerfHead();
+    if (count == 0) {
+      text(COLOR_HINT, "Collecting samples...");
+      ImGui.end();
+      return;
+    }
+
+    perfScaleMaxFps = Math.max(ringMax(getPerfFps(), count) * 1.15f, perfScaleMaxFps * 0.997f);
+    perfScaleMaxFrameMs = Math.max(ringMax(getPerfFrameMs(), count) * 1.15f, perfScaleMaxFrameMs * 0.997f);
+    perfScaleMaxHeapMb = Math.max(ringMax(getPerfHeapMb(), count) * 1.15f, perfScaleMaxHeapMb * 0.997f);
+    perfScaleMaxNativeMb = Math.max(ringMax(getPerfNativeMb(), count) * 1.15f, perfScaleMaxNativeMb * 0.997f);
+    perfScaleMaxRenderCalls = Math.max(ringMax(getPerfRenderCalls(), count) * 1.15f, perfScaleMaxRenderCalls * 0.997f);
+
+    float graphWidth = ImGui.getContentRegionAvailX();
+    float graphHeight = 60f;
+
+    text(COLOR_KEY, "FPS");
+    ImGui.sameLine();
+    text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfFps()))));
+    ImGui.plotLines("##fps", getPerfFps(), count, offset, "", 0f, perfScaleMaxFps, graphWidth, graphHeight);
+
+    text(COLOR_KEY, "Frame (ms)");
+    ImGui.sameLine();
+    text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfFrameMs())));
+    ImGui.plotLines("##frame", getPerfFrameMs(), count, offset, "", 0f, perfScaleMaxFrameMs, graphWidth, graphHeight);
+
+    text(COLOR_KEY, "Heap (MB)");
+    ImGui.sameLine();
+    text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfHeapMb())));
+    ImGui.plotLines("##heap", getPerfHeapMb(), count, offset, "", 0f, perfScaleMaxHeapMb, graphWidth, graphHeight);
+
+    float nativePeek = latestSample(getPerfNativeMb());
+    if (nativePeek > 0f) {
+      text(COLOR_KEY, "Native (MB)");
+      ImGui.sameLine();
+      text(COLOR_VALUE, formatOneDecimal(nativePeek));
+      ImGui.plotLines("##native", getPerfNativeMb(), count, offset, "", 0f, perfScaleMaxNativeMb, graphWidth,
+          graphHeight);
+    }
+
+    text(COLOR_KEY, "Render calls");
+    ImGui.sameLine();
+    text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfRenderCalls()))));
+    ImGui.plotLines("##rendercalls", getPerfRenderCalls(), count, offset, "", 0f, perfScaleMaxRenderCalls, graphWidth,
+        graphHeight);
+
+    ImGui.end();
+  }
+
+  /**
+   * The bgfx render-statistics panel: rolling graphs for every per-frame timing and workload counter
+   * bgfx exposes, plus a table of the one-off counters (peak draw calls, VRAM totals, transient buffer
+   * usage, and live GPU resource counts). Values are read from the graphics manager's cached
+   * {@link BGFXStats}, so the panel never allocates or issues an extra native call to gather them.
+   */
+  private void drawRenderWindow() {
+    if (!showRenderWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutRenderX, layoutRenderY, layoutRenderW, layoutRenderH);
+    if (!ImGui.begin("Render (bgfx)", showRenderWindow)) {
+      ImGui.end();
+      return;
+    }
+
+    text(COLOR_KEY, "Backend");
+    ImGui.sameLine();
+    text(COLOR_VALUE, graphics.getApi().toString());
+    text(COLOR_KEY, "Back buffer");
+    ImGui.sameLine();
+    text(COLOR_VALUE, graphics.getBackBufferWidth() + " x " + graphics.getBackBufferHeight());
+
+    BGFXStats stats = graphics.getBgfxStats();
+    if (stats == null) {
+      ImGui.separator();
+      text(COLOR_HINT, "bgfx statistics are not available yet.");
+      ImGui.end();
+      return;
+    }
+
+    int count = statsSampler.getCount();
+    int offset = statsSampler.getPlotOffset();
+    float graphWidth = ImGui.getContentRegionAvailX();
+    float graphHeight = 52f;
+    double cpuToMs = statsSampler.getCpuToMs();
+    double gpuToMs = statsSampler.getGpuToMs();
+
+    if (count == 0) {
+      text(COLOR_HINT, "Collecting samples...");
+    } else {
+      drawBgfxGraph(0, "CPU frame (ms)", statsSampler.getCpuFrameMs(), count, offset, graphWidth, graphHeight, true);
+      drawBgfxGraph(1, "CPU submit (ms)", statsSampler.getCpuSubmitMs(), count, offset, graphWidth, graphHeight, true);
+      drawBgfxGraph(2, "GPU (ms)", statsSampler.getGpuMs(), count, offset, graphWidth, graphHeight, true);
+      drawBgfxGraph(3, "Wait submit (ms)", statsSampler.getWaitSubmitMs(), count, offset, graphWidth, graphHeight,
+          true);
+      drawBgfxGraph(4, "Wait render (ms)", statsSampler.getWaitRenderMs(), count, offset, graphWidth, graphHeight,
+          true);
+      drawBgfxGraph(5, "Draw calls", statsSampler.getDrawCalls(), count, offset, graphWidth, graphHeight, false);
+      drawBgfxGraph(6, "GPU memory (MB)", statsSampler.getGpuMemoryMb(), count, offset, graphWidth, graphHeight, false);
+    }
+
+    if (ImGui.collapsingHeader("Submission", ImGuiTreeNodeFlags.DefaultOpen)) {
+      drawStatRow("Draw calls", stats.numDraw());
+      drawStatRow("Peak draw calls", stats.numDrawCallsPeak());
+      drawStatRow("Compute calls", stats.numCompute());
+      drawStatRow("Blit calls", stats.numBlit());
+      drawStatRow("Triangles", stats.numPrims(BGFX.BGFX_TOPOLOGY_TRI_LIST));
+      drawStatRow("Views", stats.numViews());
+      drawStatRow("Encoders", stats.numEncoders());
+      drawStatRow("GPU latency", stats.maxGpuLatency());
+    }
+
+    if (ImGui.collapsingHeader("Timing", ImGuiTreeNodeFlags.DefaultOpen)) {
+      drawStatRow("CPU frame (ms)", (float) (stats.cpuTimeFrame() * cpuToMs));
+      drawStatRow("CPU submit (ms)", (float) ((stats.cpuTimeEnd() - stats.cpuTimeBegin()) * cpuToMs));
+      if (gpuToMs > 0.0) {
+        drawStatRow("GPU (ms)", (float) ((stats.gpuTimeEnd() - stats.gpuTimeBegin()) * gpuToMs));
+      } else {
+        text(COLOR_KEY, "GPU (ms)");
+        ImGui.sameLine();
+        text(COLOR_VALUE, "n/a");
+      }
+      drawStatRow("Wait submit (ms)", (float) (stats.waitSubmit() * cpuToMs));
+      drawStatRow("Wait render (ms)", (float) (stats.waitRender() * cpuToMs));
+    }
+
+    if (ImGui.collapsingHeader("Memory", ImGuiTreeNodeFlags.DefaultOpen)) {
+      drawByteRow("GPU memory used", stats.gpuMemoryUsed());
+      drawByteRow("GPU memory max", stats.gpuMemoryMax());
+      drawByteRow("Texture memory", stats.textureMemoryUsed());
+      drawByteRow("Render target memory", stats.rtMemoryUsed());
+      drawStatRow("Transient VB (KB)", stats.transientVbUsed() / 1024);
+      drawStatRow("Transient IB (KB)", stats.transientIbUsed() / 1024);
+    }
+
+    if (ImGui.collapsingHeader("Resources")) {
+      drawStatRow("Textures", stats.numTextures());
+      drawStatRow("Shaders", stats.numShaders());
+      drawStatRow("Programs", stats.numPrograms());
+      drawStatRow("Uniforms", stats.numUniforms());
+      drawStatRow("Frame buffers", stats.numFrameBuffers());
+      drawStatRow("Vertex buffers", stats.numVertexBuffers());
+      drawStatRow("Index buffers", stats.numIndexBuffers());
+      drawStatRow("Dynamic VB", stats.numDynamicVertexBuffers());
+      drawStatRow("Dynamic IB", stats.numDynamicIndexBuffers());
+    }
+    ImGui.end();
+  }
+
+  /**
+   * Draws one labelled bgfx graph with a live value readout.
+   *
+   * @param index The per-series scale slot (0 to {@link #BGFX_GRAPH_COUNT} - 1).
+   * @param label The row label.
+   * @param ring The ring buffer to plot.
+   * @param count The number of valid samples.
+   * @param offset The read offset of the oldest sample.
+   * @param width The graph width in pixels.
+   * @param height The graph height in pixels.
+   * @param oneDecimal Whether to format the live value with one decimal ({@code true}) or as a
+   *     rounded integer ({@code false}).
+   */
+  private void drawBgfxGraph(int index, String label, float[] ring, int count, int offset,
+      float width, float height, boolean oneDecimal) {
+    float latest = statsSampler.latest(ring);
+    bgfxScaleMax[index] = Math.max(ringMax(ring, count) * 1.15f, bgfxScaleMax[index] * 0.997f);
+    if (bgfxScaleMax[index] < 1e-4f) {
+      bgfxScaleMax[index] = 1e-4f;
+    }
+    text(COLOR_KEY, label);
+    ImGui.sameLine();
+    text(COLOR_VALUE, oneDecimal ? formatOneDecimal(latest) : Integer.toString(Math.round(latest)));
+    ImGui.plotLines("##bgfx" + index, ring, count, offset, "", 0f, bgfxScaleMax[index], width, height);
+  }
+
+  private void drawControlsWindow() {
+    if (!showControlsWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutControlsX, layoutControlsY, layoutControlsW, layoutControlsH);
+    if (!ImGui.begin("Controls", showControlsWindow)) {
+      ImGui.end();
+      return;
+    }
+
+    boolean drawDebug = isDrawDebug();
+    if (ImGui.checkbox("Show hitboxes", drawDebug)) {
+      toggleDrawDebug();
+    }
+    boolean paused = Flixel.game.isGamePaused();
+    if (ImGui.checkbox("Pause game loop", paused)) {
+      Flixel.game.setGamePaused(!paused);
+    }
+
+    ImGui.separator();
+    text(COLOR_HEADER, "Time scale");
+    timeScaleSliderBuf[0] = Flixel.timeScale;
+    ImGui.pushItemWidth(-100f);
+    if (ImGui.sliderFloat("##timescale", timeScaleSliderBuf, 0.1f, 4.0f, "%.2fx")) {
+      Flixel.timeScale = timeScaleSliderBuf[0];
+    }
+    ImGui.sameLine();
+    if (ImGui.button("Reset##timescale")) {
+      Flixel.timeScale = 1f;
+    }
+
+    ImGui.separator();
+    text(COLOR_HEADER, "Keybinds");
+    refreshKeybindLabelsIfNeeded();
+    drawKeybindRow("Toggle overlay", keybindToggleLabel);
+    drawKeybindRow("Toggle hitboxes", keybindHitboxLabel);
+    drawKeybindRow("Pause", keybindPauseLabel);
+    drawKeybindRow("Cycle camera left", keybindCycleLeftLabel);
+    drawKeybindRow("Cycle camera right", keybindCycleRightLabel);
+    drawKeybindRow("Pan camera (paused)", "Right Mouse drag");
+    drawKeybindRow("Move sprite (paused)", "Left Mouse drag");
+    drawKeybindRow("Inspect sprite (paused)", "Left Mouse click");
+    drawKeybindRow("Zoom camera (paused)", "Mouse wheel");
+
+    ImGui.separator();
+    if (ImGui.button("Reset zoom on inspected camera")) {
+      FlixelArray<FlixelCamera> cams = Flixel.cameras;
+      if (cams != null && cams.getSize() > 0) {
+        FlixelCamera cam = cams.get(getInspectCameraIndex());
+        cam.setZoom(1f);
+      }
+    }
+    ImGui.sameLine();
+    if (ImGui.button("Toggle Texture Inspector")) {
+      showTextureWindow.set(!showTextureWindow.get());
+    }
+    ImGui.end();
+  }
+
+  private void drawKeybindRow(String label, String value) {
+    text(COLOR_KEY, label);
+    ImGui.sameLine();
+    text(COLOR_VALUE, value);
+  }
+
+  /**
+   * Rebuilds the cached keybind label strings only when the underlying key codes have changed.
+   * {@link FlixelKey#toString(int)} allocates a fresh {@link String} each call, so this caching keeps
+   * the controls panel allocation-free on the steady-state path.
+   */
+  private void refreshKeybindLabelsIfNeeded() {
+    int t = this.toggleKey;
+    int h = this.drawDebugKey;
+    int p = this.pauseKey;
+    int cl = this.cameraCycleLeftKey;
+    int cr = this.cameraCycleRightKey;
+    if (t != cachedToggleKey || keybindToggleLabel == null) {
+      keybindToggleLabel = FlixelKey.toString(t);
+      cachedToggleKey = t;
+    }
+    if (h != cachedHitboxKey || keybindHitboxLabel == null) {
+      keybindHitboxLabel = FlixelKey.toString(h);
+      cachedHitboxKey = h;
+    }
+    if (p != cachedPauseKey || keybindPauseLabel == null) {
+      keybindPauseLabel = FlixelKey.toString(p);
+      cachedPauseKey = p;
+    }
+    if (cl != cachedCycleLeftKey || keybindCycleLeftLabel == null) {
+      keybindCycleLeftLabel = "Alt + " + FlixelKey.toString(cl);
+      cachedCycleLeftKey = cl;
+    }
+    if (cr != cachedCycleRightKey || keybindCycleRightLabel == null) {
+      keybindCycleRightLabel = "Alt + " + FlixelKey.toString(cr);
+      cachedCycleRightKey = cr;
+    }
+  }
+
+  private void drawWatchWindow() {
+    if (!showWatchWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutWatchX, layoutWatchY, layoutWatchW, layoutWatchH);
+    if (!ImGui.begin("Watch", showWatchWindow)) {
+      ImGui.end();
+      return;
+    }
+    if (watchCount == 0) {
+      ImGui.textDisabled(WATCH_EMPTY_HINT);
+      ImGui.end();
+      return;
+    }
+    int flags = ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingStretchProp;
+    if (ImGui.beginTable("watch_table", 2, flags)) {
+      ImGui.tableSetupColumn("Name");
+      ImGui.tableSetupColumn("Value");
+      ImGui.tableHeadersRow();
+      for (int i = 0; i < watchCount; i++) {
+        ImGui.tableNextRow();
+        ImGui.tableNextColumn();
+        text(COLOR_KEY, watchKeyStr[i]);
+        ImGui.tableNextColumn();
+        text(COLOR_VALUE, watchValueStr[i]);
+      }
+      ImGui.endTable();
+    }
+    ImGui.end();
+  }
+
+  private void drawLogWindow() {
+    if (!showLogWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutLogX, layoutLogY, layoutLogW, layoutLogH);
+    int flags = ImGuiWindowFlags.MenuBar;
+    if (!ImGui.begin("Log", showLogWindow, flags)) {
+      ImGui.end();
+      return;
+    }
+
+    if (ImGui.beginMenuBar()) {
+      ImGui.menuItem("Info", null, logShowInfo);
+      ImGui.menuItem("Warn", null, logShowWarn);
+      ImGui.menuItem("Error", null, logShowError);
+      ImGui.menuItem("Debug", null, logShowDebug);
+      ImGui.separator();
+      ImGui.menuItem("Auto-scroll", null, logAutoScroll);
+      ImGui.endMenuBar();
+    }
+
+    if (ImGui.beginChild("log_scroll", 0, 0, false, ImGuiWindowFlags.HorizontalScrollbar)) {
+      for (int i = 0; i < logSnapshot.getSize(); i++) {
+        BufferedLogLine line = logSnapshot.get(i);
+        if (line == null || !isLogLevelVisible(line.level)) {
+          continue;
+        }
+        float[] color = colorForLevel(line.level);
+        if (line.tagStr.isEmpty()) {
+          text(color, "[" + line.level.name() + "] " + line.messageStr);
+        } else {
+          text(color, "[" + line.level.name() + "] [" + line.tagStr + "] " + line.messageStr);
+        }
+      }
+      if (scrollLogToBottom || (logAutoScroll.get() && ImGui.getScrollY() >= ImGui.getScrollMaxY() - 1f)) {
+        ImGui.setScrollHereY(1f);
+      }
+      scrollLogToBottom = false;
+    }
+    ImGui.endChild();
+    ImGui.end();
+  }
+
+  /**
+   * Renders the Tracker panel: a collapsible header per registered
+   * {@link org.flixelgdx.debug.FlixelDebugTrackerEntry FlixelDebugTrackerEntry}, each with a
+   * {@code name -> value} table like the Watch panel. When no trackers are registered it stays visible
+   * with a hint, mirroring the Watch panel's empty state.
+   */
+  private void drawTrackerWindow() {
+    if (!showTrackerWindow.get()) {
+      return;
+    }
+    applyWindowLayout(layoutTrackerX, layoutTrackerY, layoutTrackerW, layoutTrackerH);
+    if (!ImGui.begin("Tracker", showTrackerWindow)) {
+      ImGui.end();
+      return;
+    }
+    if (trackerBlockCount == 0) {
+      ImGui.textDisabled(TRACKER_EMPTY_HINT);
+      ImGui.end();
+      return;
+    }
+    int tableFlags = ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.SizingStretchProp;
+    for (int i = 0; i < trackerBlockCount; i++) {
+      String name = trackerNameStr[i];
+      if (name == null) {
+        continue;
+      }
+      if (ImGui.collapsingHeader(name, ImGuiTreeNodeFlags.DefaultOpen)) {
+        String[] keys = trackerKeyStrs[i];
+        String[] vals = trackerValueStrs[i];
+        int n = trackerPairCounts[i];
+        ImGui.pushID(i);
+        if (ImGui.beginTable("tracker_table", 2, tableFlags)) {
+          ImGui.tableSetupColumn("Name");
+          ImGui.tableSetupColumn("Value");
+          ImGui.tableHeadersRow();
+          for (int p = 0; p < n; p++) {
+            ImGui.tableNextRow();
+            ImGui.tableNextColumn();
+            text(COLOR_KEY, keys != null && keys[p] != null ? keys[p] : "");
+            ImGui.tableNextColumn();
+            text(COLOR_VALUE, vals != null && vals[p] != null ? vals[p] : "");
+          }
+          ImGui.endTable();
+        }
+        ImGui.popID();
+      }
+    }
+    ImGui.end();
+  }
+
+  /**
+   * Renders the runtime command line. Pressing Enter routes the input through
+   * {@code Flixel.debug.executeCommand(...)}, so the same parser is shared with code-driven
+   * invocations.
+   */
+  private void drawCommandWindow() {
+    if (!showCommandWindow.get()) {
+      commandInputFocusedLastFrame = false;
+      return;
+    }
+    applyWindowLayout(layoutCommandX, layoutCommandY, layoutCommandW, layoutCommandH);
+    if (!ImGui.begin("Command Line", showCommandWindow)) {
+      commandInputFocusedLastFrame = false;
+      ImGui.end();
+      return;
+    }
+
+    text(COLOR_HINT, "Enter a command and press Enter. Type \"help\" for a list.");
+    ImGui.pushItemWidth(-100f);
+    int inputFlags = ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.CallbackHistory;
+    if (focusCommandLine) {
+      ImGui.setKeyboardFocusHere();
+      focusCommandLine = false;
+    }
+    boolean submitted = ImGui.inputText("##cmd", commandInputBuffer, inputFlags, commandHistoryCallback);
+    commandInputFocusedLastFrame = ImGui.isItemFocused();
+    String commandSnapshot = commandInputBuffer.get();
+    ImGui.popItemWidth();
+    ImGui.sameLine();
+    boolean clickedRun = ImGui.button("Run");
+
+    updateCommandLineScratchAfterInput(clickedRun);
+
+    if (submitted || clickedRun) {
+      String line = commandSnapshot != null ? commandSnapshot.trim() : "";
+      if (line.isEmpty() && clickedRun && commandLineUtf8ScratchLen > 0) {
+        line = decodeCommandLineScratchUtf8();
+      }
+      if (!line.isEmpty()) {
+        Flixel.info("FlixelDebug", "> " + line);
+        Flixel.debug.executeCommand(line);
+        commandLineUtf8ScratchLen = 0;
+      }
+      commandInputBuffer.set("");
+      commandHistoryCursor = -1;
+      focusCommandLine = true;
+    }
+    ImGui.end();
+  }
+
+  /**
+   * Renders the texture inspector for the currently selected sprite (set by the LMB picker). For
+   * atlas-backed sprites this shows the entire backing texture, not just the active frame, so you can
+   * see what other graphics share the same atlas page.
+   */
+  private void drawTextureWindow() {
+    if (!showTextureWindow.get()) {
+      return;
+    }
+    int layoutCond = textureInspectorSnapNextFrame ? ImGuiCond.Always : nextLayoutCond();
+    if (textureInspectorSnapNextFrame) {
+      textureInspectorSnapNextFrame = false;
+    }
+    applyWindowLayout(layoutTextureX, layoutTextureY, layoutTextureW, layoutTextureH, layoutCond);
+    if (!ImGui.begin("Texture Inspector", showTextureWindow)) {
+      ImGui.end();
+      return;
+    }
+
+    FlixelObject inspected = Flixel.debug.getInspectedSprite();
+    if (inspected == null) {
+      text(COLOR_HINT, "Click a sprite while paused (left mouse button) to inspect its texture.");
+      ImGui.end();
+      return;
+    }
+
+    text(COLOR_KEY, "Type");
+    ImGui.sameLine();
+    text(COLOR_VALUE, inspected.getClass().getSimpleName());
+    text(COLOR_KEY, "Position");
+    ImGui.sameLine();
+    text(COLOR_VALUE, "(" + formatOneDecimal(inspected.getX()) + ", " + formatOneDecimal(inspected.getY()) + ")");
+    text(COLOR_KEY, "Size");
+    ImGui.sameLine();
+    text(COLOR_VALUE, "(" + formatOneDecimal(inspected.getWidth()) + ", " + formatOneDecimal(inspected.getHeight())
+        + ")");
+
+    if (!(inspected instanceof FlixelSprite sprite)) {
+      ImGui.separator();
+      text(COLOR_HINT, "This object does not have a texture (only FlixelSprite subclasses do).");
+      ImGui.end();
+      return;
+    }
+
+    FlixelTexture texture = sprite.getTexture();
+    if (texture == null) {
+      ImGui.separator();
+      text(COLOR_HINT, "Sprite has no texture loaded.");
+      ImGui.end();
+      return;
+    }
+
+    long handle = texture.getHandle();
+    int texW = texture.getWidth();
+    int texH = texture.getHeight();
+    text(COLOR_KEY, "Texture");
+    ImGui.sameLine();
+    text(COLOR_VALUE, texW + " x " + texH + " (bgfx=" + handle + ")");
+
+    ImGui.separator();
+    textureViewerZoomBuf[0] = textureViewerZoom;
+    if (ImGui.sliderFloat("Zoom", textureViewerZoomBuf, 0.25f, 8f, "%.2fx")) {
+      textureViewerZoom = textureViewerZoomBuf[0];
+    }
+
+    if (ImGui.beginChild("texscroll", 0, 0, true, ImGuiWindowFlags.HorizontalScrollbar)) {
+      // Pass the bgfx texture handle as the Dear ImGui texture id; the bgfx renderer binds it back.
+      // Framework textures store texel (0, 0) at the top-left, matching ImGui's default UVs, so the
+      // image renders upright.
+      ImGui.image(handle, texW * textureViewerZoom, texH * textureViewerZoom);
+    }
+    ImGui.endChild();
+    ImGui.end();
+  }
+
+  /**
+   * Refreshes the UTF-8 scratch from the live ImGui buffer when it has content; when empty, keeps the
+   * previous scratch if {@code clickedRun} is true so Run can still read the last typed line.
+   */
+  private void updateCommandLineScratchAfterInput(boolean clickedRun) {
+    byte[] src = commandInputBuffer.getData();
+    int cap = Math.min(src.length, commandLineUtf8Scratch.length);
+    int i = 0;
+    for (; i < cap && src[i] != 0; i++) {
+      commandLineUtf8Scratch[i] = src[i];
+    }
+    if (i > 0) {
+      commandLineUtf8ScratchLen = i;
+    } else if (!clickedRun) {
+      commandLineUtf8ScratchLen = 0;
+    }
+  }
+
+  private String decodeCommandLineScratchUtf8() {
+    return new String(commandLineUtf8Scratch, 0, commandLineUtf8ScratchLen, StandardCharsets.UTF_8).trim();
+  }
+
+  /**
+   * Walks the persistent command history from an {@code InputText} history callback. {@code direction}
+   * is {@code -1} for Up (older) or {@code +1} for Down (newer). Wrapping is disabled so Down past the
+   * newest clears the buffer.
+   */
+  private void applyHistoryKeyInInputCallback(ImGuiInputTextCallbackData data, int direction) {
+    FlixelArray<String> history = Flixel.debug.getCommandHistory();
+    if (history.getSize() == 0) {
+      return;
+    }
+    if (commandHistoryCursor < 0) {
+      commandHistoryCursor = history.getSize();
+    }
+    int next = commandHistoryCursor + direction;
+    if (next < 0) {
+      next = 0;
+    } else if (next > history.getSize()) {
+      next = history.getSize();
+    }
+    commandHistoryCursor = next;
+    String line = next == history.getSize() ? "" : history.get(next);
+    data.deleteChars(0, data.getBufTextLen());
+    if (!line.isEmpty()) {
+      data.insertChars(0, line);
+    }
+    int end = data.getBufTextLen();
+    data.setSelectionStart(end);
+    data.setSelectionEnd(end);
+    data.setCursorPos(end);
+  }
+
+  private boolean isLogLevelVisible(FlixelLogLevel level) {
+    return switch (level) {
+      case INFO -> logShowInfo.get();
+      case WARN -> logShowWarn.get();
+      case ERROR -> logShowError.get();
+      case DEBUG -> logShowDebug.get();
+    };
+  }
+
+  /** Returns the most-recent sample written into {@code buffer}, accounting for ring rollover. */
+  private float latestSample(float[] buffer) {
+    int count = getPerfCount();
+    if (count == 0 || buffer.length == 0) {
+      return 0f;
+    }
+    int head = getPerfHead();
+    int last = (head - 1 + buffer.length) % buffer.length;
+    return buffer[last];
+  }
+
+  /**
+   * @return {@code true} for keys that should keep working as debug shortcuts even while the command
+   *     field is focused (function keys, Escape, modifiers, and lock keys, none of which type text).
+   */
+  private static boolean isNonTypableSystemDebugKey(int keycode) {
+    if (keycode < 0) {
+      return true;
+    }
+    if (keycode >= FlixelKey.F1 && keycode <= FlixelKey.F12) {
+      return true;
+    }
+    return keycode == FlixelKey.ESCAPE
+        || keycode == FlixelKey.CONTROL_LEFT
+        || keycode == FlixelKey.CONTROL_RIGHT
+        || keycode == FlixelKey.ALT_LEFT
+        || keycode == FlixelKey.ALT_RIGHT
+        || keycode == FlixelKey.SHIFT_LEFT
+        || keycode == FlixelKey.SHIFT_RIGHT
+        || keycode == FlixelKey.SYM
+        || keycode == FlixelKey.MENU
+        || keycode == FlixelKey.CAPS_LOCK
+        || keycode == FlixelKey.SCROLL_LOCK
+        || keycode == FlixelKey.NUM_LOCK
+        || keycode == FlixelKey.PAUSE
+        || keycode == FlixelKey.PRINT_SCREEN;
+  }
+
+  private static float[] colorForLevel(FlixelLogLevel level) {
+    return switch (level) {
+      case INFO -> COLOR_INFO;
+      case WARN -> COLOR_WARN;
+      case ERROR -> COLOR_ERROR;
+      case DEBUG -> COLOR_DEBUG;
+    };
+  }
+
+  /**
+   * Formats {@code value} with one decimal place. Allocates a small {@link String}, but only when a
+   * value is actually shown, so the cost is negligible.
+   */
+  private static String formatOneDecimal(float value) {
+    int whole = (int) value;
+    int tenths = Math.abs((int) ((value - whole) * 10f));
+    return whole + "." + tenths;
+  }
+
+  /**
+   * Returns the maximum value across the first {@code count} elements of {@code buf} without
+   * allocating a sorted copy. Returns {@code 0} when {@code count} is zero.
+   */
+  private static float ringMax(float[] buf, int count) {
+    float m = 0f;
+    for (int i = 0; i < count; i++) {
+      if (buf[i] > m) {
+        m = buf[i];
+      }
+    }
+    return m;
+  }
+
+  /** Draws a {@code label} plus a byte count formatted as megabytes, or "n/a" for a negative total. */
+  private void drawByteRow(String label, long bytes) {
+    text(COLOR_KEY, label);
+    ImGui.sameLine();
+    if (bytes < 0) {
+      text(COLOR_VALUE, "n/a");
+    } else {
+      text(COLOR_VALUE, formatOneDecimal(bytes / (1024f * 1024f)) + " MB");
+    }
+  }
+
+  /**
+   * Renders {@code message} colored by the supplied {@code [r, g, b, a]} tuple. Uses
+   * {@link ImGui#textUnformatted(String)} so a literal {@code %} is not interpreted as a printf format
+   * sequence by the native Dear ImGui binding.
+   */
+  private static void text(float[] color, String message) {
+    ImGui.pushStyleColor(ImGuiCol.Text, color[0], color[1], color[2], color[3]);
+    ImGui.textUnformatted(message != null ? message : "");
+    ImGui.popStyleColor();
+  }
+}

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -289,9 +289,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
 
   private boolean focusCommandLine;
 
-  /** Whether the command {@code InputText} had focus at the end of the last {@link #drawUI()} pass. */
-  private boolean commandInputFocusedLastFrame;
-
   /** When true, the next {@link #drawUI()} pass clears the Dear ImGui IO input queues once. */
   private boolean sanitizeImGuiInputBeforeNextDraw;
 
@@ -440,14 +437,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   }
 
   @Override
-  protected boolean shouldSuppressDebugRawKeybind(int keycode) {
-    if (!commandInputFocusedLastFrame) {
-      return false;
-    }
-    return !isNonTypableSystemDebugKey(keycode);
-  }
-
-  @Override
   protected void onWatchEntriesRefreshed() {
     int n = cachedWatchKeys.getSize();
     if (watchKeyStr.length < n) {
@@ -523,7 +512,9 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     ImGui.createContext();
     ImGuiIO io = ImGui.getIO();
     io.setIniFilename(null);
-    io.addConfigFlags(ImGuiConfigFlags.NavEnableKeyboard);
+    // Keyboard navigation is intentionally left off: with it on, focusing any overlay window makes
+    // Dear ImGui report WantCaptureKeyboard, which would suppress the F2/F3/F4 toggle keys (they now
+    // go through the normal input path). Mouse drives the overlay; the toggles stay reliable.
     io.addConfigFlags(ImGuiConfigFlags.DockingEnable);
     // The bgfx renderer binds a per-command vertex offset, so let Dear ImGui keep large draw lists in
     // one buffer instead of forcing 16-bit index limits.
@@ -1271,12 +1262,10 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
    */
   private void drawCommandWindow() {
     if (!showCommandWindow.get()) {
-      commandInputFocusedLastFrame = false;
       return;
     }
     applyWindowLayout(layoutCommandX, layoutCommandY, layoutCommandW, layoutCommandH);
     if (!ImGui.begin("Command Line", showCommandWindow)) {
-      commandInputFocusedLastFrame = false;
       ImGui.end();
       return;
     }
@@ -1289,7 +1278,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       focusCommandLine = false;
     }
     boolean submitted = ImGui.inputText("##cmd", commandInputBuffer, inputFlags, commandHistoryCallback);
-    commandInputFocusedLastFrame = ImGui.isItemFocused();
     String commandSnapshot = commandInputBuffer.get();
     ImGui.popItemWidth();
     ImGui.sameLine();
@@ -1460,33 +1448,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     int head = getPerfHead();
     int last = (head - 1 + buffer.length) % buffer.length;
     return buffer[last];
-  }
-
-  /**
-   * @return {@code true} for keys that should keep working as debug shortcuts even while the command
-   *     field is focused (function keys, Escape, modifiers, and lock keys, none of which type text).
-   */
-  private static boolean isNonTypableSystemDebugKey(int keycode) {
-    if (keycode < 0) {
-      return true;
-    }
-    if (keycode >= FlixelKey.F1 && keycode <= FlixelKey.F12) {
-      return true;
-    }
-    return keycode == FlixelKey.ESCAPE
-        || keycode == FlixelKey.CONTROL_LEFT
-        || keycode == FlixelKey.CONTROL_RIGHT
-        || keycode == FlixelKey.ALT_LEFT
-        || keycode == FlixelKey.ALT_RIGHT
-        || keycode == FlixelKey.SHIFT_LEFT
-        || keycode == FlixelKey.SHIFT_RIGHT
-        || keycode == FlixelKey.SYM
-        || keycode == FlixelKey.MENU
-        || keycode == FlixelKey.CAPS_LOCK
-        || keycode == FlixelKey.SCROLL_LOCK
-        || keycode == FlixelKey.NUM_LOCK
-        || keycode == FlixelKey.PAUSE
-        || keycode == FlixelKey.PRINT_SCREEN;
   }
 
   private static float[] colorForLevel(FlixelLogLevel level) {

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -32,6 +32,7 @@ import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.debug.FlixelDebugOverlay;
 import org.flixelgdx.graphics.FlixelTexture;
 import org.flixelgdx.input.keyboard.FlixelKey;
+import org.flixelgdx.input.mouse.FlixelMouseCursor;
 import org.flixelgdx.logging.FlixelLogLevel;
 import org.lwjgl.bgfx.BGFX;
 import org.lwjgl.bgfx.BGFXStats;
@@ -52,6 +53,7 @@ import imgui.flag.ImGuiConfigFlags;
 import imgui.flag.ImGuiDockNodeFlags;
 import imgui.flag.ImGuiInputTextFlags;
 import imgui.flag.ImGuiKey;
+import imgui.flag.ImGuiMouseCursor;
 import imgui.flag.ImGuiTableFlags;
 import imgui.flag.ImGuiTreeNodeFlags;
 import imgui.flag.ImGuiWindowFlags;
@@ -439,6 +441,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
 
     ImGui.render();
     renderer.render(ImGui.getDrawData());
+    updateImGuiCursor();
   }
 
   @Override
@@ -592,6 +595,8 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     imguiInput.setActive(nowVisible);
     if (nowVisible) {
       sanitizeImGuiInputBeforeNextDraw = true;
+    } else if (Flixel.mouse != null) {
+      Flixel.mouse.icons.resetCursor();
     }
   }
 
@@ -859,7 +864,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       return;
     }
 
-    text(COLOR_KEY, "Backend");
+    text(COLOR_KEY, "Graphics API");
     ImGui.sameLine();
     text(COLOR_VALUE, graphics.getApi().toString());
     text(COLOR_KEY, "Back buffer");
@@ -887,7 +892,8 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       } else {
         perfScaleMaxFps = Math.max(ringMax(getPerfFps(), count) * 1.15f, perfScaleMaxFps * 0.997f);
         perfScaleMaxFrameMs = Math.max(ringMax(getPerfFrameMs(), count) * 1.15f, perfScaleMaxFrameMs * 0.997f);
-        perfScaleMaxRenderCalls = Math.max(ringMax(getPerfRenderCalls(), count) * 1.15f, perfScaleMaxRenderCalls * 0.997f);
+        perfScaleMaxRenderCalls =
+            Math.max(ringMax(getPerfRenderCalls(), count) * 1.15f, perfScaleMaxRenderCalls * 0.997f);
 
         text(COLOR_KEY, "FPS");
         ImGui.sameLine();
@@ -897,12 +903,14 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
         text(COLOR_KEY, "Frame (ms)");
         ImGui.sameLine();
         text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfFrameMs())));
-        ImGui.plotLines("##frame", getPerfFrameMs(), count, offset, "", 0f, perfScaleMaxFrameMs, graphWidth, graphHeight);
+        ImGui.plotLines("##frame", getPerfFrameMs(), count, offset, "", 0f, perfScaleMaxFrameMs, graphWidth,
+            graphHeight);
 
         text(COLOR_KEY, "Draw calls");
         ImGui.sameLine();
         text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfRenderCalls()))));
-        ImGui.plotLines("##rendercalls", getPerfRenderCalls(), count, offset, "", 0f, perfScaleMaxRenderCalls, graphWidth,
+        ImGui.plotLines("##rendercalls", getPerfRenderCalls(), count, offset, "", 0f, perfScaleMaxRenderCalls,
+            graphWidth,
             graphHeight);
       }
     }
@@ -928,10 +936,11 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       }
       if (bgfxCount > 0) {
         if (statsSampler.latest(statsSampler.getGpuMemoryMb()) > 0f) {
-          drawBgfxGraph(4, "GPU (MB)", statsSampler.getGpuMemoryMb(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall,
+          drawBgfxGraph(4, "GPU (MB)", statsSampler.getGpuMemoryMb(), bgfxCount, bgfxOffset, graphWidth,
+              graphHeightSmall,
               false);
         } else {
-          text(COLOR_HINT, "GPU memory tracking unavailable for this backend.");
+          text(COLOR_HINT, "GPU memory tracking unavailable for this graphics API.");
         }
       }
       if (stats != null) {
@@ -951,7 +960,8 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       } else {
         drawBgfxGraph(0, "CPU submit (ms)", statsSampler.getCpuSubmitMs(), bgfxCount, bgfxOffset, graphWidth,
             graphHeightSmall, true);
-        drawBgfxGraph(1, "GPU (ms)", statsSampler.getGpuMs(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall, true);
+        drawBgfxGraph(1, "GPU (ms)", statsSampler.getGpuMs(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall,
+            true);
         drawBgfxGraph(2, "Wait submit (ms)", statsSampler.getWaitSubmitMs(), bgfxCount, bgfxOffset, graphWidth,
             graphHeightSmall, true);
         drawBgfxGraph(3, "Wait render (ms)", statsSampler.getWaitRenderMs(), bgfxCount, bgfxOffset, graphWidth,
@@ -1509,6 +1519,37 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     ImGui.pushStyleColor(ImGuiCol.Text, color[0], color[1], color[2], color[3]);
     ImGui.textUnformatted(message != null ? message : "");
     ImGui.popStyleColor();
+  }
+
+  /**
+   * Applies the cursor that Dear ImGui requested for this frame. Only takes effect when ImGui owns
+   * the mouse or explicitly wants a non-arrow cursor (resize grips, text fields, etc.); otherwise
+   * the call is skipped so the game's own cursor choice is not overwritten while the cursor is over
+   * the game viewport.
+   */
+  private void updateImGuiCursor() {
+    if (Flixel.mouse == null) {
+      return;
+    }
+    int cursor = ImGui.getMouseCursor();
+    if (cursor != ImGuiMouseCursor.Arrow || ImGui.getIO().getWantCaptureMouse()) {
+      Flixel.mouse.icons.setCursor(imguiCursorToFlixel(cursor));
+    }
+  }
+
+  private static FlixelMouseCursor imguiCursorToFlixel(int imguiCursor) {
+    return switch (imguiCursor) {
+      case ImGuiMouseCursor.TextInput -> FlixelMouseCursor.IBEAM;
+      case ImGuiMouseCursor.ResizeAll -> FlixelMouseCursor.ALL_RESIZE;
+      case ImGuiMouseCursor.ResizeNS -> FlixelMouseCursor.VERTICAL_RESIZE;
+      case ImGuiMouseCursor.ResizeEW -> FlixelMouseCursor.HORIZONTAL_RESIZE;
+      case ImGuiMouseCursor.ResizeNESW -> FlixelMouseCursor.NORTH_EAST_SOUTH_WEST_RESIZE;
+      case ImGuiMouseCursor.ResizeNWSE -> FlixelMouseCursor.NORTH_WEST_SOUTH_EAST_RESIZE;
+      case ImGuiMouseCursor.Hand -> FlixelMouseCursor.HAND;
+      case ImGuiMouseCursor.NotAllowed -> FlixelMouseCursor.NOT_ALLOWED;
+      case ImGuiMouseCursor.None -> FlixelMouseCursor.NONE;
+      default -> FlixelMouseCursor.ARROW;
+    };
   }
 
   /**

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -195,6 +195,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   // Reused float buffers fed to ImGui.sliderFloat() so the controls stay allocation-free.
   private final float[] textureViewerZoomBuf = new float[1];
   private final float[] timeScaleSliderBuf = new float[1];
+  private final float[] overlayUpdateRateBuf = new float[1];
 
   // Watch caches mirroring cachedWatchKeys / cachedWatchValues as java String.
   private String[] watchKeyStr = new String[0];
@@ -256,6 +257,8 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private float layoutCommandY;
   private float layoutCommandW;
   private float layoutCommandH;
+  private float bgfxSampleTimer = 0f;
+  private float overlayUpdateRate = 20f;
   private float textureViewerZoom = 1f;
 
   // Per-series Y-axis scale maxima for the core performance graphs. Each grows immediately when a new
@@ -385,7 +388,12 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       return;
     }
     snapshotLogBuffer();
-    statsSampler.sample(graphics.getBgfxStats());
+    bgfxSampleTimer += Flixel.getRawElapsed();
+    float bgfxSampleInterval = 1f / overlayUpdateRate;
+    if (bgfxSampleTimer >= bgfxSampleInterval) {
+      bgfxSampleTimer -= bgfxSampleInterval;
+      statsSampler.sample(graphics.getBgfxStats());
+    }
 
     if (sanitizeImGuiInputBeforeNextDraw) {
       sanitizeImGuiInputBeforeNextDraw = false;
@@ -861,8 +869,12 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     BGFXStats stats = graphics.getBgfxStats();
     int bgfxCount = statsSampler.getCount();
     int bgfxOffset = statsSampler.getPlotOffset();
-    double cpuToMs = statsSampler.getCpuToMs();
-    double gpuToMs = statsSampler.getGpuToMs();
+    // Read conversion factors directly from the live stats so they stay current even when the
+    // sampler is throttled; fall back to the sampler's last known values when stats is null.
+    long cpuFreq = stats != null ? stats.cpuTimerFreq() : 0;
+    long gpuFreq = stats != null ? stats.gpuTimerFreq() : 0;
+    double cpuToMs = cpuFreq > 0 ? 1000.0 / cpuFreq : statsSampler.getCpuToMs();
+    double gpuToMs = gpuFreq > 0 ? 1000.0 / gpuFreq : statsSampler.getGpuToMs();
     float graphWidth = ImGui.getContentRegionAvailX();
     float graphHeight = 60f;
     float graphHeightSmall = 48f;
@@ -915,8 +927,12 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
         }
       }
       if (bgfxCount > 0) {
-        drawBgfxGraph(4, "GPU (MB)", statsSampler.getGpuMemoryMb(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall,
-            false);
+        if (statsSampler.latest(statsSampler.getGpuMemoryMb()) > 0f) {
+          drawBgfxGraph(4, "GPU (MB)", statsSampler.getGpuMemoryMb(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall,
+              false);
+        } else {
+          text(COLOR_HINT, "GPU memory tracking unavailable for this backend.");
+        }
       }
       if (stats != null) {
         ImGui.separator();
@@ -1039,6 +1055,20 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     if (ImGui.button("Reset##timescale")) {
       Flixel.timeScale = 1f;
     }
+    ImGui.popItemWidth();
+
+    ImGui.separator();
+    text(COLOR_HEADER, "Update rate (Hz)");
+    overlayUpdateRateBuf[0] = overlayUpdateRate;
+    ImGui.pushItemWidth(-100f);
+    if (ImGui.sliderFloat("##updaterate", overlayUpdateRateBuf, 1f, 30f, "%.0f Hz")) {
+      setOverlayUpdateRate(overlayUpdateRateBuf[0]);
+    }
+    ImGui.sameLine();
+    if (ImGui.button("Reset##updaterate")) {
+      setOverlayUpdateRate(20f);
+    }
+    ImGui.popItemWidth();
 
     ImGui.separator();
     text(COLOR_HEADER, "Keybinds");
@@ -1479,5 +1509,36 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     ImGui.pushStyleColor(ImGuiCol.Text, color[0], color[1], color[2], color[3]);
     ImGui.textUnformatted(message != null ? message : "");
     ImGui.popStyleColor();
+  }
+
+  /**
+   * Returns the current data update rate for this overlay in updates per second.
+   *
+   * <p>This rate governs how often the graphs sample new data, how often the Watch and Tracker
+   * panels refresh their values, and how often the Stats panel updates its counters. The value is
+   * always within the range {@code [1, 30]} Hz.
+   *
+   * @return The update rate in Hertz.
+   */
+  public float getOverlayUpdateRate() {
+    return overlayUpdateRate;
+  }
+
+  /**
+   * Sets the data update rate for this overlay, in updates per second. Affects graphs, the Watch
+   * panel, the Tracker panel, and the Stats panel.
+   *
+   * <p>The value is clamped to {@code [1, 30]} Hz. Lower values reduce CPU overhead from the debug
+   * overlay; higher values give smoother, more reactive graphs and watch readings.
+   *
+   * @param hz The desired rate in Hertz. Values below 1 are raised to 1; values above 30 are
+   *     lowered to 30.
+   */
+  public void setOverlayUpdateRate(float hz) {
+    overlayUpdateRate = Math.max(1f, Math.min(30f, hz));
+    float interval = 1f / overlayUpdateRate;
+    perfSampleInterval = interval;
+    watchRefreshInterval = interval;
+    statsUpdateInterval = interval;
   }
 }

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -134,8 +134,12 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private static final String TRACKER_EMPTY_HINT =
       "No trackers registered. Use Flixel.debug.addTrackerEntry(...) to show grouped values here.";
 
-  /** Number of bgfx time-series graphs, used to size the per-series Y-axis scale array. */
-  private static final int BGFX_GRAPH_COUNT = 7;
+  /**
+   * Number of unique bgfx time-series graphs, used to size the per-series Y-axis scale array.
+   * Indices: 0 CPU submit, 1 GPU, 2 Wait submit, 3 Wait render, 4 GPU memory.
+   * CPU frame and draw calls are omitted because they duplicate the core perf ring buffers.
+   */
+  private static final int BGFX_GRAPH_COUNT = 5;
 
   private final FlixelImGuiSdlInput imguiInput = new FlixelImGuiSdlInput();
   private final FlixelBgfxStatsSampler statsSampler = new FlixelBgfxStatsSampler();
@@ -149,7 +153,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   // Window visibility flags (toggled from the debug menu).
   private final ImBoolean showStatsWindow = new ImBoolean(true);
   private final ImBoolean showPerformanceWindow = new ImBoolean(true);
-  private final ImBoolean showRenderWindow = new ImBoolean(true);
   private final ImBoolean showControlsWindow = new ImBoolean(true);
   private final ImBoolean showWatchWindow = new ImBoolean(true);
   private final ImBoolean showLogWindow = new ImBoolean(true);
@@ -253,10 +256,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private float layoutCommandY;
   private float layoutCommandW;
   private float layoutCommandH;
-  private float layoutRenderX;
-  private float layoutRenderY;
-  private float layoutRenderW;
-  private float layoutRenderH;
   private float textureViewerZoom = 1f;
 
   // Per-series Y-axis scale maxima for the core performance graphs. Each grows immediately when a new
@@ -417,7 +416,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
 
     drawStatsWindow();
     drawPerformanceWindow();
-    drawRenderWindow();
     drawWatchWindow();
     drawControlsWindow();
     drawLogWindow();
@@ -561,6 +559,13 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     setStyleColor(style, ImGuiCol.ResizeGripActive, COLOR_RESIZE_GRIP_ACTIVE);
     setStyleColor(style, ImGuiCol.SliderGrab, COLOR_SLIDER_GRAB);
     setStyleColor(style, ImGuiCol.SliderGrabActive, COLOR_SLIDER_GRAB_ACTIVE);
+    style.setWindowRounding(8f);
+    style.setChildRounding(6f);
+    style.setFrameRounding(4f);
+    style.setPopupRounding(6f);
+    style.setScrollbarRounding(6f);
+    style.setGrabRounding(4f);
+    style.setTabRounding(6f);
   }
 
   private static void setStyleColor(ImGuiStyle style, int target, float[] color) {
@@ -717,13 +722,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     layoutCommandY = yCmd;
     layoutCommandW = workW;
     layoutCommandH = cmdH;
-
-    // The bgfx render panel defaults to a floating window just right of the left column; docking lets
-    // the user move it wherever they like afterward.
-    layoutRenderW = Math.min(430f, Math.max(320f, workW * 0.26f));
-    layoutRenderH = Math.min(620f, Math.max(320f, availH * 0.8f));
-    layoutRenderX = Math.min(ox + colW + gap, ox + workW - layoutRenderW - gap);
-    layoutRenderY = oy;
   }
 
   /** Returns the imgui condition flag to use for the next window's default position / size hint. */
@@ -751,7 +749,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     if (ImGui.beginMenu("Debug")) {
       ImGui.menuItem("Stats", null, showStatsWindow);
       ImGui.menuItem("Performance", null, showPerformanceWindow);
-      ImGui.menuItem("Render (bgfx)", null, showRenderWindow);
       ImGui.menuItem("Controls", null, showControlsWindow);
       ImGui.menuItem("Tracker", null, showTrackerWindow);
       ImGui.menuItem("Watch", null, showWatchWindow);
@@ -840,9 +837,9 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   }
 
   /**
-   * Real-time graphs of the platform-agnostic performance ring buffers owned by
-   * {@link FlixelDebugOverlay} (FPS, frame time, Java and native heap, and render calls). Each series
-   * plots directly against the parent's primitive arrays, so no temporary buffer is copied.
+   * Merged Performance panel: real-time graphs of the platform-agnostic ring buffers and bgfx render
+   * statistics, organized into collapsing sections. The Core section (FPS, frame time, draw calls)
+   * starts open; Memory, GPU Timing, Submission, and Resources start collapsed.
    */
   private void drawPerformanceWindow() {
     if (!showPerformanceWindow.get()) {
@@ -850,71 +847,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     }
     applyWindowLayout(layoutPerfX, layoutPerfY, layoutPerfW, layoutPerfH);
     if (!ImGui.begin("Performance", showPerformanceWindow)) {
-      ImGui.end();
-      return;
-    }
-    int count = getPerfCount();
-    int offset = (count < PERF_HISTORY_SIZE) ? 0 : getPerfHead();
-    if (count == 0) {
-      text(COLOR_HINT, "Collecting samples...");
-      ImGui.end();
-      return;
-    }
-
-    perfScaleMaxFps = Math.max(ringMax(getPerfFps(), count) * 1.15f, perfScaleMaxFps * 0.997f);
-    perfScaleMaxFrameMs = Math.max(ringMax(getPerfFrameMs(), count) * 1.15f, perfScaleMaxFrameMs * 0.997f);
-    perfScaleMaxHeapMb = Math.max(ringMax(getPerfHeapMb(), count) * 1.15f, perfScaleMaxHeapMb * 0.997f);
-    perfScaleMaxNativeMb = Math.max(ringMax(getPerfNativeMb(), count) * 1.15f, perfScaleMaxNativeMb * 0.997f);
-    perfScaleMaxRenderCalls = Math.max(ringMax(getPerfRenderCalls(), count) * 1.15f, perfScaleMaxRenderCalls * 0.997f);
-
-    float graphWidth = ImGui.getContentRegionAvailX();
-    float graphHeight = 60f;
-
-    text(COLOR_KEY, "FPS");
-    ImGui.sameLine();
-    text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfFps()))));
-    ImGui.plotLines("##fps", getPerfFps(), count, offset, "", 0f, perfScaleMaxFps, graphWidth, graphHeight);
-
-    text(COLOR_KEY, "Frame (ms)");
-    ImGui.sameLine();
-    text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfFrameMs())));
-    ImGui.plotLines("##frame", getPerfFrameMs(), count, offset, "", 0f, perfScaleMaxFrameMs, graphWidth, graphHeight);
-
-    text(COLOR_KEY, "Heap (MB)");
-    ImGui.sameLine();
-    text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfHeapMb())));
-    ImGui.plotLines("##heap", getPerfHeapMb(), count, offset, "", 0f, perfScaleMaxHeapMb, graphWidth, graphHeight);
-
-    float nativePeek = latestSample(getPerfNativeMb());
-    if (nativePeek > 0f) {
-      text(COLOR_KEY, "Native (MB)");
-      ImGui.sameLine();
-      text(COLOR_VALUE, formatOneDecimal(nativePeek));
-      ImGui.plotLines("##native", getPerfNativeMb(), count, offset, "", 0f, perfScaleMaxNativeMb, graphWidth,
-          graphHeight);
-    }
-
-    text(COLOR_KEY, "Render calls");
-    ImGui.sameLine();
-    text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfRenderCalls()))));
-    ImGui.plotLines("##rendercalls", getPerfRenderCalls(), count, offset, "", 0f, perfScaleMaxRenderCalls, graphWidth,
-        graphHeight);
-
-    ImGui.end();
-  }
-
-  /**
-   * The bgfx render-statistics panel: rolling graphs for every per-frame timing and workload counter
-   * bgfx exposes, plus a table of the one-off counters (peak draw calls, VRAM totals, transient buffer
-   * usage, and live GPU resource counts). Values are read from the graphics manager's cached
-   * {@link BGFXStats}, so the panel never allocates or issues an extra native call to gather them.
-   */
-  private void drawRenderWindow() {
-    if (!showRenderWindow.get()) {
-      return;
-    }
-    applyWindowLayout(layoutRenderX, layoutRenderY, layoutRenderW, layoutRenderH);
-    if (!ImGui.begin("Render (bgfx)", showRenderWindow)) {
       ImGui.end();
       return;
     }
@@ -927,79 +859,127 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     text(COLOR_VALUE, graphics.getBackBufferWidth() + " x " + graphics.getBackBufferHeight());
 
     BGFXStats stats = graphics.getBgfxStats();
-    if (stats == null) {
-      ImGui.separator();
-      text(COLOR_HINT, "bgfx statistics are not available yet.");
-      ImGui.end();
-      return;
-    }
-
-    int count = statsSampler.getCount();
-    int offset = statsSampler.getPlotOffset();
-    float graphWidth = ImGui.getContentRegionAvailX();
-    float graphHeight = 52f;
+    int bgfxCount = statsSampler.getCount();
+    int bgfxOffset = statsSampler.getPlotOffset();
     double cpuToMs = statsSampler.getCpuToMs();
     double gpuToMs = statsSampler.getGpuToMs();
+    float graphWidth = ImGui.getContentRegionAvailX();
+    float graphHeight = 60f;
+    float graphHeightSmall = 48f;
+    int count = getPerfCount();
+    int offset = (count < PERF_HISTORY_SIZE) ? 0 : getPerfHead();
 
-    if (count == 0) {
-      text(COLOR_HINT, "Collecting samples...");
-    } else {
-      drawBgfxGraph(0, "CPU frame (ms)", statsSampler.getCpuFrameMs(), count, offset, graphWidth, graphHeight, true);
-      drawBgfxGraph(1, "CPU submit (ms)", statsSampler.getCpuSubmitMs(), count, offset, graphWidth, graphHeight, true);
-      drawBgfxGraph(2, "GPU (ms)", statsSampler.getGpuMs(), count, offset, graphWidth, graphHeight, true);
-      drawBgfxGraph(3, "Wait submit (ms)", statsSampler.getWaitSubmitMs(), count, offset, graphWidth, graphHeight,
-          true);
-      drawBgfxGraph(4, "Wait render (ms)", statsSampler.getWaitRenderMs(), count, offset, graphWidth, graphHeight,
-          true);
-      drawBgfxGraph(5, "Draw calls", statsSampler.getDrawCalls(), count, offset, graphWidth, graphHeight, false);
-      drawBgfxGraph(6, "GPU memory (MB)", statsSampler.getGpuMemoryMb(), count, offset, graphWidth, graphHeight, false);
-    }
-
-    if (ImGui.collapsingHeader("Submission", ImGuiTreeNodeFlags.DefaultOpen)) {
-      drawStatRow("Draw calls", stats.numDraw());
-      drawStatRow("Peak draw calls", stats.numDrawCallsPeak());
-      drawStatRow("Compute calls", stats.numCompute());
-      drawStatRow("Blit calls", stats.numBlit());
-      drawStatRow("Triangles", stats.numPrims(BGFX.BGFX_TOPOLOGY_TRI_LIST));
-      drawStatRow("Views", stats.numViews());
-      drawStatRow("Encoders", stats.numEncoders());
-      drawStatRow("GPU latency", stats.maxGpuLatency());
-    }
-
-    if (ImGui.collapsingHeader("Timing", ImGuiTreeNodeFlags.DefaultOpen)) {
-      drawStatRow("CPU frame (ms)", (float) (stats.cpuTimeFrame() * cpuToMs));
-      drawStatRow("CPU submit (ms)", (float) ((stats.cpuTimeEnd() - stats.cpuTimeBegin()) * cpuToMs));
-      if (gpuToMs > 0.0) {
-        drawStatRow("GPU (ms)", (float) ((stats.gpuTimeEnd() - stats.gpuTimeBegin()) * gpuToMs));
+    if (ImGui.collapsingHeader("Core", ImGuiTreeNodeFlags.DefaultOpen)) {
+      if (count == 0) {
+        text(COLOR_HINT, "Collecting samples...");
       } else {
-        text(COLOR_KEY, "GPU (ms)");
+        perfScaleMaxFps = Math.max(ringMax(getPerfFps(), count) * 1.15f, perfScaleMaxFps * 0.997f);
+        perfScaleMaxFrameMs = Math.max(ringMax(getPerfFrameMs(), count) * 1.15f, perfScaleMaxFrameMs * 0.997f);
+        perfScaleMaxRenderCalls = Math.max(ringMax(getPerfRenderCalls(), count) * 1.15f, perfScaleMaxRenderCalls * 0.997f);
+
+        text(COLOR_KEY, "FPS");
         ImGui.sameLine();
-        text(COLOR_VALUE, "n/a");
+        text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfFps()))));
+        ImGui.plotLines("##fps", getPerfFps(), count, offset, "", 0f, perfScaleMaxFps, graphWidth, graphHeight);
+
+        text(COLOR_KEY, "Frame (ms)");
+        ImGui.sameLine();
+        text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfFrameMs())));
+        ImGui.plotLines("##frame", getPerfFrameMs(), count, offset, "", 0f, perfScaleMaxFrameMs, graphWidth, graphHeight);
+
+        text(COLOR_KEY, "Draw calls");
+        ImGui.sameLine();
+        text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfRenderCalls()))));
+        ImGui.plotLines("##rendercalls", getPerfRenderCalls(), count, offset, "", 0f, perfScaleMaxRenderCalls, graphWidth,
+            graphHeight);
       }
-      drawStatRow("Wait submit (ms)", (float) (stats.waitSubmit() * cpuToMs));
-      drawStatRow("Wait render (ms)", (float) (stats.waitRender() * cpuToMs));
     }
 
-    if (ImGui.collapsingHeader("Memory", ImGuiTreeNodeFlags.DefaultOpen)) {
-      drawByteRow("GPU memory used", stats.gpuMemoryUsed());
-      drawByteRow("GPU memory max", stats.gpuMemoryMax());
-      drawByteRow("Texture memory", stats.textureMemoryUsed());
-      drawByteRow("Render target memory", stats.rtMemoryUsed());
-      drawStatRow("Transient VB (KB)", stats.transientVbUsed() / 1024);
-      drawStatRow("Transient IB (KB)", stats.transientIbUsed() / 1024);
+    if (ImGui.collapsingHeader("Memory")) {
+      if (count > 0) {
+        perfScaleMaxHeapMb = Math.max(ringMax(getPerfHeapMb(), count) * 1.15f, perfScaleMaxHeapMb * 0.997f);
+        perfScaleMaxNativeMb = Math.max(ringMax(getPerfNativeMb(), count) * 1.15f, perfScaleMaxNativeMb * 0.997f);
+
+        text(COLOR_KEY, "Heap (MB)");
+        ImGui.sameLine();
+        text(COLOR_VALUE, formatOneDecimal(latestSample(getPerfHeapMb())));
+        ImGui.plotLines("##heap", getPerfHeapMb(), count, offset, "", 0f, perfScaleMaxHeapMb, graphWidth, graphHeight);
+
+        float nativePeek = latestSample(getPerfNativeMb());
+        if (nativePeek > 0f) {
+          text(COLOR_KEY, "Native (MB)");
+          ImGui.sameLine();
+          text(COLOR_VALUE, formatOneDecimal(nativePeek));
+          ImGui.plotLines("##native", getPerfNativeMb(), count, offset, "", 0f, perfScaleMaxNativeMb, graphWidth,
+              graphHeight);
+        }
+      }
+      if (bgfxCount > 0) {
+        drawBgfxGraph(4, "GPU (MB)", statsSampler.getGpuMemoryMb(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall,
+            false);
+      }
+      if (stats != null) {
+        ImGui.separator();
+        drawByteRow("GPU memory used", stats.gpuMemoryUsed());
+        drawByteRow("GPU memory max", stats.gpuMemoryMax());
+        drawByteRow("Texture memory", stats.textureMemoryUsed());
+        drawByteRow("Render target memory", stats.rtMemoryUsed());
+        drawStatRow("Transient VB (KB)", stats.transientVbUsed() / 1024);
+        drawStatRow("Transient IB (KB)", stats.transientIbUsed() / 1024);
+      }
     }
 
-    if (ImGui.collapsingHeader("Resources")) {
-      drawStatRow("Textures", stats.numTextures());
-      drawStatRow("Shaders", stats.numShaders());
-      drawStatRow("Programs", stats.numPrograms());
-      drawStatRow("Uniforms", stats.numUniforms());
-      drawStatRow("Frame buffers", stats.numFrameBuffers());
-      drawStatRow("Vertex buffers", stats.numVertexBuffers());
-      drawStatRow("Index buffers", stats.numIndexBuffers());
-      drawStatRow("Dynamic VB", stats.numDynamicVertexBuffers());
-      drawStatRow("Dynamic IB", stats.numDynamicIndexBuffers());
+    if (ImGui.collapsingHeader("GPU Timing")) {
+      if (bgfxCount == 0) {
+        text(COLOR_HINT, "Collecting samples...");
+      } else {
+        drawBgfxGraph(0, "CPU submit (ms)", statsSampler.getCpuSubmitMs(), bgfxCount, bgfxOffset, graphWidth,
+            graphHeightSmall, true);
+        drawBgfxGraph(1, "GPU (ms)", statsSampler.getGpuMs(), bgfxCount, bgfxOffset, graphWidth, graphHeightSmall, true);
+        drawBgfxGraph(2, "Wait submit (ms)", statsSampler.getWaitSubmitMs(), bgfxCount, bgfxOffset, graphWidth,
+            graphHeightSmall, true);
+        drawBgfxGraph(3, "Wait render (ms)", statsSampler.getWaitRenderMs(), bgfxCount, bgfxOffset, graphWidth,
+            graphHeightSmall, true);
+      }
+      if (stats != null) {
+        ImGui.separator();
+        drawStatRow("CPU frame (ms)", (float) (stats.cpuTimeFrame() * cpuToMs));
+        drawStatRow("CPU submit (ms)", (float) ((stats.cpuTimeEnd() - stats.cpuTimeBegin()) * cpuToMs));
+        if (gpuToMs > 0.0) {
+          drawStatRow("GPU (ms)", (float) ((stats.gpuTimeEnd() - stats.gpuTimeBegin()) * gpuToMs));
+        } else {
+          text(COLOR_KEY, "GPU (ms)");
+          ImGui.sameLine();
+          text(COLOR_VALUE, "n/a");
+        }
+        drawStatRow("Wait submit (ms)", (float) (stats.waitSubmit() * cpuToMs));
+        drawStatRow("Wait render (ms)", (float) (stats.waitRender() * cpuToMs));
+      }
     }
+
+    if (stats != null) {
+      if (ImGui.collapsingHeader("Submission")) {
+        drawStatRow("Peak draw calls", stats.numDrawCallsPeak());
+        drawStatRow("Compute calls", stats.numCompute());
+        drawStatRow("Blit calls", stats.numBlit());
+        drawStatRow("Triangles", stats.numPrims(BGFX.BGFX_TOPOLOGY_TRI_LIST));
+        drawStatRow("Views", stats.numViews());
+        drawStatRow("Encoders", stats.numEncoders());
+        drawStatRow("GPU latency", stats.maxGpuLatency());
+      }
+      if (ImGui.collapsingHeader("Resources")) {
+        drawStatRow("Textures", stats.numTextures());
+        drawStatRow("Shaders", stats.numShaders());
+        drawStatRow("Programs", stats.numPrograms());
+        drawStatRow("Uniforms", stats.numUniforms());
+        drawStatRow("Frame buffers", stats.numFrameBuffers());
+        drawStatRow("Vertex buffers", stats.numVertexBuffers());
+        drawStatRow("Index buffers", stats.numIndexBuffers());
+        drawStatRow("Dynamic VB", stats.numDynamicVertexBuffers());
+        drawStatRow("Dynamic IB", stats.numDynamicIndexBuffers());
+      }
+    }
+
     ImGui.end();
   }
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -547,6 +547,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     imguiInitialized = true;
     imguiInput.setActive(isVisible());
     forceRefreshOnNextUpdate();
+    setOverlayUpdateRate(overlayUpdateRate);
   }
 
   /** Applies the red-themed Dear ImGui style, replacing the default blue accents. */

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -39,6 +39,7 @@ import org.lwjgl.bgfx.BGFXStats;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 import imgui.ImFontAtlas;
 import imgui.ImGui;
@@ -68,8 +69,7 @@ import imgui.type.ImString;
  *
  * <p>{@code FlixelDesktopLauncher} registers this class as the default debug overlay factory when
  * launching in {@link org.flixelgdx.backend.FlixelRuntimeMode#DEBUG DEBUG} mode. You can also
- * register it manually with {@link Flixel#setDebugOverlay(java.util.function.Supplier)} before the
- * game starts.
+ * register it manually with {@link Flixel#setDebugOverlay(Supplier)} before the game starts.
  *
  * <p>Initialization (creating the Dear ImGui context, uploading the font atlas as a bgfx texture, and
  * registering the SDL input listener) happens lazily on the first {@link #draw()} call, so
@@ -88,7 +88,7 @@ import imgui.type.ImString;
  *
  * <h2>Extending the overlay</h2>
  *
- * <p>Because Dear ImGui is exposed as an api dependency, games can add their own panels by
+ * <p>Because Dear ImGui is exposed as an API dependency, games can add their own panels by
  * subclassing this overlay and overriding {@link #onDrawImGui()}; any standard {@code ImGui.*} call is
  * valid there.
  */
@@ -1010,7 +1010,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   }
 
   /**
-   * Draws one labelled bgfx graph with a live value readout.
+   * Draws one labeled bgfx graph with a live value readout.
    *
    * @param index The per-series scale slot (0 to {@link #BGFX_GRAPH_COUNT} - 1).
    * @param label The row label.

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiKeyMap.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiKeyMap.java
@@ -1,0 +1,147 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.desktop.debug;
+
+import org.flixelgdx.input.keyboard.FlixelKey;
+
+import imgui.flag.ImGuiKey;
+
+/**
+ * Translates FlixelGDX {@link FlixelKey} codes into Dear ImGui {@link ImGuiKey} codes.
+ *
+ * <p>The desktop runner already turns SDL scancodes into FlixelGDX key codes for the game's input
+ * layer, so the debug overlay's ImGui platform backend reuses those instead of parsing SDL a second
+ * time: it just needs to know which ImGui key each FlixelGDX key corresponds to. ImGui uses these
+ * codes to drive keyboard navigation and text-field editing (arrows, Home/End, Backspace, and so on);
+ * printable characters arrive separately as text-input events.
+ *
+ * <p>The lookup is a plain {@code int[]} indexed by FlixelGDX key code, filled once when the class
+ * loads, so each translation is a single bounds-checked array read that never allocates. Unmapped
+ * keys resolve to {@link ImGuiKey#None}.
+ */
+public final class FlixelImGuiKeyMap {
+
+  /** FlixelKey-to-ImGuiKey table. Unmapped entries stay {@link ImGuiKey#None} (the array default). */
+  private static final int[] TABLE = new int[512];
+
+  static {
+    // Letters, number-row digits, and numpad digits are contiguous in both key spaces, so they map
+    // in order; everything else is listed explicitly.
+    for (int i = 0; i < 26; i++) {
+      put(FlixelKey.A + i, ImGuiKey.A + i);
+    }
+    for (int i = 0; i < 10; i++) {
+      put(FlixelKey.NUM_0 + i, ImGuiKey._0 + i);
+      put(FlixelKey.NUMPAD_0 + i, ImGuiKey.Keypad0 + i);
+    }
+
+    put(FlixelKey.F1, ImGuiKey.F1);
+    put(FlixelKey.F2, ImGuiKey.F2);
+    put(FlixelKey.F3, ImGuiKey.F3);
+    put(FlixelKey.F4, ImGuiKey.F4);
+    put(FlixelKey.F5, ImGuiKey.F5);
+    put(FlixelKey.F6, ImGuiKey.F6);
+    put(FlixelKey.F7, ImGuiKey.F7);
+    put(FlixelKey.F8, ImGuiKey.F8);
+    put(FlixelKey.F9, ImGuiKey.F9);
+    put(FlixelKey.F10, ImGuiKey.F10);
+    put(FlixelKey.F11, ImGuiKey.F11);
+    put(FlixelKey.F12, ImGuiKey.F12);
+
+    put(FlixelKey.ENTER, ImGuiKey.Enter);
+    put(FlixelKey.ESCAPE, ImGuiKey.Escape);
+    put(FlixelKey.BACKSPACE, ImGuiKey.Backspace);
+    put(FlixelKey.TAB, ImGuiKey.Tab);
+    put(FlixelKey.SPACE, ImGuiKey.Space);
+
+    put(FlixelKey.LEFT, ImGuiKey.LeftArrow);
+    put(FlixelKey.RIGHT, ImGuiKey.RightArrow);
+    put(FlixelKey.UP, ImGuiKey.UpArrow);
+    put(FlixelKey.DOWN, ImGuiKey.DownArrow);
+
+    put(FlixelKey.INSERT, ImGuiKey.Insert);
+    put(FlixelKey.FORWARD_DEL, ImGuiKey.Delete);
+    put(FlixelKey.HOME, ImGuiKey.Home);
+    put(FlixelKey.END, ImGuiKey.End);
+    put(FlixelKey.PAGE_UP, ImGuiKey.PageUp);
+    put(FlixelKey.PAGE_DOWN, ImGuiKey.PageDown);
+
+    put(FlixelKey.MINUS, ImGuiKey.Minus);
+    put(FlixelKey.EQUALS, ImGuiKey.Equal);
+    put(FlixelKey.LEFT_BRACKET, ImGuiKey.LeftBracket);
+    put(FlixelKey.RIGHT_BRACKET, ImGuiKey.RightBracket);
+    put(FlixelKey.BACKSLASH, ImGuiKey.Backslash);
+    put(FlixelKey.SEMICOLON, ImGuiKey.Semicolon);
+    put(FlixelKey.APOSTROPHE, ImGuiKey.Apostrophe);
+    put(FlixelKey.GRAVE, ImGuiKey.GraveAccent);
+    put(FlixelKey.COMMA, ImGuiKey.Comma);
+    put(FlixelKey.PERIOD, ImGuiKey.Period);
+    put(FlixelKey.SLASH, ImGuiKey.Slash);
+
+    put(FlixelKey.CAPS_LOCK, ImGuiKey.CapsLock);
+    put(FlixelKey.SCROLL_LOCK, ImGuiKey.ScrollLock);
+    put(FlixelKey.NUM_LOCK, ImGuiKey.NumLock);
+    put(FlixelKey.PRINT_SCREEN, ImGuiKey.PrintScreen);
+    put(FlixelKey.PAUSE, ImGuiKey.Pause);
+    put(FlixelKey.MENU, ImGuiKey.Menu);
+
+    put(FlixelKey.CONTROL_LEFT, ImGuiKey.LeftCtrl);
+    put(FlixelKey.CONTROL_RIGHT, ImGuiKey.RightCtrl);
+    put(FlixelKey.SHIFT_LEFT, ImGuiKey.LeftShift);
+    put(FlixelKey.SHIFT_RIGHT, ImGuiKey.RightShift);
+    put(FlixelKey.ALT_LEFT, ImGuiKey.LeftAlt);
+    put(FlixelKey.ALT_RIGHT, ImGuiKey.RightAlt);
+    put(FlixelKey.SYM, ImGuiKey.LeftSuper);
+
+    put(FlixelKey.NUMPAD_DIVIDE, ImGuiKey.KeypadDivide);
+    put(FlixelKey.NUMPAD_MULTIPLY, ImGuiKey.KeypadMultiply);
+    put(FlixelKey.NUMPAD_SUBTRACT, ImGuiKey.KeypadSubtract);
+    put(FlixelKey.NUMPAD_ADD, ImGuiKey.KeypadAdd);
+    put(FlixelKey.NUMPAD_ENTER, ImGuiKey.KeypadEnter);
+    put(FlixelKey.NUMPAD_DOT, ImGuiKey.KeypadDecimal);
+    put(FlixelKey.NUMPAD_EQUALS, ImGuiKey.KeypadEqual);
+  }
+
+  private FlixelImGuiKeyMap() {}
+
+  /**
+   * Translates a FlixelGDX key code into its Dear ImGui key code.
+   *
+   * @param flixelKey The {@link FlixelKey} code to translate.
+   * @return The matching {@link ImGuiKey} code, or {@link ImGuiKey#None} if the key is unmapped.
+   */
+  public static int toImGuiKey(int flixelKey) {
+    if (flixelKey < 0 || flixelKey >= TABLE.length) {
+      return ImGuiKey.None;
+    }
+    return TABLE[flixelKey];
+  }
+
+  /** Records a FlixelKey-to-ImGuiKey entry, ignoring out-of-range codes so loading never fails. */
+  private static void put(int flixelKey, int imGuiKey) {
+    if (flixelKey >= 0 && flixelKey < TABLE.length) {
+      TABLE[flixelKey] = imGuiKey;
+    }
+  }
+}

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiSdlInput.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiSdlInput.java
@@ -1,0 +1,237 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.desktop.debug;
+
+import org.flixelgdx.input.FlixelKeyboardListener;
+import org.flixelgdx.input.FlixelMouseListener;
+import org.flixelgdx.input.keyboard.FlixelKey;
+
+import imgui.ImGui;
+import imgui.ImGuiIO;
+import imgui.flag.ImGuiKey;
+
+/**
+ * Feeds SDL3 input into Dear ImGui: the platform backend for the desktop debug overlay.
+ *
+ * <p>Dear ImGui does not read the keyboard or mouse itself; a platform backend has to push events
+ * into its {@link ImGuiIO} each frame. imgui-java ships a GLFW backend, but this project runs on
+ * SDL3, so this class bridges the two. Rather than parse SDL events a second time, it registers as a
+ * {@link FlixelKeyboardListener} and {@link FlixelMouseListener} on the desktop input device and
+ * receives the same translated events the game's input layer does. Printable characters arrive
+ * through {@link #keyTyped(char)} (driven by SDL text-input events), which is what makes the debug
+ * command line typeable.
+ *
+ * <p>All forwarding is gated on {@link #setActive(boolean)}. The overlay marks the backend active
+ * only while the Dear ImGui context exists and the overlay is visible, so events are never pushed
+ * into a destroyed context, and keys typed while the overlay is hidden do not queue up and flush into
+ * a text field the next time it opens.
+ */
+public final class FlixelImGuiSdlInput implements FlixelKeyboardListener, FlixelMouseListener {
+
+  private boolean active;
+  private boolean ctrlLeft;
+  private boolean ctrlRight;
+  private boolean shiftLeft;
+  private boolean shiftRight;
+  private boolean altLeft;
+  private boolean altRight;
+  private boolean superDown;
+
+  /**
+   * Enables or disables event forwarding. When disabled, any queued Dear ImGui input is cleared so a
+   * later frame does not replay stale keys or mouse state.
+   *
+   * @param active {@code true} while the Dear ImGui context exists and the overlay is visible.
+   */
+  public void setActive(boolean active) {
+    if (this.active == active) {
+      return;
+    }
+    this.active = active;
+    if (!active) {
+      clearInput();
+    }
+  }
+
+  /**
+   * Updates Dear ImGui's per-frame display size and delta time. Call once each frame, before
+   * {@code ImGui.newFrame()}.
+   *
+   * @param width The current back buffer width in pixels.
+   * @param height The current back buffer height in pixels.
+   * @param deltaSeconds The real elapsed time since the previous frame, in seconds.
+   */
+  public void newFrame(int width, int height, float deltaSeconds) {
+    ImGuiIO io = ImGui.getIO();
+    io.setDisplaySize(width, height);
+    io.setDisplayFramebufferScale(1f, 1f);
+    io.setDeltaTime(deltaSeconds > 0f ? deltaSeconds : 1f / 60f);
+  }
+
+  @Override
+  public boolean keyDown(int keycode) {
+    if (active) {
+      int imKey = FlixelImGuiKeyMap.toImGuiKey(keycode);
+      if (imKey != ImGuiKey.None) {
+        ImGui.getIO().addKeyEvent(imKey, true);
+      }
+      if (updateModifierState(keycode, true)) {
+        syncModifiers();
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean keyUp(int keycode) {
+    if (active) {
+      int imKey = FlixelImGuiKeyMap.toImGuiKey(keycode);
+      if (imKey != ImGuiKey.None) {
+        ImGui.getIO().addKeyEvent(imKey, false);
+      }
+      if (updateModifierState(keycode, false)) {
+        syncModifiers();
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean keyTyped(char character) {
+    // SDL text-input events only deliver actual text, never control keys, so every character here is
+    // safe to hand straight to the focused Dear ImGui widget.
+    if (active && character != 0) {
+      ImGui.getIO().addInputCharacter(character);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean mouseDown(int button, int x, int y) {
+    if (active) {
+      ImGuiIO io = ImGui.getIO();
+      io.addMousePosEvent(x, y);
+      if (button >= 0 && button <= 4) {
+        io.addMouseButtonEvent(button, true);
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean mouseUp(int button, int x, int y) {
+    if (active) {
+      ImGuiIO io = ImGui.getIO();
+      io.addMousePosEvent(x, y);
+      if (button >= 0 && button <= 4) {
+        io.addMouseButtonEvent(button, false);
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean mouseMoved(int x, int y) {
+    if (active) {
+      ImGui.getIO().addMousePosEvent(x, y);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean mouseDragged(int x, int y) {
+    if (active) {
+      ImGui.getIO().addMousePosEvent(x, y);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean scrolled(float amountX, float amountY) {
+    // SDL and Dear ImGui agree on wheel signs (positive y scrolls up, positive x scrolls right), so
+    // the amounts pass through unchanged.
+    if (active) {
+      ImGui.getIO().addMouseWheelEvent(amountX, amountY);
+    }
+    return false;
+  }
+
+  /**
+   * Clears Dear ImGui's queued keyboard and mouse input, resetting the tracked modifier state.
+   *
+   * <p>Only ever runs on an active-to-inactive transition, which the overlay always performs while
+   * the Dear ImGui context is still alive (it deactivates before destroying the context), so the IO
+   * calls here are safe.
+   */
+  private void clearInput() {
+    ctrlLeft = false;
+    ctrlRight = false;
+    shiftLeft = false;
+    shiftRight = false;
+    altLeft = false;
+    altRight = false;
+    superDown = false;
+    ImGuiIO io = ImGui.getIO();
+    io.clearInputKeys();
+    io.clearInputMouse();
+    io.clearEventsQueue();
+  }
+
+  /**
+   * Records a modifier key's pressed state.
+   *
+   * @param flixelKey The key that changed.
+   * @param down Whether it was pressed ({@code true}) or released ({@code false}).
+   * @return {@code true} if the key was a modifier, so the aggregate modifier flags should be resent.
+   */
+  private boolean updateModifierState(int flixelKey, boolean down) {
+    if (flixelKey == FlixelKey.CONTROL_LEFT) {
+      ctrlLeft = down;
+    } else if (flixelKey == FlixelKey.CONTROL_RIGHT) {
+      ctrlRight = down;
+    } else if (flixelKey == FlixelKey.SHIFT_LEFT) {
+      shiftLeft = down;
+    } else if (flixelKey == FlixelKey.SHIFT_RIGHT) {
+      shiftRight = down;
+    } else if (flixelKey == FlixelKey.ALT_LEFT) {
+      altLeft = down;
+    } else if (flixelKey == FlixelKey.ALT_RIGHT) {
+      altRight = down;
+    } else if (flixelKey == FlixelKey.SYM) {
+      superDown = down;
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  /** Resends the four aggregate modifier flags (Ctrl, Shift, Alt, Super) to Dear ImGui. */
+  private void syncModifiers() {
+    ImGuiIO io = ImGui.getIO();
+    io.addKeyEvent(ImGuiKey.ModCtrl, ctrlLeft || ctrlRight);
+    io.addKeyEvent(ImGuiKey.ModShift, shiftLeft || shiftRight);
+    io.addKeyEvent(ImGuiKey.ModAlt, altLeft || altRight);
+    io.addKeyEvent(ImGuiKey.ModSuper, superDown);
+  }
+}

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
@@ -163,6 +163,17 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
   @Nullable
   private FlixelBgfxTexture opaqueAlphaTexture;
 
+  /**
+   * Cached wrapper around bgfx's internal per-frame stats struct.
+   *
+   * <p>{@code bgfx_get_stats()} always returns a pointer to the same struct, which bgfx updates in
+   * place every frame; only the Java wrapper LWJGL builds around that pointer is new each call. The
+   * wrapper is therefore created once (see {@link #getBgfxStats()}) and reused, so reading stats
+   * every frame for the debug overlay never allocates.
+   */
+  @Nullable
+  private BGFXStats bgfxStats;
+
   /** Reused ortho matrix for the final upscale blit, rebuilt each composite to match the window. */
   @NotNull
   private final FlixelMatrix compositeOrtho = new FlixelMatrix();
@@ -383,7 +394,7 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
       return;
     }
 
-    BGFXStats stats = BGFX.bgfx_get_stats();
+    BGFXStats stats = getBgfxStats();
     double windowFps = statsWindowFrames * 1_000_000_000.0 / statsWindowNanos;
     statsWindowNanos = 0L;
     statsWindowFrames = 0;
@@ -725,6 +736,75 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
   @Override
   public int getFps() {
     return (int) averageFps;
+  }
+
+  /**
+   * Returns the cached {@link BGFXStats} wrapper, creating it on first use.
+   *
+   * <p>The returned object points directly at bgfx's internal stats struct, so every field reflects
+   * the most recently completed frame without another native call or allocation. Callers must not
+   * hold onto stale copies of individual values across frames if they need live data; re-read the
+   * fields instead. Returns {@code null} only if bgfx has not been initialized yet.
+   *
+   * @return The shared, live-updating bgfx stats wrapper, or {@code null} before bgfx is ready.
+   */
+  @Nullable
+  public BGFXStats getBgfxStats() {
+    if (bgfxStats == null) {
+      bgfxStats = BGFX.bgfx_get_stats();
+    }
+    return bgfxStats;
+  }
+
+  /**
+   * The compiled sprite shader program, or {@code -1} when none is available.
+   *
+   * <p>Exposed so the desktop debug overlay's ImGui renderer can reuse the exact same program the
+   * sprite batch uses. The ImGui vertex format (position, texture coordinate, packed color) is
+   * identical to the sprite layout and the sprite fragment shader already outputs
+   * {@code texture * vertexColor}, which is what ImGui needs, so no separate shader is required.
+   *
+   * @return The bgfx sprite program handle, or {@code -1} if the shaders were not bundled.
+   */
+  public short getSpriteProgram() {
+    return spriteProgram;
+  }
+
+  /**
+   * The sampler uniform ({@code s_texture}) the sprite program reads its texture from.
+   *
+   * <p>Shared with the debug overlay's ImGui renderer so it can bind the font atlas and inspected
+   * textures through the same uniform the sprite pipeline uses.
+   *
+   * @return The bgfx sampler uniform handle, or {@code -1} if it was not created.
+   */
+  public short getTextureUniform() {
+    return textureUniform;
+  }
+
+  /**
+   * Reserves a fresh, top-most on-screen bgfx view bound to the back buffer for the debug overlay to
+   * draw into, and returns its id.
+   *
+   * <p>bgfx submits views in ascending id order, so handing out the next screen view id makes the
+   * overlay draw over everything the game rendered this frame. The caller sets the view transform
+   * and submits its own draws; this only allocates the view, points it at the whole back buffer, and
+   * selects sequential submission mode so the overlay's draw order is preserved.
+   *
+   * @return The bgfx view id the overlay should submit its draws into.
+   */
+  public int beginOverlayView() {
+    int view = nextScreenView;
+    if (nextScreenView < MAX_SCREEN_VIEWS - 1) {
+      nextScreenView++;
+    }
+    viewStack[0] = view;
+    viewStackDepth = 1;
+    BGFX.bgfx_set_view_frame_buffer(view, (short) -1);
+    BGFX.bgfx_set_view_mode(view, BGFX.BGFX_VIEW_MODE_SEQUENTIAL);
+    BGFX.bgfx_set_view_rect(view, 0, 0, Math.max(1, backBufferWidth), Math.max(1, backBufferHeight));
+    BGFX.bgfx_set_view_clear(view, BGFX.BGFX_CLEAR_NONE, 0, 1f, 0);
+    return view;
   }
 
   /** Directs subsequent submissions into a render target's framebuffer via a fresh view. */

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
@@ -804,6 +804,7 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
     BGFX.bgfx_set_view_mode(view, BGFX.BGFX_VIEW_MODE_SEQUENTIAL);
     BGFX.bgfx_set_view_rect(view, 0, 0, Math.max(1, backBufferWidth), Math.max(1, backBufferHeight));
     BGFX.bgfx_set_view_clear(view, BGFX.BGFX_CLEAR_NONE, 0, 1f, 0);
+    BGFX.bgfx_touch(view);
     return view;
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "8.7.3"
 asm = "9.7.1"
 desugarJdkLibs = "2.1.5"
 graalvm = "24.2.0"
+imgui = "1.90.0"
 jansi = "2.4.2"
 jetbrainsAnnotations = "26.1.0"
 junit = "5.10.0"
@@ -19,6 +20,10 @@ asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 graalvm-nativeimage = { module = "org.graalvm.sdk:nativeimage", version.ref = "graalvm" }
+imgui-binding = { module = "io.github.spair:imgui-java-binding", version.ref = "imgui" }
+imgui-natives-linux = { module = "io.github.spair:imgui-java-natives-linux", version.ref = "imgui" }
+imgui-natives-macos = { module = "io.github.spair:imgui-java-natives-macos", version.ref = "imgui" }
+imgui-natives-windows = { module = "io.github.spair:imgui-java-natives-windows", version.ref = "imgui" }
 jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrainsAnnotations" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }


### PR DESCRIPTION
## Description

The debug overlay was the last piece of the desktop backend still tied to the old libGDX + `imgui-gl3` stack. This brings it back on the new **bgfx + SDL3** backend, reimplemented from the `v0.5.1` `FlixelImGuiDebugOverlay` so it keeps the same feel (rolling graphs, dockable panels, red theme, command line, texture inspector) while running entirely on our own rendering and input path.

Dear ImGui still powers it, via the SpaiR `imgui-java` binding, but only the **core binding** is used. Since we no longer have libGDX (and never had GLFW), imgui-java's bundled GLFW/OpenGL backends do not apply, so this PR adds two small custom backends:

- **`FlixelImGuiBgfxRenderer`** turns ImGui draw data into bgfx transient geometry. The ImGui vertex format is identical to the sprite batch's, and the sprite fragment shader already outputs `texture * vertexColor`, so it reuses the existing sprite program instead of compiling a dedicated ImGui shader for every backend. Colors are swizzled to BGRA only on the non-GL backends that need it.
- **`FlixelImGuiSdlInput`** registers as a framework input listener and forwards mouse, keyboard, and text events into ImGui, so there is no coupling between the runner and the overlay. The runner now also pumps `SDL_EVENT_TEXT_INPUT` (previously unhandled), which is what makes the command line typeable.

### Highlights

- **Every bgfx stat is surfaced** in a new "Render (bgfx)" panel: rolling graphs for CPU frame/submit time, GPU time, submit/render waits, draw calls, and VRAM; plus live rows for peak draw calls, triangles, view/encoder counts, GPU memory used/max, texture and render-target memory, transient buffer usage, and every GPU resource count.
- **`bgfx_get_stats()` no longer allocates per frame.** It returns a pointer to the same struct each frame, so the `BGFXStats` wrapper is now created once and reused (the whole stats panel is allocation-free).
- **Runtime mode is chosen by a JVM flag.** `FlixelDesktopLauncher.launch(game)` reads `-Dflixel.mode=debug|test` (default release), so a Gradle `debug` run task enables the overlay and shipped builds simply run without the flag: nothing to remember to strip before publishing.

Web is intentionally left for later, as discussed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Verified locally: `:flixelgdx-desktop:compileJava`, `spotlessCheck`, and `javadoc` all pass, and the full `flixelgdx-test` suite is green (506 tests, 0 failures).

The overlay itself needs a live GPU and window (a bgfx context), so it cannot be exercised by the headless unit-test suite; it is meant to be verified interactively. In the test project's `lwjgl3` module, run `./gradlew :lwjgl3:debug` (added alongside `runTest`) to launch the game with the overlay enabled and confirm the panels, graphs, command line, and picker.

> Note on docs: the README already documents `FlixelImGuiDebugOverlay` by name (the class name is unchanged, only its package moved to the desktop backend), and the overlay ships with thorough Javadoc, so no Markdown changes were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
