### PR TITLE
Added monitor reading support to the framework 

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelCrashHandler.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelCrashHandler.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.backend;
 
+import org.flixelgdx.FlixelGame;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  * TeaVM a backend would additionally wire into {@code window.onerror} to catch JavaScript-level
  * exceptions that bypass the Java exception system.
  *
- * <p>The handler itself is supplied by {@link org.flixelgdx.FlixelGame} during {@code create()}.
+ * <p>The handler itself is supplied by {@link FlixelGame} during {@code create()}.
  * It performs the standard framework crash response: logging the exception, showing an error alert,
  * tearing down game resources, and exiting the process on platforms where that is allowed.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
@@ -171,6 +171,13 @@ public interface FlixelHostIntegration {
   }
 
   /**
+   * @return {@code true} if monitor information is supported or allowed on this platform.
+   */
+  default boolean supportsMonitors() {
+    return false;
+  }
+
+  /**
    * Signal dispatched when {@link #pasteFromClipboard()} resolves with text content.
    *
    * <p>The dispatched value is the pasted text. Handlers may be called off the game thread.
@@ -211,6 +218,18 @@ public interface FlixelHostIntegration {
   default FlixelMonitor getPrimaryMonitor() {
     return FlixelNoopMonitor.INSTANCE;
   }
+
+  /**
+   * Prompts the user to grant permission for obtaining monitor information for this origin.
+   *
+   * <p>On the web backend this triggers the browser permission dialog. It must be called in
+   * response to a user gesture (button press, key press, etc.) or the browser will silently
+   * ignore it. If granted, {@link #getMonitors()} returns a real list of all the monitors that
+   * are connected to the user's computer; otherwise, it returns empty.
+   *
+   * <p>On desktop, permission is implicit and this method does nothing.
+   */
+  default void requestMonitorPermission() {}
 
   /**
    * Returns the platform this game is running on.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
@@ -84,6 +84,18 @@ public interface FlixelHostIntegration {
   default void requestNotificationPermission() {}
 
   /**
+   * Prompts the user to grant permission for obtaining monitor information for this origin.
+   *
+   * <p>On the web backend this triggers the browser permission dialog. It must be called in
+   * response to a user gesture (button press, key press, etc.) or the browser will silently
+   * ignore it. If granted, {@link #getMonitors()} returns a real list of all the monitors that
+   * are connected to the user's computer; otherwise, it returns empty.
+   *
+   * <p>On desktop, permission is implicit and this method does nothing.
+   */
+  default void requestMonitorPermission() {}
+
+  /**
    * Asks the window manager to highlight this app (taskbar entry flash, dock bounce, and similar).
    *
    * <p>On the web backend, this flashes the browser tab title while the tab is in the background.
@@ -218,18 +230,6 @@ public interface FlixelHostIntegration {
   default FlixelMonitor getPrimaryMonitor() {
     return FlixelNoopMonitor.INSTANCE;
   }
-
-  /**
-   * Prompts the user to grant permission for obtaining monitor information for this origin.
-   *
-   * <p>On the web backend this triggers the browser permission dialog. It must be called in
-   * response to a user gesture (button press, key press, etc.) or the browser will silently
-   * ignore it. If granted, {@link #getMonitors()} returns a real list of all the monitors that
-   * are connected to the user's computer; otherwise, it returns empty.
-   *
-   * <p>On desktop, permission is implicit and this method does nothing.
-   */
-  default void requestMonitorPermission() {}
 
   /**
    * Returns the platform this game is running on.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelMonitor.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelMonitor.java
@@ -73,9 +73,9 @@ public interface FlixelMonitor {
   int getHeight();
 
   /**
-   * @return The monitor's refresh rate in hertz, or {@code 0} when the platform cannot report it.
+   * @return The monitor's refresh rate in hertz, or {@code 0.0f} when the platform cannot report it.
    */
-  int getRefreshRate();
+  float getRefreshRate();
 
   /**
    * @return {@code true} if this is the primary monitor, where the OS typically places new windows

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopRuntimeDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopRuntimeDevice.java
@@ -28,6 +28,8 @@ import org.flixelgdx.logging.FlixelStackTraceProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 /**
  * Default {@link FlixelRuntimeDevice} used before a backend is installed and on platforms that do
  * not report memory or classpath layout (such as web targets).
@@ -45,6 +47,8 @@ public enum FlixelNoopRuntimeDevice implements FlixelRuntimeDevice {
   private FlixelRuntimeMode runtimeMode = FlixelRuntimeMode.RELEASE;
   private FlixelStackTraceProvider stackTraceProvider = FlixelNoopStackTraceProvider.INSTANCE;
 
+  private boolean runtimeModeSet = false;
+
   @Override
   @NotNull
   public FlixelRuntimeMode getMode() {
@@ -53,8 +57,12 @@ public enum FlixelNoopRuntimeDevice implements FlixelRuntimeDevice {
 
   @Override
   public void setMode(@NotNull FlixelRuntimeMode mode) {
-    if (mode != null) {
-      this.runtimeMode = mode;
+    Objects.requireNonNull(runtimeMode, "The provided runtime mode cannot be null.");
+    if (!runtimeModeSet) {
+      runtimeMode = mode;
+      runtimeModeSet = true;
+    } else {
+      throw new RuntimeException("The runtime mode has already been set, it cannot be changed.");
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelPlatform.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelPlatform.java
@@ -63,7 +63,7 @@ public final class FlixelPlatform {
   public static final FlixelPlatform Desktop = of("Desktop");
 
   /** A web browser. */
-  public static final FlixelPlatform Web = of("Web");
+  public static final FlixelPlatform HTML5 = of("HTML5");
 
   /** An Android mobile device. */
   public static final FlixelPlatform Android = of("Android");

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopHostIntegration.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopHostIntegration.java
@@ -25,6 +25,7 @@ package org.flixelgdx.backend.desktop;
 
 import org.flixelgdx.backend.FlixelHostIntegration;
 import org.flixelgdx.backend.FlixelMonitor;
+import org.flixelgdx.backend.FlixelNoopMonitor;
 import org.flixelgdx.backend.FlixelPlatform;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelList;
@@ -123,6 +124,19 @@ public class FlixelDesktopHostIntegration implements FlixelHostIntegration {
   @Override
   public FlixelList<FlixelMonitor> getMonitors() {
     return monitors;
+  }
+
+  @Override
+  public @NotNull FlixelMonitor getPrimaryMonitor() {
+    for (FlixelMonitor monitor : monitors) {
+      if (monitor.isPrimary()) {
+        return monitor;
+      }
+    }
+    if (!monitors.isEmpty()) {
+      return monitors.get(0);
+    }
+    return FlixelNoopMonitor.INSTANCE;
   }
 
   @NotNull

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopHostIntegration.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopHostIntegration.java
@@ -53,10 +53,12 @@ public class FlixelDesktopHostIntegration implements FlixelHostIntegration {
    * that convention, assuring no unexpected crashes happen.
    */
   public static final int MAX_NOTIFY_ARG_LEN = 6000;
+
+  final FlixelArray<FlixelMonitor> monitors = new FlixelArray<>(FlixelMonitor[]::new);
+
   private static final String OS = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
 
   private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
-  private final FlixelArray<FlixelMonitor> monitors = new FlixelArray<>(FlixelMonitor[]::new);
 
   @Override
   public void sendNotification(@Nullable String title, @NotNull String message) {

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopLauncher.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopLauncher.java
@@ -160,12 +160,12 @@ public final class FlixelDesktopLauncher {
     // Flixel.gamepads and Flixel.mouse are created inside Flixel.start, so wire their desktop
     // implementations once they exist, just before the runner takes over the loop.
     Flixel.boot.afterStart(() -> {
+      Flixel.debug.setOverlayFactory(FlixelImGuiDebugOverlay::new);
       Flixel.gamepads.setGamepadProvider(gamepads);
       Flixel.gamepads.addMappingResolver(gamepads);
       Flixel.mouse.setMouseIconManager(iconManager);
     });
 
-    Flixel.debug.setOverlayFactory(FlixelImGuiDebugOverlay::new);
     Flixel.runtime.setMode(runtimeMode);
 
     try {

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopLauncher.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopLauncher.java
@@ -130,6 +130,7 @@ public final class FlixelDesktopLauncher {
     }
 
     FlixelSdlWindow window = new FlixelSdlWindow();
+    FlixelDesktopHostIntegration host = new FlixelDesktopHostIntegration();
     FlixelDesktopInputDevice input = new FlixelDesktopInputDevice();
     FlixelBgfxGraphics graphics = new FlixelBgfxGraphics();
     FlixelSdlGamepadProvider gamepads = new FlixelSdlGamepadProvider();
@@ -139,14 +140,15 @@ public final class FlixelDesktopLauncher {
 
     Flixel.alert = new FlixelDesktopAlerter();
     Flixel.window = window;
-    Flixel.host = new FlixelDesktopHostIntegration();
+    Flixel.host = host;
     Flixel.files = new FlixelJvmFiles();
     Flixel.input = input;
     Flixel.graphics = graphics;
     Flixel.runtime.setStackTraceProvider(new FlixelJvmStackTraceProvider());
     Flixel.log.logFileHandler = new FlixelJvmLogFileHandler();
     FlixelSoundManager.defaultFactory = FlixelMiniAudioFactory.create();
-    FlixelGameRunner runner = new FlixelDesktopRunner(window, input, graphics, gamepads, iconManager, width, height);
+    FlixelGameRunner runner = new FlixelDesktopRunner(window, input, graphics, gamepads,
+        iconManager, host, width, height);
 
     FlixelJvmAssetManager assets = new FlixelJvmAssetManager();
     assets.registerLoader(".ktx2", new FlixelKtx2Loader());

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -39,7 +39,9 @@ import org.lwjgl.sdl.SDLInit;
 import org.lwjgl.sdl.SDLKeyboard;
 import org.lwjgl.sdl.SDLMouse;
 import org.lwjgl.sdl.SDLVideo;
+import org.lwjgl.sdl.SDL_DisplayMode;
 import org.lwjgl.sdl.SDL_Event;
+import org.lwjgl.sdl.SDL_Rect;
 import org.lwjgl.system.MemoryStack;
 
 import java.nio.IntBuffer;
@@ -81,6 +83,9 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
   @NotNull
   private final FlixelSdlMouseIconManager iconManager;
 
+  @NotNull
+  private final FlixelDesktopHostIntegration host;
+
   private int width;
   private int height;
 
@@ -99,12 +104,13 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
    */
   public FlixelDesktopRunner(@NotNull FlixelSdlWindow window, @NotNull FlixelDesktopInputDevice input,
       @NotNull FlixelBgfxGraphics graphics, @NotNull FlixelSdlGamepadProvider gamepads,
-      @NotNull FlixelSdlMouseIconManager iconManager, int width, int height) {
+      @NotNull FlixelSdlMouseIconManager iconManager, FlixelDesktopHostIntegration host, int width, int height) {
     this.window = window;
     this.input = input;
     this.graphics = graphics;
     this.gamepads = gamepads;
     this.iconManager = iconManager;
+    this.host = host;
     this.width = width;
     this.height = height;
   }
@@ -372,6 +378,10 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
           input.onScrolled(event.wheel().x(), event.wheel().y());
         case SDLEvents.SDL_EVENT_GAMEPAD_ADDED -> gamepads.onDeviceAdded(event.gdevice().which());
         case SDLEvents.SDL_EVENT_GAMEPAD_REMOVED -> gamepads.onDeviceRemoved(event.gdevice().which());
+        case SDLEvents.SDL_EVENT_DISPLAY_ADDED,
+             SDLEvents.SDL_EVENT_DISPLAY_REMOVED,
+             SDLEvents.SDL_EVENT_DISPLAY_MOVED,
+             SDLEvents.SDL_EVENT_DISPLAY_CURRENT_MODE_CHANGED -> refreshMonitors();
         default -> {
         }
       }
@@ -392,7 +402,7 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
   }
 
   /** Maps an SDL mouse button (1=left, 2=middle, 3=right) to the framework's 0-based index. */
-  private static int mouseButton(int sdlButton) {
+  private int mouseButton(int sdlButton) {
     if (sdlButton == SDLMouse.SDL_BUTTON_LEFT) {
       return 0;
     }
@@ -403,6 +413,38 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
       return 2;
     }
     return Math.max(0, sdlButton - 1);
+  }
+
+  private void refreshMonitors() {
+    try (MemoryStack stack = MemoryStack.stackPush()) {
+      host.monitors.clear();
+
+      IntBuffer countBuf = stack.mallocInt(1);
+      IntBuffer displaysBuf = SDLVideo.SDL_GetDisplays();
+
+      if (displaysBuf != null) {
+        int count = countBuf.get(0);
+        int primaryId = SDLVideo.SDL_GetPrimaryDisplay();
+
+        for (int i = 0; i < count; i++) {
+          int displayId = displaysBuf.get(i);
+          String name = SDLVideo.SDL_GetDisplayName(displayId);
+          boolean isPrimary = (displayId == primaryId);
+
+          SDL_Rect bounds = SDL_Rect.malloc(stack);
+          SDLVideo.SDL_GetDisplayBounds(displayId, bounds);
+
+          SDL_DisplayMode mode = SDLVideo.SDL_GetCurrentDisplayMode(displayId);
+          float refreshRate = mode != null ? mode.refresh_rate() : 0.0f;
+
+          FlixelSdlMonitor monitor = new FlixelSdlMonitor(name, bounds.x(), bounds.y(), bounds.w(), bounds.h(),
+              refreshRate, isPrimary);
+          host.monitors.add(monitor);
+        }
+
+        
+      }
+    }
   }
 
   @NotNull
@@ -428,6 +470,11 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
   @NotNull
   public FlixelSdlMouseIconManager getIconManager() {
     return iconManager;
+  }
+
+  @NotNull
+  public FlixelDesktopHostIntegration getHost() {
+    return host;
   }
 
   public int getWidth() {

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -171,6 +171,7 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
       SDLKeyboard.SDL_StartTextInput(windowHandle);
     }
 
+    refreshMonitors(); // Fill in the monitors at startup.
     game.create();
 
     long lastNanos = System.nanoTime();
@@ -181,6 +182,8 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
           break;
         }
 
+        // TODO: Find a workaround for allowing the game to tick the update loop
+        // while stopping rendering as well.
         if (!window.isContinuousRendering() && !window.consumeRenderRequest()) {
           Thread.yield();
           continue;
@@ -420,14 +423,13 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
     try (MemoryStack stack = MemoryStack.stackPush()) {
       host.monitors.clear();
 
-      IntBuffer countBuf = stack.mallocInt(1);
       IntBuffer displaysBuf = SDLVideo.SDL_GetDisplays();
 
       if (displaysBuf != null) {
-        int count = countBuf.get(0);
+        int monitorCount = displaysBuf.limit();
         int primaryId = SDLVideo.SDL_GetPrimaryDisplay();
 
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < monitorCount; i++) {
           int displayId = displaysBuf.get(i);
           String name = SDLVideo.SDL_GetDisplayName(displayId);
           boolean isPrimary = (displayId == primaryId);

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -379,9 +379,10 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
         case SDLEvents.SDL_EVENT_GAMEPAD_ADDED -> gamepads.onDeviceAdded(event.gdevice().which());
         case SDLEvents.SDL_EVENT_GAMEPAD_REMOVED -> gamepads.onDeviceRemoved(event.gdevice().which());
         case SDLEvents.SDL_EVENT_DISPLAY_ADDED,
-             SDLEvents.SDL_EVENT_DISPLAY_REMOVED,
-             SDLEvents.SDL_EVENT_DISPLAY_MOVED,
-             SDLEvents.SDL_EVENT_DISPLAY_CURRENT_MODE_CHANGED -> refreshMonitors();
+            SDLEvents.SDL_EVENT_DISPLAY_REMOVED,
+            SDLEvents.SDL_EVENT_DISPLAY_MOVED,
+            SDLEvents.SDL_EVENT_DISPLAY_CURRENT_MODE_CHANGED ->
+          refreshMonitors();
         default -> {
         }
       }
@@ -442,7 +443,6 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
           host.monitors.add(monitor);
         }
 
-        
       }
     }
   }

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -91,20 +91,10 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
 
   private boolean vsync = true;
 
-  /**
-   * Creates a runner wired to the desktop backend objects the launcher installed.
-   *
-   * @param window The window wrapper to bind to the created SDL window.
-   * @param input The input device to feed SDL events into.
-   * @param graphics The bgfx graphics manager to initialize.
-   * @param gamepads The gamepad provider to open devices on and feed connect events into.
-   * @param iconManager The SDL cursor manager to dispose before SDL shuts down.
-   * @param width The initial window width in pixels.
-   * @param height The initial window height in pixels.
-   */
   public FlixelDesktopRunner(@NotNull FlixelSdlWindow window, @NotNull FlixelDesktopInputDevice input,
       @NotNull FlixelBgfxGraphics graphics, @NotNull FlixelSdlGamepadProvider gamepads,
-      @NotNull FlixelSdlMouseIconManager iconManager, FlixelDesktopHostIntegration host, int width, int height) {
+      @NotNull FlixelSdlMouseIconManager iconManager, @NotNull FlixelDesktopHostIntegration host,
+      int width, int height) {
     this.window = window;
     this.input = input;
     this.graphics = graphics;

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -431,7 +431,7 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
           float refreshRate = mode != null ? mode.refresh_rate() : 0.0f;
 
           FlixelSdlMonitor monitor = new FlixelSdlMonitor(name != null ? name : "Unknown", bounds.x(), bounds.y(),
-            bounds.w(), bounds.h(), refreshRate, isPrimary);
+              bounds.w(), bounds.h(), refreshRate, isPrimary);
           host.monitors.add(monitor);
         }
       }

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopRunner.java
@@ -438,11 +438,10 @@ public class FlixelDesktopRunner implements FlixelGameRunner {
           SDL_DisplayMode mode = SDLVideo.SDL_GetCurrentDisplayMode(displayId);
           float refreshRate = mode != null ? mode.refresh_rate() : 0.0f;
 
-          FlixelSdlMonitor monitor = new FlixelSdlMonitor(name, bounds.x(), bounds.y(), bounds.w(), bounds.h(),
-              refreshRate, isPrimary);
+          FlixelSdlMonitor monitor = new FlixelSdlMonitor(name != null ? name : "Unknown", bounds.x(), bounds.y(),
+            bounds.w(), bounds.h(), refreshRate, isPrimary);
           host.monitors.add(monitor);
         }
-
       }
     }
   }

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlMonitor.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlMonitor.java
@@ -27,11 +27,13 @@ import org.flixelgdx.backend.FlixelMonitor;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A monitor display, instantiated whenever SDL receives a monitor refresh event.
+ * A data container for a monitor display, instantiated whenever SDL receives a monitor
+ * refresh event.
  *
  * <p>You shouldn't create a new object of this class manually. This class is only used when
- * the {@link FlixelDesktopRunner} inside of the events handler receives any {@code DISPLAY_*}
- * events. You're better off pulling the current monitors held inside of {@link FlixelDesktopHostIntegration}.
+ * the {@link FlixelDesktopRunner} inside of the events handler receives any SDL {@code DISPLAY_*}
+ * events. You're better off pulling the current monitors held inside of {@link FlixelDesktopHostIntegration},
+ * which is much more reliable.
  */
 class FlixelSdlMonitor implements FlixelMonitor {
 
@@ -42,7 +44,6 @@ class FlixelSdlMonitor implements FlixelMonitor {
   final int virtualY;
   final int width;
   final int height;
-
   final float refreshRate;
 
   final boolean isPrimary;

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlMonitor.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlMonitor.java
@@ -21,55 +21,71 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.flixelgdx.backend;
+package org.flixelgdx.backend.desktop;
 
+import org.flixelgdx.backend.FlixelMonitor;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Safe placeholder {@link FlixelMonitor} for platforms that cannot report a real display.
- *
- * <p>Returning this instead of {@code null} means game code that reads the current monitor never
- * has to null-check and never crashes on web, mobile, or headless targets. Every value is neutral:
- * an empty name, a zero position, a zero size, and not primary.
+ * A monitor display, instantiated whenever SDL receives a monitor refresh event.
  */
-public enum FlixelNoopMonitor implements FlixelMonitor {
+class FlixelSdlMonitor implements FlixelMonitor {
 
-  /** Shared no-op instance. */
-  INSTANCE;
+  @NotNull
+  final String name;
+
+  final int virtualX;
+  final int virtualY;
+  final int width;
+  final int height;
+
+  final float refreshRate;
+
+  final boolean isPrimary;
+
+  FlixelSdlMonitor(@NotNull String name, int virtualX, int virtualY, int width, int height,
+      float refreshRate, boolean isPrimary) {
+    this.name = name;
+    this.virtualX = virtualX;
+    this.virtualY = virtualY;
+    this.width = width;
+    this.height = height;
+    this.refreshRate = refreshRate;
+    this.isPrimary = isPrimary;
+  }
 
   @Override
-  @NotNull
-  public String getName() {
-    return "";
+  public @NotNull String getName() {
+    return name;
   }
 
   @Override
   public int getVirtualX() {
-    return 0;
+    return virtualX;
   }
 
   @Override
   public int getVirtualY() {
-    return 0;
+    return virtualY;
   }
 
   @Override
   public int getWidth() {
-    return 0;
+    return width;
   }
 
   @Override
   public int getHeight() {
-    return 0;
+    return height;
   }
 
   @Override
   public float getRefreshRate() {
-    return 0.0f;
+    return refreshRate;
   }
 
   @Override
   public boolean isPrimary() {
-    return false;
+    return isPrimary;
   }
 }

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlMonitor.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlMonitor.java
@@ -28,6 +28,10 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * A monitor display, instantiated whenever SDL receives a monitor refresh event.
+ *
+ * <p>You shouldn't create a new object of this class manually. This class is only used when
+ * the {@link FlixelDesktopRunner} inside of the events handler receives any {@code DISPLAY_*}
+ * events. You're better off pulling the current monitors held inside of {@link FlixelDesktopHostIntegration}.
  */
 class FlixelSdlMonitor implements FlixelMonitor {
 

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
@@ -71,7 +71,12 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
 
   @Override
   public void requestMonitorPermission() {
-    FlixelHtml5MonitorHelper.requestScreenDetails(this::updateMonitors);
+    // Since requestScreenDetails(...) registers a 'screenschange' callback on the
+    // JavaScript side, we have a guard here to ensure the same callback doesn't get
+    // added twice and cause issues.
+    if (!FlixelHtml5MonitorHelper.isWindowManagementSupported()) {
+      FlixelHtml5MonitorHelper.requestScreenDetails(this::updateMonitors);
+    }
   }
 
   @Override
@@ -169,7 +174,7 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
    * @param screens The JavaScript array of the user's connected monitors. May be {@code null} if
    *     {@link FlixelHostIntegration#supportsMonitors()} returns {@code false}.
    */
-  public void updateMonitors(@Nullable JSArray<FlixelHtml5MonitorHelper.JSScreenDetailed> screens) {
+  public void updateMonitors(@Nullable JSArray<FlixelHtml5MonitorHelper.JSScreen> screens) {
     monitors.clear();
 
     if (screens == null) {
@@ -177,7 +182,7 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
     }
 
     for (int i = 0; i < screens.getLength(); i++) {
-      FlixelHtml5MonitorHelper.JSScreenDetailed screen = screens.get(i);
+      FlixelHtml5MonitorHelper.JSScreen screen = screens.get(i);
       FlixelHtml5Monitor monitor = new FlixelHtml5Monitor(screen.getLabel(), screen.getLeft(), screen.getTop(),
         screen.getWidth(), screen.getHeight(), screen.isPrimary());
       monitors.add(monitor);

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
@@ -132,7 +132,7 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
   @Override
   @NotNull
   public FlixelPlatform getPlatform() {
-    return FlixelPlatform.Web;
+    return FlixelPlatform.HTML5;
   }
 
   @JSBody(script = "if (typeof Notification !== 'undefined') { Notification.requestPermission(); }")

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
@@ -184,7 +184,7 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
     for (int i = 0; i < screens.getLength(); i++) {
       FlixelHtml5MonitorHelper.JSScreen screen = screens.get(i);
       FlixelHtml5Monitor monitor = new FlixelHtml5Monitor(screen.getLabel(), screen.getLeft(), screen.getTop(),
-        screen.getWidth(), screen.getHeight(), screen.isPrimary());
+          screen.getWidth(), screen.getHeight(), screen.isPrimary());
       monitors.add(monitor);
     }
   }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5HostIntegration.java
@@ -25,6 +25,7 @@ package org.flixelgdx.backend.html5;
 
 import org.flixelgdx.backend.FlixelHostIntegration;
 import org.flixelgdx.backend.FlixelMonitor;
+import org.flixelgdx.backend.FlixelNoopMonitor;
 import org.flixelgdx.backend.FlixelPlatform;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelList;
@@ -34,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.JSFunctor;
 import org.teavm.jso.JSObject;
+import org.teavm.jso.core.JSArray;
 
 /**
  * Web host integration: the bridge between the game and the browser environment it runs in.
@@ -52,10 +54,10 @@ import org.teavm.jso.JSObject;
 public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
 
   @NotNull
-  private final FlixelSignal<String> textPasted = new FlixelSignal<>();
+  final FlixelArray<FlixelMonitor> monitors = new FlixelArray<>();
 
   @NotNull
-  private final FlixelArray<FlixelMonitor> monitors = new FlixelArray<>();
+  private final FlixelSignal<String> textPasted = new FlixelSignal<>();
 
   @Override
   public void requestNotificationPermission() {
@@ -65,6 +67,11 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
   @Override
   public void requestAttention() {
     flashTitle();
+  }
+
+  @Override
+  public void requestMonitorPermission() {
+    FlixelHtml5MonitorHelper.requestScreenDetails(this::updateMonitors);
   }
 
   @Override
@@ -118,6 +125,11 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
   }
 
   @Override
+  public boolean supportsMonitors() {
+    return FlixelHtml5MonitorHelper.isWindowManagementSupported() && !monitors.isEmpty();
+  }
+
+  @Override
   @NotNull
   public FlixelSignal<String> onTextPasted() {
     return textPasted;
@@ -130,9 +142,46 @@ public class FlixelHtml5HostIntegration implements FlixelHostIntegration {
   }
 
   @Override
+  public @NotNull FlixelMonitor getPrimaryMonitor() {
+    for (FlixelMonitor monitor : monitors) {
+      if (monitor.isPrimary()) {
+        return monitor;
+      }
+    }
+    if (!monitors.isEmpty()) {
+      return monitors.get(0);
+    }
+    return FlixelNoopMonitor.INSTANCE;
+  }
+
+  @Override
   @NotNull
   public FlixelPlatform getPlatform() {
     return FlixelPlatform.HTML5;
+  }
+
+  /**
+   * Updates the current {@link #monitors} array from the provided JavaScript array.
+   *
+   * <p>This is primarily meant to be used for {@link FlixelHtml5MonitorHelper#requestScreenDetails},
+   * although you may find it useful for other purposes.
+   *
+   * @param screens The JavaScript array of the user's connected monitors. May be {@code null} if
+   *     {@link FlixelHostIntegration#supportsMonitors()} returns {@code false}.
+   */
+  public void updateMonitors(@Nullable JSArray<FlixelHtml5MonitorHelper.JSScreenDetailed> screens) {
+    monitors.clear();
+
+    if (screens == null) {
+      return;
+    }
+
+    for (int i = 0; i < screens.getLength(); i++) {
+      FlixelHtml5MonitorHelper.JSScreenDetailed screen = screens.get(i);
+      FlixelHtml5Monitor monitor = new FlixelHtml5Monitor(screen.getLabel(), screen.getLeft(), screen.getTop(),
+        screen.getWidth(), screen.getHeight(), screen.isPrimary());
+      monitors.add(monitor);
+    }
   }
 
   @JSBody(script = "if (typeof Notification !== 'undefined') { Notification.requestPermission(); }")

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Launcher.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Launcher.java
@@ -84,12 +84,13 @@ public final class FlixelHtml5Launcher {
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode) {
     FlixelHtml5Graphics graphics = new FlixelHtml5Graphics();
     FlixelHtml5Window window = new FlixelHtml5Window();
+    FlixelHtml5HostIntegration host = new FlixelHtml5HostIntegration();
     FlixelHtml5InputDevice input = new FlixelHtml5InputDevice();
     FlixelHtml5GamepadProvider gamepads = new FlixelHtml5GamepadProvider();
 
     Flixel.alert = new FlixelHtml5Alerter();
     Flixel.window = window;
-    Flixel.host = new FlixelHtml5HostIntegration();
+    Flixel.host = host;
     Flixel.runtime = new FlixelHtml5RuntimeDevice();
     Flixel.files = new FlixelHtml5Files();
     Flixel.input = input;
@@ -110,7 +111,7 @@ public final class FlixelHtml5Launcher {
     Flixel.runtime.setMode(runtimeMode);
 
     FlixelGameRunner runner = new FlixelHtml5Runner(CANVAS_ID, game.getInitialWidth(), game.getInitialHeight(),
-        graphics, window, input);
+        graphics, window, host, input);
     Flixel.start(game, runner);
   }
 

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Monitor.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Monitor.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.html5;
+
+import org.flixelgdx.backend.FlixelMonitor;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The HTML5 representation of a computer monitor, using provided information from the native
+ * Window Management API.
+ *
+ * <p>Do not create objects of this class directly. It's advised you handle monitors through the
+ * {@link FlixelHtml5HostIntegration} class instead, as monitor information is much more accurate
+ * through that API.
+ *
+ * <p>Note that due to an API limitation and security restrictions, there's no way to obtain the
+ * refresh rate of a monitor. Because of this, {@link #getRefreshRate()} returns {@code 0.0f}.
+ */
+class FlixelHtml5Monitor implements FlixelMonitor {
+
+  @NotNull
+  final String name;
+
+  final int virtualX;
+  final int virtualY;
+  final int width;
+  final int height;
+  final boolean isPrimary;
+
+  FlixelHtml5Monitor(@NotNull String name, int virtualX, int virtualY, int width, int height, boolean isPrimary) {
+    this.name = name;
+    this.virtualX = virtualX;
+    this.virtualY = virtualY;
+    this.width = width;
+    this.height = height;
+    this.isPrimary = isPrimary;
+  }
+
+  @Override
+  public @NotNull String getName() {
+    return name;
+  }
+
+  @Override
+  public int getVirtualX() {
+    return virtualX;
+  }
+
+  @Override
+  public int getVirtualY() {
+    return virtualY;
+  }
+
+  @Override
+  public int getWidth() {
+    return width;
+  }
+
+  @Override
+  public int getHeight() {
+    return height;
+  }
+
+  @Override
+  public float getRefreshRate() {
+    return 0.0f;
+  }
+
+  @Override
+  public boolean isPrimary() {
+    return isPrimary;
+  }
+}

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Monitor.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Monitor.java
@@ -46,6 +46,7 @@ class FlixelHtml5Monitor implements FlixelMonitor {
   final int virtualY;
   final int width;
   final int height;
+
   final boolean isPrimary;
 
   FlixelHtml5Monitor(@NotNull String name, int virtualX, int virtualY, int width, int height, boolean isPrimary) {

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
@@ -107,7 +107,6 @@ public final class FlixelHtml5MonitorHelper {
         details.addEventListener('screenschange', () => callback(details.screens));
       }).catch(err => {
         callback(null);
-      });"""
-  )
+      });""")
   public static native void requestScreenDetails(MonitorUpdateCallback callback);
 }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
@@ -1,6 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.flixelgdx.backend.html5;
 
 import org.teavm.jso.JSBody;
+import org.teavm.jso.JSFunctor;
 import org.teavm.jso.JSObject;
 import org.teavm.jso.JSProperty;
 import org.teavm.jso.core.JSArray;
@@ -12,31 +36,25 @@ public final class FlixelHtml5MonitorHelper {
 
   private FlixelHtml5MonitorHelper() {}
 
-  @JSBody(params = { "callback" }, script = """
-      if (!window.getScreenDetails) {
-        callback(null);
-        return;
-      }
-      window.getScreenDetails().then(details => {
-        callback(details.screens);
-        details.addEventListener('screenschange', () => callback(details.screens));
-      }).catch(err => {
-        callback(null);
-      });"""
-  )
-  public static native void requestScreenDetails(MonitorUpdateCallback callback);
-
-  public interface MonitorUpdateCallback {
-    void onUpdate(JSArray<JSScreenDetailed> screens);
+  /**
+   * Callback that gets executed whenever JavaScript triggers a {@code 'screenschange'} event.
+   *
+   * @see #requestScreenDetails
+   */
+  @JSFunctor
+  public interface MonitorUpdateCallback extends JSObject {
+    void onUpdate(JSArray<JSScreen> screens);
   }
 
-  public interface JSWindowManagement extends JSObject {
-
-    @JSProperty
-    JSArray<JSScreenDetailed> getScreens(); // Maps to screenDetails.screens
-  }
-
-  public interface JSScreenDetailed extends JSObject {
+  /**
+   * JavaScript data container which holds information of a computer monitor.
+   *
+   * <p>This is primarily used in {@link MonitorUpdateCallback} inside of a TeaVM {@link JSArray}.
+   *
+   * @see MonitorUpdateCallback
+   * @see #requestScreenDetails
+   */
+  public interface JSScreen extends JSObject {
 
     @JSProperty
     String getLabel();
@@ -57,6 +75,39 @@ public final class FlixelHtml5MonitorHelper {
     boolean isPrimary();
   }
 
+  /**
+   * Native function that returns if the Window Management API is allowed to be used on the
+   * JavaScript side.
+   *
+   * @return If the browser's native Window Management API is available.
+   */
   @JSBody(script = "return typeof window !== 'undefined' && 'getScreenDetails' in window;")
   public static native boolean isWindowManagementSupported();
+
+  /**
+   * Sends a browser request to the user for permission to have access to window management.
+   *
+   * <p>This is primarily used by {@link FlixelHtml5HostIntegration#requestMonitorPermission()}
+   * and inside {@link FlixelHtml5Runner} during the boot sequence (aka during startup). It is
+   * incredibly important to note that this method should be called only <b>once</b>, as it registers
+   * a {@code 'screenschange'} callback on the JavaScript side, which automatically updates the
+   * monitors list that {@link FlixelHtml5HostIntegration} uses.
+   *
+   * @param callback The {@link MonitorUpdateCallback} that will be used when JavaScript
+   *     triggers a {@code 'screenschange'} callback.
+   * @author stringdotjar
+   */
+  @JSBody(params = { "callback" }, script = """
+      if (!window.getScreenDetails) {
+        callback(null);
+        return;
+      }
+      window.getScreenDetails().then(details => {
+        callback(details.screens);
+        details.addEventListener('screenschange', () => callback(details.screens));
+      }).catch(err => {
+        callback(null);
+      });"""
+  )
+  public static native void requestScreenDetails(MonitorUpdateCallback callback);
 }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
@@ -76,16 +76,17 @@ public final class FlixelHtml5MonitorHelper {
   }
 
   /**
-   * Native function that returns if the Window Management API is allowed to be used on the
-   * JavaScript side.
+   * Native function that returns {@code true} if the Window Management API is allowed to be
+   * used on the JavaScript side.
    *
-   * @return If the browser's native Window Management API is available.
+   * @return {@code true} if the browser's native Window Management API is available or
+   *     allowed to be used.
    */
   @JSBody(script = "return typeof window !== 'undefined' && 'getScreenDetails' in window;")
   public static native boolean isWindowManagementSupported();
 
   /**
-   * Sends a browser request to the user for permission to have access to window management.
+   * Sends a browser request to the user for permission to interact with their monitors.
    *
    * <p>This is primarily used by {@link FlixelHtml5HostIntegration#requestMonitorPermission()}
    * and inside {@link FlixelHtml5Runner} during the boot sequence (aka during startup). It is

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
@@ -95,7 +95,7 @@ public final class FlixelHtml5MonitorHelper {
    * monitors list that {@link FlixelHtml5HostIntegration} uses.
    *
    * @param callback The {@link MonitorUpdateCallback} that will be used when JavaScript
-   *     triggers a {@code 'screenschange'} callback.
+   *     triggers a {@code 'screenschange'} event.
    */
   @JSBody(params = { "callback" }, script = """
       if (!window.getScreenDetails) {

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
@@ -1,0 +1,62 @@
+package org.flixelgdx.backend.html5;
+
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.JSProperty;
+import org.teavm.jso.core.JSArray;
+
+/**
+ * Helper class for interacting with the browser's native Window Management API.
+ */
+public final class FlixelHtml5MonitorHelper {
+
+  private FlixelHtml5MonitorHelper() {}
+
+  @JSBody(params = { "callback" }, script = """
+      if (!window.getScreenDetails) {
+        callback(null);
+        return;
+      }
+      window.getScreenDetails().then(details => {
+        callback(details.screens);
+        details.addEventListener('screenschange', () => callback(details.screens));
+      }).catch(err => {
+        callback(null);
+      });"""
+  )
+  public static native void requestScreenDetails(MonitorUpdateCallback callback);
+
+  public interface MonitorUpdateCallback {
+    void onUpdate(JSArray<JSScreenDetailed> screens);
+  }
+
+  public interface JSWindowManagement extends JSObject {
+
+    @JSProperty
+    JSArray<JSScreenDetailed> getScreens(); // Maps to screenDetails.screens
+  }
+
+  public interface JSScreenDetailed extends JSObject {
+
+    @JSProperty
+    String getLabel();
+
+    @JSProperty
+    int getWidth();
+
+    @JSProperty
+    int getHeight();
+
+    @JSProperty
+    int getLeft();
+
+    @JSProperty
+    int getTop();
+
+    @JSProperty(value = "isPrimary")
+    boolean isPrimary();
+  }
+
+  @JSBody(script = "return typeof window !== 'undefined' && 'getScreenDetails' in window;")
+  public static native boolean isWindowManagementSupported();
+}

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5MonitorHelper.java
@@ -95,7 +95,6 @@ public final class FlixelHtml5MonitorHelper {
    *
    * @param callback The {@link MonitorUpdateCallback} that will be used when JavaScript
    *     triggers a {@code 'screenschange'} callback.
-   * @author stringdotjar
    */
   @JSBody(params = { "callback" }, script = """
       if (!window.getScreenDetails) {

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -32,10 +32,7 @@ import org.flixelgdx.backend.html5.graphics.FlixelHtml5Graphics;
 import org.flixelgdx.backend.html5.input.FlixelHtml5InputDevice;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
-import org.teavm.jso.JSObject;
-import org.teavm.jso.JSProperty;
 import org.teavm.jso.browser.Window;
-import org.teavm.jso.core.JSArray;
 import org.teavm.jso.dom.html.HTMLCanvasElement;
 import org.teavm.jso.dom.html.HTMLDocument;
 
@@ -80,7 +77,8 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
   private FlixelGame game;
 
   public FlixelHtml5Runner(@NotNull String canvasId, int width, int height, @NotNull FlixelHtml5Graphics graphics,
-      @NotNull FlixelHtml5Window window, @NotNull FlixelHtml5HostIntegration host, @NotNull FlixelHtml5InputDevice input) {
+      @NotNull FlixelHtml5Window window, @NotNull FlixelHtml5HostIntegration host,
+      @NotNull FlixelHtml5InputDevice input) {
     this.canvasId = canvasId;
     this.width = width;
     this.height = height;

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -104,6 +104,7 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
 
     registerLifecycleListeners(document);
 
+    // Fill in the monitor list at startup if the user granted permission before.
     if (FlixelHtml5MonitorHelper.isWindowManagementSupported()) {
       FlixelHtml5MonitorHelper.requestScreenDetails(host::updateMonitors);
     }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -32,7 +32,10 @@ import org.flixelgdx.backend.html5.graphics.FlixelHtml5Graphics;
 import org.flixelgdx.backend.html5.input.FlixelHtml5InputDevice;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.JSProperty;
 import org.teavm.jso.browser.Window;
+import org.teavm.jso.core.JSArray;
 import org.teavm.jso.dom.html.HTMLCanvasElement;
 import org.teavm.jso.dom.html.HTMLDocument;
 
@@ -65,6 +68,9 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
   private final FlixelHtml5InputDevice input;
 
   @NotNull
+  private final FlixelHtml5HostIntegration host;
+
+  @NotNull
   private final String canvasId;
 
   private final int width;
@@ -74,12 +80,13 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
   private FlixelGame game;
 
   public FlixelHtml5Runner(@NotNull String canvasId, int width, int height, @NotNull FlixelHtml5Graphics graphics,
-      @NotNull FlixelHtml5Window window, @NotNull FlixelHtml5InputDevice input) {
+      @NotNull FlixelHtml5Window window, @NotNull FlixelHtml5HostIntegration host, @NotNull FlixelHtml5InputDevice input) {
     this.canvasId = canvasId;
     this.width = width;
     this.height = height;
     this.graphics = graphics;
     this.window = window;
+    this.host = host;
     this.input = input;
   }
 
@@ -98,6 +105,10 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
     graphics.initialize(element);
 
     registerLifecycleListeners(document);
+
+    if (FlixelHtml5MonitorHelper.isWindowManagementSupported()) {
+      FlixelHtml5MonitorHelper.requestScreenDetails(host::updateMonitors);
+    }
 
     // The browser cannot read files synchronously, so every bundled asset is downloaded first and
     // the game only starts once the cache is warm. See FlixelHtml5AssetPreloader.
@@ -122,9 +133,9 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
    */
   private static void onPreloadFailed() {
     Flixel.error("Html5",
-        "Asset preloading failed. Check the browser console for details. Common causes: the "
-            + "'assets/assets.txt' manifest is missing (make sure the org.flixelgdx.html5 plugin "
-            + "is applied), or a non-image asset could not be downloaded. The game will not start.");
+        "Asset preloading failed. Common causes: the 'assets/assets.txt' manifest is missing "
+            + "(make sure the org.flixelgdx.html5 plugin is applied), or a non-image asset could not be "
+            + "downloaded. The game will not start.");
     showLoadingError("Failed to load game assets. See the console for details.");
   }
 

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -25,7 +25,11 @@ package org.flixelgdx.backend.html5;
 
 import org.flixelgdx.backend.FlixelRunEnvironment;
 import org.flixelgdx.backend.FlixelRuntimeDevice;
+import org.flixelgdx.backend.FlixelRuntimeMode;
+import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
+
+import java.util.Objects;
 
 /**
  * Reports what a browser can tell a game about the machine it runs on, which is very little.
@@ -38,6 +42,10 @@ import org.teavm.jso.JSBody;
  */
 public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
 
+  private FlixelRuntimeMode mode = FlixelRuntimeMode.RELEASE;
+
+  private boolean runtimeModeSet = false;
+
   @Override
   public long getJavaHeap() {
     return usedHeapBytes();
@@ -46,6 +54,22 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
   @Override
   public FlixelRunEnvironment getEnvironment() {
     return FlixelRunEnvironment.BROWSER;
+  }
+
+  @Override
+  public @NotNull FlixelRuntimeMode getMode() {
+    return mode;
+  }
+
+  @Override
+  public void setMode(@NotNull FlixelRuntimeMode mode) {
+    Objects.requireNonNull(mode, "The provided runtime mode cannot be null.");
+    if (!runtimeModeSet) {
+      this.mode = mode;
+      runtimeModeSet = true;
+    } else {
+      throw new RuntimeException("The runtime mode has already been set, it cannot be changed.");
+    }
   }
 
   @JSBody(script = """

--- a/flixelgdx-jvm/src/main/java/org/flixelgdx/backend/jvm/runtime/FlixelJvmRuntimeDevice.java
+++ b/flixelgdx-jvm/src/main/java/org/flixelgdx/backend/jvm/runtime/FlixelJvmRuntimeDevice.java
@@ -26,6 +26,7 @@ package org.flixelgdx.backend.jvm.runtime;
 import org.flixelgdx.backend.FlixelCrashHandler;
 import org.flixelgdx.backend.FlixelRunEnvironment;
 import org.flixelgdx.backend.FlixelRuntimeDevice;
+import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +35,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.jar.JarFile;
 
 /**
@@ -42,6 +44,10 @@ import java.util.jar.JarFile;
  * targets.
  */
 public class FlixelJvmRuntimeDevice implements FlixelRuntimeDevice {
+
+  private FlixelRuntimeMode mode = FlixelRuntimeMode.RELEASE;
+
+  private boolean runtimeModeSet = false;
 
   @Override
   public long getJavaHeap() {
@@ -172,8 +178,24 @@ public class FlixelJvmRuntimeDevice implements FlixelRuntimeDevice {
   }
 
   @Override
+  public @NotNull FlixelRuntimeMode getMode() {
+    return mode;
+  }
+
+  @Override
+  public void setMode(@NotNull FlixelRuntimeMode mode) {
+    Objects.requireNonNull(mode, "The provided runtime mode cannot be null.");
+    if (!runtimeModeSet) {
+      this.mode = mode;
+      runtimeModeSet = true;
+    } else {
+      throw new RuntimeException("The runtime mode has already been set, it cannot be changed.");
+    }
+  }
+
+  @Override
   public void setCrashHandler(@NotNull FlixelCrashHandler handler) {
-    Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> handler.onCrash(thread, throwable));
+    Thread.setDefaultUncaughtExceptionHandler(handler::onCrash);
   }
 
   /**


### PR DESCRIPTION
## Description

Originally, the framework didn't support reading the monitors connected to the user's computer, causing `FlixelHostIntegration` to fallback to a no-op.

This pull request changes that by adding full support for both desktop and HTML5, via SDL3 and the browser's native Window Management API. Additionally, it also adds two new methods to the framework's API inside of `FlixelHostIntegration`: `supportsMonitors()` and `requestMonitorPermission()`. Refer to their Javadocs to see what they're for.

A small change: `FlixelPlatform.Web` has been renamed to `HTML5` to remain consistent with the framework's module names.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
