### PR TITLE
Shortened all Javadoc @link references to use simple class names with imports

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -386,7 +386,7 @@ public final class Flixel {
    * between keys that are held down, freshly pressed on the current frame, and freshly released
    * on the current frame, so your game logic can respond precisely to each event type.
    *
-   * <p>Key constants are defined in {@link FlixelKey FlixelKey}. Pass any of
+   * <p>Key constants are defined in {@link FlixelKey}. Pass any of
    * those constants to the methods below:
    * <ul>
    *   <li>{@link FlixelKeyInputManager#pressed(int)} - {@code true} while the key is held down.</li>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -45,6 +45,7 @@ import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.debug.FlixelDebugManager;
 import org.flixelgdx.debug.FlixelDebugOverlay;
 import org.flixelgdx.debug.FlixelDebugWatchManager;
+import org.flixelgdx.debug.FlixelHeadlessDebugOverlay;
 import org.flixelgdx.file.FlixelFiles;
 import org.flixelgdx.file.FlixelNoopFiles;
 import org.flixelgdx.functional.FlixelAntialiasable;
@@ -61,6 +62,7 @@ import org.flixelgdx.input.FlixelTouchListener;
 import org.flixelgdx.input.gamepad.FlixelGamepadAxis;
 import org.flixelgdx.input.gamepad.FlixelGamepadButton;
 import org.flixelgdx.input.gamepad.FlixelGamepadInputManager;
+import org.flixelgdx.input.keyboard.FlixelKey;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
 import org.flixelgdx.input.mouse.FlixelMouseInputManager;
@@ -384,7 +386,7 @@ public final class Flixel {
    * between keys that are held down, freshly pressed on the current frame, and freshly released
    * on the current frame, so your game logic can respond precisely to each event type.
    *
-   * <p>Key constants are defined in {@link org.flixelgdx.input.keyboard.FlixelKey FlixelKey}. Pass any of
+   * <p>Key constants are defined in {@link FlixelKey FlixelKey}. Pass any of
    * those constants to the methods below:
    * <ul>
    *   <li>{@link FlixelKeyInputManager#pressed(int)} - {@code true} while the key is held down.</li>
@@ -514,7 +516,7 @@ public final class Flixel {
    *
    * <p>The overlay itself is created by a factory set before the game starts. Desktop launchers
    * typically supply a richer overlay (for example, one built with Dear ImGui), while headless or
-   * web builds fall back to {@link org.flixelgdx.debug.FlixelHeadlessDebugOverlay}. Use
+   * web builds fall back to {@link FlixelHeadlessDebugOverlay}. Use
    * {@link FlixelDebugManager#setOverlayFactory} to install a custom factory before
    * {@link #start(FlixelGame, FlixelGameRunner)}.
    *
@@ -669,7 +671,7 @@ public final class Flixel {
    * These all delegate to this field.
    *
    * <p>Each message is automatically annotated with the calling class name and line number by the
-   * active {@link org.flixelgdx.logging.FlixelStackTraceProvider}, making it easy to trace output back to its source
+   * active {@link FlixelStackTraceProvider}, making it easy to trace output back to its source
    * without a full stack dump.
    *
    * <p>To write logs to a file, call {@link FlixelLogger#startFileLogging()} after configuring

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
@@ -60,7 +60,7 @@ import org.jetbrains.annotations.Nullable;
  *     </tr>
  *     <tr>
  *       <td>Reuse a "dead" slot in a {@link FlixelBasicGroup}</td>
- *       <td>{@link FlixelBasicGroup#recycle() FlixelBasicGroup.recycle()} or {@link #revive()} after {@link #kill()}</td>
+ *       <td>{@link FlixelBasicGroup#recycle()} or {@link #revive()} after {@link #kill()}</td>
  *       <td>{@link #destroy()} unless you truly discard the instance</td>
  *     </tr>
  *     <tr>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
@@ -24,6 +24,8 @@
 package org.flixelgdx;
 
 import org.flixelgdx.collections.FlixelPool;
+import org.flixelgdx.collections.FlixelPoolable;
+import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.functional.FlixelExistable;
 import org.flixelgdx.functional.IFlixelBasic;
 import org.flixelgdx.graphics.FlixelBatch;
@@ -36,14 +38,14 @@ import org.jetbrains.annotations.Nullable;
  * The most generic Flixel object. Both {@link FlixelObject} and {@link FlixelCamera}
  * extend this class. It has no size, position, or graphical data, only lifecycle flags and a unique ID.
  * It implements {@link IFlixelBasic}, the full contract used by {@link FlixelState} and
- * {@link org.flixelgdx.group.FlixelBasicGroup FlixelBasicGroup}. The existence and active flags
+ * {@link FlixelBasicGroup FlixelBasicGroup}. The existence and active flags
  * ({@link #exists}, {@link #active}) are defined by {@link FlixelExistable}.
  *
  * <p>Prefer {@link #kill()} when an object should stop updating and drawing but might be {@link #revive()}d later
  * (bullets, particles, pooled gameplay objects). Call {@link #destroy()} when you are done with the instance for good:
  * it clears lifecycle state and, in subclasses such as {@link FlixelSprite}, releases graphics and
- * other resources. {@link #reset()} (the {@link org.flixelgdx.collections.FlixelPoolable} hook) delegates to
- * {@link #destroy()}, so returning an instance to a {@link org.flixelgdx.collections.FlixelPool} cleans it up.
+ * other resources. {@link #reset()} (the {@link FlixelPoolable} hook) delegates to
+ * {@link #destroy()}, so returning an instance to a {@link FlixelPool} cleans it up.
  *
  * <table border="1">
  *   <caption><strong>Lifecycle cheat sheet</strong></caption>
@@ -111,7 +113,7 @@ public abstract class FlixelBasic implements IFlixelBasic {
   public boolean alive = true;
 
   /**
-   * Controls whether {@link #update(float)} and {@link org.flixelgdx.functional.FlixelDrawable#draw(FlixelBatch)} are automatically called.
+   * Controls whether {@link #update(float)} and {@link FlixelDrawable#draw(FlixelBatch)} are automatically called.
    *
    * @see FlixelExistable#isExists()
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * The most generic Flixel object. Both {@link FlixelObject} and {@link FlixelCamera}
  * extend this class. It has no size, position, or graphical data, only lifecycle flags and a unique ID.
  * It implements {@link IFlixelBasic}, the full contract used by {@link FlixelState} and
- * {@link FlixelBasicGroup FlixelBasicGroup}. The existence and active flags
+ * {@link FlixelBasicGroup}. The existence and active flags
  * ({@link #exists}, {@link #active}) are defined by {@link FlixelExistable}.
  *
  * <p>Prefer {@link #kill()} when an object should stop updating and drawing but might be {@link #revive()}d later
@@ -59,7 +59,7 @@ import org.jetbrains.annotations.Nullable;
  *       <td>{@link #destroy()} (drops resources you may still want)</td>
  *     </tr>
  *     <tr>
- *       <td>Reuse a "dead" slot in a {@link FlixelBasicGroup FlixelBasicGroup}</td>
+ *       <td>Reuse a "dead" slot in a {@link FlixelBasicGroup}</td>
  *       <td>{@link FlixelBasicGroup#recycle() FlixelBasicGroup.recycle()} or {@link #revive()} after {@link #kill()}</td>
  *       <td>{@link #destroy()} unless you truly discard the instance</td>
  *     </tr>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelConfig.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelConfig.java
@@ -177,7 +177,7 @@ public final class FlixelConfig {
    * Returns whether an alpha-capable (transparent) default framebuffer was requested at launch.
    *
    * <p>When {@code true}, the launcher creates the window with compositing support so
-   * {@link org.flixelgdx.backend.FlixelWindow#setTransparencyActive(boolean)} can blend the game with the desktop.
+   * {@link FlixelWindow#setTransparencyActive(boolean)} can blend the game with the desktop.
    * When {@code false} (the default), the framebuffer is opaque and transparency has no effect.
    *
    * @return {@code true} when an alpha-capable framebuffer was requested.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -94,7 +94,7 @@ import java.util.function.Supplier;
  * so members placed at {@code (x, y)} always appear at those design-resolution coordinates
  * regardless of what the active game camera is doing. Enable and disable the overlay with
  * {@link #enableGlobalOverlay(boolean)}. The overlay is completely separate from
- * {@link org.flixelgdx.debug.FlixelDebugOverlay} and does not appear in debug mode unless you
+ * {@link FlixelDebugOverlay} and does not appear in debug mode unless you
  * explicitly enable it.
  *
  * <h2>Signals</h2>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
@@ -38,8 +38,8 @@ import org.flixelgdx.util.FlixelDirectionFlags;
  * capabilities on top of this spatial foundation.
  *
  * <h2>Collision</h2>
- * Use {@link Flixel#overlap Flixel.overlap()} and
- * {@link Flixel#collide Flixel.collide()} for overlap/separation
+ * Use {@link Flixel#overlap} and
+ * {@link Flixel#collide} for overlap/separation
  * checks. The static {@link #separate(FlixelObject, FlixelObject)} method resolves overlaps
  * by adjusting positions and velocities.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
@@ -38,8 +38,8 @@ import org.flixelgdx.util.FlixelDirectionFlags;
  * capabilities on top of this spatial foundation.
  *
  * <h2>Collision</h2>
- * Use {@link org.flixelgdx.Flixel#overlap Flixel.overlap()} and
- * {@link org.flixelgdx.Flixel#collide Flixel.collide()} for overlap/separation
+ * Use {@link Flixel#overlap Flixel.overlap()} and
+ * {@link Flixel#collide Flixel.collide()} for overlap/separation
  * checks. The static {@link #separate(FlixelObject, FlixelObject)} method resolves overlaps
  * by adjusting positions and velocities.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -25,6 +25,7 @@ package org.flixelgdx;
 
 import org.flixelgdx.animation.FlixelAnimationController;
 import org.flixelgdx.animation.FlixelSpritemapJsonLoader;
+import org.flixelgdx.asset.FlixelAsset;
 import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.file.FlixelFile;
@@ -53,7 +54,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h2>Loading graphics</h2>
  * <p>Use {@link #loadGraphic(String)} for asset-managed textures (the texture is cached and
- * reference-counted by {@link org.flixelgdx.asset.FlixelAssetManager FlixelAssetManager}).
+ * reference-counted by {@link FlixelAssetManager FlixelAssetManager}).
  * {@link #makeGraphic(int, int, FlixelColor)} generates a solid-color rectangle on the fly and
  * owns the resulting texture. For Sparrow XML atlases, call
  * {@link #ensureAnimation()}{@code .addSparrowAtlas(...)} instead of loading the texture directly.
@@ -187,7 +188,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    *
    * <p>Set via {@link #setShader(FlixelShader)}. Prefer keeping this {@code null} unless you
    * specifically need a per-sprite effect; each unique shader in draw order costs a GPU batch
-   * flush. See {@link org.flixelgdx.functional.FlixelShaderable FlixelShaderable} for the
+   * flush. See {@link FlixelShaderable FlixelShaderable} for the
    * full performance breakdown.
    */
   @Nullable
@@ -524,8 +525,8 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * texture so an appended atlas matches the visual filter of the original.
    *
    * <p>The graphic is assumed to have already been retained by the caller (typically via
-   * {@link org.flixelgdx.asset.FlixelAssetManager#get(String) FlixelAssetManager.get(...)} followed
-   * by {@link org.flixelgdx.asset.FlixelAsset#retain() retain()}), so this method only stores the
+   * {@link FlixelAssetManager#get(String) FlixelAssetManager.get(...)} followed
+   * by {@link FlixelAsset#retain() retain()}), so this method only stores the
    * reference and does not call {@link FlixelGraphic#retain()} again. This is an advanced hook used
    * by atlas-merging code such as {@link FlixelAnimationController#addSparrowFrames(String)} and
    * the Animate rig loader; most game code never calls it directly.
@@ -825,7 +826,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * the shader is no longer needed. Pass {@code null} to remove the current shader.
    *
    * <p>If you need a full-scene effect (post-processing applied to everything a camera sees),
-   * prefer {@link org.flixelgdx.FlixelCamera#setShader(FlixelShader) FlixelCamera.setShader()}
+   * prefer {@link FlixelCamera#setShader(FlixelShader) FlixelCamera.setShader()}
    * instead, as it captures the entire scene into a single FBO and applies the shader once, with
    * no per-sprite flush cost.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -826,7 +826,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * the shader is no longer needed. Pass {@code null} to remove the current shader.
    *
    * <p>If you need a full-scene effect (post-processing applied to everything a camera sees),
-   * prefer {@link FlixelCamera#setShader(FlixelShader) FlixelCamera.setShader()}
+   * prefer {@link FlixelCamera#setShader(FlixelShader)}
    * instead, as it captures the entire scene into a single FBO and applies the shader once, with
    * no per-sprite flush cost.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -54,7 +54,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h2>Loading graphics</h2>
  * <p>Use {@link #loadGraphic(String)} for asset-managed textures (the texture is cached and
- * reference-counted by {@link FlixelAssetManager FlixelAssetManager}).
+ * reference-counted by {@link FlixelAssetManager}).
  * {@link #makeGraphic(int, int, FlixelColor)} generates a solid-color rectangle on the fly and
  * owns the resulting texture. For Sparrow XML atlases, call
  * {@link #ensureAnimation()}{@code .addSparrowAtlas(...)} instead of loading the texture directly.
@@ -188,7 +188,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    *
    * <p>Set via {@link #setShader(FlixelShader)}. Prefer keeping this {@code null} unless you
    * specifically need a per-sprite effect; each unique shader in draw order costs a GPU batch
-   * flush. See {@link FlixelShaderable FlixelShaderable} for the
+   * flush. See {@link FlixelShaderable} for the
    * full performance breakdown.
    */
   @Nullable

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSubState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSubState.java
@@ -68,7 +68,7 @@ public abstract class FlixelSubState extends FlixelState {
     setBgColor(subStateBackground);
   }
 
-  /** Re-applies this substate's background to all cameras (needed if the constructor ran before {@link FlixelGame#create FlixelGame.create}). */
+  /** Re-applies this substate's background to all cameras (needed if the constructor ran before {@link FlixelGame#create}). */
   protected void syncBackgroundToCameras() {
     setBgColor(subStateBackground);
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSubState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSubState.java
@@ -68,7 +68,7 @@ public abstract class FlixelSubState extends FlixelState {
     setBgColor(subStateBackground);
   }
 
-  /** Re-applies this substate's background to all cameras (needed if the constructor ran before {@link org.flixelgdx.FlixelGame#create FlixelGame.create}). */
+  /** Re-applies this substate's background to all cameras (needed if the constructor ran before {@link FlixelGame#create FlixelGame.create}). */
   protected void syncBackgroundToCameras() {
     setBgColor(subStateBackground);
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.animation;
 
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelMap;
 import org.flixelgdx.graphics.FlixelFrame;
@@ -76,8 +77,8 @@ public final class FlixelAnimateRig {
 
   /**
    * The shared atlas regions indexed by {@link Part#atlasIndex}. This is the same list installed on the
-   * owning {@link org.flixelgdx.FlixelSprite FlixelSprite} through
-   * {@link org.flixelgdx.FlixelSprite#applySparrowAtlas FlixelSprite.applySparrowAtlas}, so callers may look up a region
+   * owning {@link FlixelSprite FlixelSprite} through
+   * {@link FlixelSprite#applySparrowAtlas FlixelSprite.applySparrowAtlas}, so callers may look up a region
    * either way.
    */
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
@@ -78,7 +78,7 @@ public final class FlixelAnimateRig {
   /**
    * The shared atlas regions indexed by {@link Part#atlasIndex}. This is the same list installed on the
    * owning {@link FlixelSprite} through
-   * {@link FlixelSprite#applySparrowAtlas FlixelSprite.applySparrowAtlas}, so callers may look up a region
+   * {@link FlixelSprite#applySparrowAtlas}, so callers may look up a region
    * either way.
    */
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRig.java
@@ -77,7 +77,7 @@ public final class FlixelAnimateRig {
 
   /**
    * The shared atlas regions indexed by {@link Part#atlasIndex}. This is the same list installed on the
-   * owning {@link FlixelSprite FlixelSprite} through
+   * owning {@link FlixelSprite} through
    * {@link FlixelSprite#applySparrowAtlas FlixelSprite.applySparrowAtlas}, so callers may look up a region
    * either way.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
@@ -319,7 +319,7 @@ final class FlixelAnimateRigLoader {
    * when game code switches between atlases.
    *
    * <p>The new spritemap's frames are appended to {@link FlixelAnimateRig#atlas} (which is shared
-   * by reference with the owning sprite, so {@link FlixelSprite#getAtlasRegions() FlixelSprite.getAtlasRegions()}
+   * by reference with the owning sprite, so {@link FlixelSprite#getAtlasRegions()}
    * keeps working) and the new label-layer clips are added to {@link FlixelAnimateRig#clips}. Clip
    * names that collide with existing ones are silently overwritten on both the rig and the controller,
    * matching {@link FlixelMap#put}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.animation;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelMap;
 import org.flixelgdx.collections.FlixelObjectIntMap;
@@ -318,7 +319,7 @@ final class FlixelAnimateRigLoader {
    * when game code switches between atlases.
    *
    * <p>The new spritemap's frames are appended to {@link FlixelAnimateRig#atlas} (which is shared
-   * by reference with the owning sprite, so {@link org.flixelgdx.FlixelSprite#getAtlasRegions() FlixelSprite.getAtlasRegions()}
+   * by reference with the owning sprite, so {@link FlixelSprite#getAtlasRegions() FlixelSprite.getAtlasRegions()}
    * keeps working) and the new label-layer clips are added to {@link FlixelAnimateRig#clips}. Clip
    * names that collide with existing ones are silently overwritten on both the rig and the controller,
    * matching {@link FlixelMap#put}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -568,7 +568,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
   /**
    * Resolves a {@link FlixelFile} into the path string the rest of {@code addSpritemapAndAnimation}
    * overloads operate on. Asset-manager lookups (the spritemap PNG) and direct JSON reads both resolve
-   * a plain path through {@link Flixel#files Flixel.files}, so converting up front lets
+   * a plain path through {@link Flixel#files}, so converting up front lets
    * every {@link FlixelFile} overload delegate straight into the existing {@code String} pipeline
    * without duplicating loading logic.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -568,7 +568,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
   /**
    * Resolves a {@link FlixelFile} into the path string the rest of {@code addSpritemapAndAnimation}
    * overloads operate on. Asset-manager lookups (the spritemap PNG) and direct JSON reads both resolve
-   * a plain path through {@link org.flixelgdx.Flixel#files Flixel.files}, so converting up front lets
+   * a plain path through {@link Flixel#files Flixel.files}, so converting up front lets
    * every {@link FlixelFile} overload delegate straight into the existing {@code String} pipeline
    * without duplicating loading logic.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimation.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimation.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
  * frame to show.
  *
  * <p>This is the timing core under sprite animations. It knows nothing about textures; the
- * key-frame type is generic (usually {@link FlixelFrame FlixelFrame}),
+ * key-frame type is generic (usually {@link FlixelFrame}),
  * so rigs and other systems can animate any payload.
  *
  * <p>Example:

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimation.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimation.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.animation;
 
 import org.flixelgdx.collections.FlixelArray;
+import org.flixelgdx.graphics.FlixelFrame;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -33,7 +34,7 @@ import java.util.Arrays;
  * frame to show.
  *
  * <p>This is the timing core under sprite animations. It knows nothing about textures; the
- * key-frame type is generic (usually {@link org.flixelgdx.graphics.FlixelFrame FlixelFrame}),
+ * key-frame type is generic (usually {@link FlixelFrame FlixelFrame}),
  * so rigs and other systems can animate any payload.
  *
  * <p>Example:

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.animation;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.asset.FlixelAssetPaths;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelObjectIntMap;
@@ -54,7 +55,7 @@ import java.util.Objects;
  *
  * <p>Game code does not usually call this helper directly. A {@link FlixelAnimateSprite} accepts an
  * Animate atlas triple through {@link FlixelAnimateSprite#addSpritemapAndAnimation}, and a plain
- * {@link org.flixelgdx.FlixelSprite FlixelSprite} accepts a simple-format pair through
+ * {@link FlixelSprite FlixelSprite} accepts a simple-format pair through
  * {@link FlixelAnimationController#loadSpritemapFromJson}.
  */
 public final class FlixelSpritemapJsonLoader {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
@@ -55,7 +55,7 @@ import java.util.Objects;
  *
  * <p>Game code does not usually call this helper directly. A {@link FlixelAnimateSprite} accepts an
  * Animate atlas triple through {@link FlixelAnimateSprite#addSpritemapAndAnimation}, and a plain
- * {@link FlixelSprite FlixelSprite} accepts a simple-format pair through
+ * {@link FlixelSprite} accepts a simple-format pair through
  * {@link FlixelAnimationController#loadSpritemapFromJson}.
  */
 public final class FlixelSpritemapJsonLoader {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAsset.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAsset.java
@@ -23,13 +23,14 @@
  */
 package org.flixelgdx.asset;
 
+import org.flixelgdx.graphics.FlixelGraphic;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Unified handle for one asset, with reference counting and lifecycle policy.
  *
  * <p>All assets retrieved from {@link FlixelAssetManager} implement this interface.
- * {@link org.flixelgdx.graphics.FlixelGraphic FlixelGraphic} implements
+ * {@link FlixelGraphic FlixelGraphic} implements
  * {@code FlixelAsset<FlixelGraphic>} directly so the graphic object is the handle.
  * Other asset types use {@link FlixelDefaultAsset}.
  *
@@ -53,7 +54,7 @@ import org.jetbrains.annotations.NotNull;
  * }</pre>
  *
  * @param <T> The wrapper type that game code interacts with (e.g.
- *   {@link org.flixelgdx.graphics.FlixelGraphic FlixelGraphic}).
+ *   {@link FlixelGraphic FlixelGraphic}).
  */
 public interface FlixelAsset<T> {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAsset.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAsset.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  * Unified handle for one asset, with reference counting and lifecycle policy.
  *
  * <p>All assets retrieved from {@link FlixelAssetManager} implement this interface.
- * {@link FlixelGraphic FlixelGraphic} implements
+ * {@link FlixelGraphic} implements
  * {@code FlixelAsset<FlixelGraphic>} directly so the graphic object is the handle.
  * Other asset types use {@link FlixelDefaultAsset}.
  *
@@ -54,7 +54,7 @@ import org.jetbrains.annotations.NotNull;
  * }</pre>
  *
  * @param <T> The wrapper type that game code interacts with (e.g.
- *   {@link FlixelGraphic FlixelGraphic}).
+ *   {@link FlixelGraphic}).
  */
 public interface FlixelAsset<T> {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetLoader.java
@@ -24,6 +24,8 @@
 package org.flixelgdx.asset;
 
 import org.flixelgdx.file.FlixelFile;
+import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.graphics.FlixelImage;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -44,7 +46,7 @@ import org.jetbrains.annotations.NotNull;
  * </ol>
  *
  * <p>Separately, {@link #createHandle(FlixelAssetManager, String)} builds the <b>wrapper</b>
- * handle game code holds (a {@link org.flixelgdx.graphics.FlixelGraphic FlixelGraphic}, a
+ * handle game code holds (a {@link FlixelGraphic FlixelGraphic}, a
  * {@link FlixelDefaultAsset}, and so on). The handle reads the finished raw content back from
  * the manager's cache when first used, which keeps raw loading and wrapping one system instead
  * of two.
@@ -75,7 +77,7 @@ public interface FlixelAssetLoader<T> {
    * Stage one: reads and parses the file into a raw object.
    *
    * <p>On platforms with threads this may run on a worker thread; do not touch the GPU or any
-   * main-thread-only system here. Decode into CPU-side data ({@link org.flixelgdx.graphics.FlixelImage
+   * main-thread-only system here. Decode into CPU-side data ({@link FlixelImage
    * FlixelImage}, byte arrays, strings) and let {@link #finishRaw} do main-thread work.
    *
    * @param assets The owning asset manager.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetLoader.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.NotNull;
  * </ol>
  *
  * <p>Separately, {@link #createHandle(FlixelAssetManager, String)} builds the <b>wrapper</b>
- * handle game code holds (a {@link FlixelGraphic FlixelGraphic}, a
+ * handle game code holds (a {@link FlixelGraphic}, a
  * {@link FlixelDefaultAsset}, and so on). The handle reads the finished raw content back from
  * the manager's cache when first used, which keeps raw loading and wrapping one system instead
  * of two.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
@@ -122,7 +122,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
    * a {@link ClassCastException} at runtime if the inferred type does not match.
    *
    * @param path Asset path.
-   * @param <T> Expected wrapper type (e.g. {@link FlixelGraphic FlixelGraphic}).
+   * @param <T> Expected wrapper type (e.g. {@link FlixelGraphic}).
    * @return The cached or newly created handle; never {@code null}.
    * @throws IllegalArgumentException if no loader is registered for the path's extension.
    */
@@ -166,7 +166,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
   /**
    * Registers a caller-constructed asset handle directly with the manager cache. Use this for
    * assets created outside the normal loading pipeline (e.g. a texture built from a
-   * {@link FlixelImage FlixelImage}).
+   * {@link FlixelImage}).
    *
    * <p>The handle is keyed by {@link FlixelAsset#getPath()}. If a handle is already registered
    * under that key, it is replaced.
@@ -321,7 +321,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
    * been loaded yet.
    *
    * <p>This is the storage half of the loader pipeline: wrapper handles such as
-   * {@link FlixelGraphic FlixelGraphic} call it to look up their content
+   * {@link FlixelGraphic} call it to look up their content
    * (a texture, a string, decoded audio) without knowing how it was produced.
    *
    * @param path Normalized asset path.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>This is the public seam used by sprites and other runtime systems. It is a pure interface:
  * each platform installs its own implementation (the shared JVM one for desktop and Android, a
  * browser-based one for web), and a safe no-op ({@link FlixelNoopAssetManager}) is in place
- * before any backend starts. Access via {@link Flixel#assets Flixel.assets}.
+ * before any backend starts. Access via {@link Flixel#assets}.
  *
  * <p><b>Basic workflow:</b>
  *
@@ -260,7 +260,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
 
   /**
    * Unloads non-persistent asset handles whose reference count is zero. Called automatically
-   * by {@link Flixel#switchState Flixel.switchState} in
+   * by {@link Flixel#switchState} in
    * {@link FlixelAssetMode#STANDARD} and {@link FlixelAssetMode#AGGRESSIVE} modes.
    */
   void clearNonPersist();
@@ -299,7 +299,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
   /**
    * Sets the active asset management mode. Takes effect on the next
    * {@link FlixelAsset#release()} call or the next
-   * {@link Flixel#switchState Flixel.switchState}, whichever comes first.
+   * {@link Flixel#switchState}, whichever comes first.
    *
    * @param mode The new mode; must not be {@code null}.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
@@ -23,9 +23,12 @@
  */
 package org.flixelgdx.asset;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.file.FlixelFile;
 import org.flixelgdx.file.FlixelFiles;
 import org.flixelgdx.functional.FlixelDestroyable;
+import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.graphics.FlixelImage;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>This is the public seam used by sprites and other runtime systems. It is a pure interface:
  * each platform installs its own implementation (the shared JVM one for desktop and Android, a
  * browser-based one for web), and a safe no-op ({@link FlixelNoopAssetManager}) is in place
- * before any backend starts. Access via {@link org.flixelgdx.Flixel#assets Flixel.assets}.
+ * before any backend starts. Access via {@link Flixel#assets Flixel.assets}.
  *
  * <p><b>Basic workflow:</b>
  *
@@ -119,7 +122,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
    * a {@link ClassCastException} at runtime if the inferred type does not match.
    *
    * @param path Asset path.
-   * @param <T> Expected wrapper type (e.g. {@link org.flixelgdx.graphics.FlixelGraphic FlixelGraphic}).
+   * @param <T> Expected wrapper type (e.g. {@link FlixelGraphic FlixelGraphic}).
    * @return The cached or newly created handle; never {@code null}.
    * @throws IllegalArgumentException if no loader is registered for the path's extension.
    */
@@ -163,7 +166,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
   /**
    * Registers a caller-constructed asset handle directly with the manager cache. Use this for
    * assets created outside the normal loading pipeline (e.g. a texture built from a
-   * {@link org.flixelgdx.graphics.FlixelImage FlixelImage}).
+   * {@link FlixelImage FlixelImage}).
    *
    * <p>The handle is keyed by {@link FlixelAsset#getPath()}. If a handle is already registered
    * under that key, it is replaced.
@@ -257,7 +260,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
 
   /**
    * Unloads non-persistent asset handles whose reference count is zero. Called automatically
-   * by {@link org.flixelgdx.Flixel#switchState Flixel.switchState} in
+   * by {@link Flixel#switchState Flixel.switchState} in
    * {@link FlixelAssetMode#STANDARD} and {@link FlixelAssetMode#AGGRESSIVE} modes.
    */
   void clearNonPersist();
@@ -271,7 +274,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
    * Returns the default {@link FlixelAsset#isPersist()} value assigned to newly created handles.
    *
    * <p>When {@code true}, new handles survive {@link #clearNonPersist()} when unreferenced.
-   * Owned assets (e.g. textures created from a {@link org.flixelgdx.graphics.FlixelImage
+   * Owned assets (e.g. textures created from a {@link FlixelImage
    * FlixelImage}) always use {@code persist = false} regardless of this setting.
    *
    * @return The global persist default.
@@ -296,7 +299,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
   /**
    * Sets the active asset management mode. Takes effect on the next
    * {@link FlixelAsset#release()} call or the next
-   * {@link org.flixelgdx.Flixel#switchState Flixel.switchState}, whichever comes first.
+   * {@link Flixel#switchState Flixel.switchState}, whichever comes first.
    *
    * @param mode The new mode; must not be {@code null}.
    */
@@ -318,7 +321,7 @@ public interface FlixelAssetManager extends FlixelDestroyable {
    * been loaded yet.
    *
    * <p>This is the storage half of the loader pipeline: wrapper handles such as
-   * {@link org.flixelgdx.graphics.FlixelGraphic FlixelGraphic} call it to look up their content
+   * {@link FlixelGraphic FlixelGraphic} call it to look up their content
    * (a texture, a string, decoded audio) without knowing how it was produced.
    *
    * @param path Normalized asset path.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
@@ -83,7 +83,7 @@ public enum FlixelAssetMode {
    *     in AGGRESSIVE mode. It is fine in LAZY and STANDARD since those only unload at state
    *     switch boundaries, which is always on the GL thread.</li>
    *   <li>After an aggressive eviction, the underlying asset is disposed. Any code that
-   *     still holds a raw reference to the same {@link FlixelTexture FlixelTexture} (or
+   *     still holds a raw reference to the same {@link FlixelTexture} (or
    *     other resource) object will encounter a disposed object. The automated sprite pipeline
    *     ({@code loadGraphic} and {@code destroy}) handles this correctly; direct raw-asset usage
    *     outside that pipeline must ensure no other references remain before releasing.</li>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
@@ -29,7 +29,7 @@ import org.flixelgdx.graphics.FlixelTexture;
 /**
  * Controls when the asset manager reclaims memory for non-persistent assets.
  *
- * <p>The active mode is read by {@link Flixel#switchState Flixel.switchState} and by individual asset
+ * <p>The active mode is read by {@link Flixel#switchState} and by individual asset
  * handles on every {@link FlixelAsset#release()} call, so changing the mode mid-session takes
  * effect immediately without any extra steps.
  *
@@ -60,7 +60,7 @@ public enum FlixelAssetMode {
 
   /**
    * Non-persistent assets with a zero reference count are unloaded when
-   * {@link Flixel#switchState Flixel.switchState} runs. This is the default.
+   * {@link Flixel#switchState} runs. This is the default.
    *
    * <p>Persistent assets (see {@link FlixelAsset#isPersist()}) and any asset still held by a
    * live object (reference count greater than zero) are kept across the switch.
@@ -91,7 +91,7 @@ public enum FlixelAssetMode {
    *     {@link FlixelAssetManager#load(String)} again and awaiting the async load cycle.</li>
    * </ul>
    *
-   * <p>{@link Flixel#switchState Flixel.switchState} still calls {@link FlixelAssetManager#clearNonPersist()}
+   * <p>{@link Flixel#switchState} still calls {@link FlixelAssetManager#clearNonPersist()}
    * as a safety net for assets that were loaded but never retained.
    */
   AGGRESSIVE

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
@@ -24,11 +24,12 @@
 package org.flixelgdx.asset;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.graphics.FlixelTexture;
 
 /**
  * Controls when the asset manager reclaims memory for non-persistent assets.
  *
- * <p>The active mode is read by {@link org.flixelgdx.Flixel#switchState Flixel.switchState} and by individual asset
+ * <p>The active mode is read by {@link Flixel#switchState Flixel.switchState} and by individual asset
  * handles on every {@link FlixelAsset#release()} call, so changing the mode mid-session takes
  * effect immediately without any extra steps.
  *
@@ -59,7 +60,7 @@ public enum FlixelAssetMode {
 
   /**
    * Non-persistent assets with a zero reference count are unloaded when
-   * {@link org.flixelgdx.Flixel#switchState Flixel.switchState} runs. This is the default.
+   * {@link Flixel#switchState Flixel.switchState} runs. This is the default.
    *
    * <p>Persistent assets (see {@link FlixelAsset#isPersist()}) and any asset still held by a
    * live object (reference count greater than zero) are kept across the switch.
@@ -82,7 +83,7 @@ public enum FlixelAssetMode {
    *     in AGGRESSIVE mode. It is fine in LAZY and STANDARD since those only unload at state
    *     switch boundaries, which is always on the GL thread.</li>
    *   <li>After an aggressive eviction, the underlying asset is disposed. Any code that
-   *     still holds a raw reference to the same {@link org.flixelgdx.graphics.FlixelTexture FlixelTexture} (or
+   *     still holds a raw reference to the same {@link FlixelTexture FlixelTexture} (or
    *     other resource) object will encounter a disposed object. The automated sprite pipeline
    *     ({@code loadGraphic} and {@code destroy}) handles this correctly; direct raw-asset usage
    *     outside that pipeline must ensure no other references remain before releasing.</li>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelBaseAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelBaseAssetManager.java
@@ -29,6 +29,7 @@ import org.flixelgdx.collections.FlixelMap;
 import org.flixelgdx.file.FlixelFile;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.graphics.FlixelGraphicsManager;
 import org.flixelgdx.graphics.FlixelImage;
 import org.flixelgdx.graphics.FlixelTexture;
 import org.flixelgdx.util.FlixelString;
@@ -55,7 +56,7 @@ import java.nio.ByteOrder;
  * <p>Default loaders registered by the constructor:
  * <ul>
  *   <li>Images ({@code .png}, {@code .jpg}, {@code .jpeg}, {@code .bmp}, {@code .tga}) decode on
- *     the worker via {@link org.flixelgdx.graphics.FlixelGraphicsManager#decodeImage decodeImage}
+ *     the worker via {@link FlixelGraphicsManager#decodeImage decodeImage}
  *     and upload on the main thread, producing {@link FlixelGraphic} handles.</li>
  *   <li>Text ({@code .txt}, {@code .xml}, {@code .json}) loads as {@link String} inside
  *     {@link FlixelDefaultAsset} handles.</li>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAsset.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAsset.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.asset;
 
+import org.flixelgdx.audio.FlixelSoundSource;
+import org.flixelgdx.graphics.FlixelGraphic;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -33,8 +35,8 @@ import java.util.Objects;
  *
  * <p>The handle looks its content up in the owning manager's raw cache on each
  * {@link #get()}, block-loading it when it was never queued. Types with richer behavior
- * ({@link org.flixelgdx.graphics.FlixelGraphic FlixelGraphic} for textures,
- * {@link org.flixelgdx.audio.FlixelSoundSource FlixelSoundSource} for audio) implement
+ * ({@link FlixelGraphic FlixelGraphic} for textures,
+ * {@link FlixelSoundSource FlixelSoundSource} for audio) implement
  * {@link FlixelAsset} themselves instead.
  *
  * @param <T> The content type game code receives from {@link #get()} (e.g. {@link String}).

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAsset.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAsset.java
@@ -35,8 +35,8 @@ import java.util.Objects;
  *
  * <p>The handle looks its content up in the owning manager's raw cache on each
  * {@link #get()}, block-loading it when it was never queued. Types with richer behavior
- * ({@link FlixelGraphic FlixelGraphic} for textures,
- * {@link FlixelSoundSource FlixelSoundSource} for audio) implement
+ * ({@link FlixelGraphic} for textures,
+ * {@link FlixelSoundSource} for audio) implement
  * {@link FlixelAsset} themselves instead.
  *
  * @param <T> The content type game code receives from {@link #get()} (e.g. {@link String}).

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
@@ -25,6 +25,7 @@ package org.flixelgdx.audio;
 
 import org.flixelgdx.FlixelBasic;
 import org.flixelgdx.asset.FlixelAsset;
+import org.flixelgdx.asset.FlixelAssetMode;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.tween.FlixelTween;
 import org.flixelgdx.tween.settings.FlixelTweenSettings;
@@ -513,7 +514,7 @@ public abstract class FlixelSound extends FlixelBasic implements FlixelAsset<Fli
    * Attaches the backing {@link FlixelAsset} handle for the {@link FlixelSoundSource} that was
    * retained when this sound was created through {@link FlixelSoundManager}. The handle is
    * released in {@link #destroy()} so the source asset is eligible for cleanup according to the
-   * active {@link org.flixelgdx.asset.FlixelAssetMode FlixelAssetMode}.
+   * active {@link FlixelAssetMode FlixelAssetMode}.
    *
    * @param sourceAsset The retained source handle, or {@code null} to clear it.
    * @return {@code this} for chaining.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
@@ -514,7 +514,7 @@ public abstract class FlixelSound extends FlixelBasic implements FlixelAsset<Fli
    * Attaches the backing {@link FlixelAsset} handle for the {@link FlixelSoundSource} that was
    * retained when this sound was created through {@link FlixelSoundManager}. The handle is
    * released in {@link #destroy()} so the source asset is eligible for cleanup according to the
-   * active {@link FlixelAssetMode FlixelAssetMode}.
+   * active {@link FlixelAssetMode}.
    *
    * @param sourceAsset The retained source handle, or {@code null} to clear it.
    * @return {@code this} for chaining.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundFactory.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundFactory.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.audio;
 
+import org.flixelgdx.Flixel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>One implementation is installed on {@link FlixelSoundManager} per platform (miniaudio via
  * JNI on desktop and Android, the Web Audio API on web) before
- * {@link org.flixelgdx.Flixel#start Flixel.start} runs. Game code rarely touches the factory
+ * {@link Flixel#start Flixel.start} runs. Game code rarely touches the factory
  * directly; it plays audio through {@code Flixel.sound.play(...)} and
  * {@code Flixel.sound.playMusic(...)}, or creates silent-until-played instances with
  * {@code Flixel.sound.create(...)}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundFactory.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundFactory.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>One implementation is installed on {@link FlixelSoundManager} per platform (miniaudio via
  * JNI on desktop and Android, the Web Audio API on web) before
- * {@link Flixel#start Flixel.start} runs. Game code rarely touches the factory
+ * {@link Flixel#start} runs. Game code rarely touches the factory
  * directly; it plays audio through {@code Flixel.sound.play(...)} and
  * {@code Flixel.sound.playMusic(...)}, or creates silent-until-played instances with
  * {@code Flixel.sound.create(...)}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
@@ -39,12 +39,12 @@ import org.jetbrains.annotations.Nullable;
  * Central manager for all audio. {@link FlixelSound} instances, master volume,
  * sound groups (SFX and music), and focus-based pause/resume.
  *
- * <p>Access via {@link Flixel#sound Flixel.sound}. Supports
+ * <p>Access via {@link Flixel#sound}. Supports
  * separate groups for sound effects and music, global master volume, and
  * automatic pause when the game loses focus (and resume when it regains focus).
  *
  * <p>The platform's {@link FlixelSoundFactory} powers everything: install one before
- * {@link Flixel#start Flixel.start} (the desktop launcher does this for you) and
+ * {@link Flixel#start} (the desktop launcher does this for you) and
  * the manager builds its groups and sounds through it. Most games only need
  * {@link #play}, {@link #playMusic}, and the volume controls; use {@link #create} when you want
  * a {@link FlixelSound} configured up front without hearing it yet.
@@ -131,9 +131,9 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
    * Destroys all non-persistent {@link FlixelSound} instances tracked by this manager, including
    * the current music track if it is not persistent.
    *
-   * <p>Called automatically by {@link Flixel#switchState Flixel.switchState} on every state switch
-   * when the asset mode is {@link FlixelAssetMode#STANDARD FlixelAssetMode.STANDARD} or
-   * {@link FlixelAssetMode#AGGRESSIVE FlixelAssetMode.AGGRESSIVE}. Sounds whose {@link FlixelSound#isPersist()}
+   * <p>Called automatically by {@link Flixel#switchState} on every state switch
+   * when the asset mode is {@link FlixelAssetMode#STANDARD} or
+   * {@link FlixelAssetMode#AGGRESSIVE}. Sounds whose {@link FlixelSound#isPersist()}
    * flag is set survive the switch unchanged.
    *
    * <p>Sounds that were already destroyed (for example, via {@link FlixelSound#setAutoDestroy}) are

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
@@ -454,7 +454,7 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
    * Ticks all active sounds so that {@link FlixelSound#onComplete} fires and
    * {@link FlixelSound#setAutoDestroy auto-destroy} is honored.
    *
-   * <p>Called automatically by {@link FlixelGame FlixelGame} every frame
+   * <p>Called automatically by {@link FlixelGame} every frame
    * inside the game-update block; do not call this manually.
    *
    * <p>Sounds whose {@link FlixelSound#isExists() exists} flag is {@code false} (e.g.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
@@ -24,9 +24,12 @@
 package org.flixelgdx.audio;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.asset.FlixelAsset;
 import org.flixelgdx.asset.FlixelAssetManager;
+import org.flixelgdx.asset.FlixelAssetMode;
 import org.flixelgdx.collections.FlixelArray;
+import org.flixelgdx.file.FlixelFiles;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.functional.FlixelUpdatable;
 import org.jetbrains.annotations.NotNull;
@@ -36,19 +39,19 @@ import org.jetbrains.annotations.Nullable;
  * Central manager for all audio. {@link FlixelSound} instances, master volume,
  * sound groups (SFX and music), and focus-based pause/resume.
  *
- * <p>Access via {@link org.flixelgdx.Flixel#sound Flixel.sound}. Supports
+ * <p>Access via {@link Flixel#sound Flixel.sound}. Supports
  * separate groups for sound effects and music, global master volume, and
  * automatic pause when the game loses focus (and resume when it regains focus).
  *
  * <p>The platform's {@link FlixelSoundFactory} powers everything: install one before
- * {@link org.flixelgdx.Flixel#start Flixel.start} (the desktop launcher does this for you) and
+ * {@link Flixel#start Flixel.start} (the desktop launcher does this for you) and
  * the manager builds its groups and sounds through it. Most games only need
  * {@link #play}, {@link #playMusic}, and the volume controls; use {@link #create} when you want
  * a {@link FlixelSound} configured up front without hearing it yet.
  *
  * <p>For internal paths, sounds resolve through the asset pipeline: a loaded
  * {@link FlixelSoundSource} is used when present, otherwise the source is block-loaded first.
- * All file access goes through the {@link org.flixelgdx.file.FlixelFiles Flixel.files} seam, so
+ * All file access goes through the {@link FlixelFiles Flixel.files} seam, so
  * audio works identically from a folder, a packaged JAR, or any custom file root.
  */
 public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
@@ -128,9 +131,9 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
    * Destroys all non-persistent {@link FlixelSound} instances tracked by this manager, including
    * the current music track if it is not persistent.
    *
-   * <p>Called automatically by {@link org.flixelgdx.Flixel#switchState Flixel.switchState} on every state switch
-   * when the asset mode is {@link org.flixelgdx.asset.FlixelAssetMode#STANDARD FlixelAssetMode.STANDARD} or
-   * {@link org.flixelgdx.asset.FlixelAssetMode#AGGRESSIVE FlixelAssetMode.AGGRESSIVE}. Sounds whose {@link FlixelSound#isPersist()}
+   * <p>Called automatically by {@link Flixel#switchState Flixel.switchState} on every state switch
+   * when the asset mode is {@link FlixelAssetMode#STANDARD FlixelAssetMode.STANDARD} or
+   * {@link FlixelAssetMode#AGGRESSIVE FlixelAssetMode.AGGRESSIVE}. Sounds whose {@link FlixelSound#isPersist()}
    * flag is set survive the switch unchanged.
    *
    * <p>Sounds that were already destroyed (for example, via {@link FlixelSound#setAutoDestroy}) are
@@ -397,7 +400,7 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
    * <p>When {@code external} is {@code false}, reads or synchronously loads a
    * {@link FlixelSoundSource} through the asset manager and retains its handle for the sound's
    * lifetime. External paths read the file bytes from
-   * {@link org.flixelgdx.file.FlixelFiles#absolute Flixel.files.absolute} directly.
+   * {@link FlixelFiles#absolute Flixel.files.absolute} directly.
    *
    * @param path The path to the sound file.
    * @param external If {@code true}, the path is read from the absolute file root.
@@ -451,7 +454,7 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
    * Ticks all active sounds so that {@link FlixelSound#onComplete} fires and
    * {@link FlixelSound#setAutoDestroy auto-destroy} is honored.
    *
-   * <p>Called automatically by {@link org.flixelgdx.FlixelGame FlixelGame} every frame
+   * <p>Called automatically by {@link FlixelGame FlixelGame} every frame
    * inside the game-update block; do not call this manually.
    *
    * <p>Sounds whose {@link FlixelSound#isExists() exists} flag is {@code false} (e.g.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHaptics.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHaptics.java
@@ -29,14 +29,14 @@ import org.flixelgdx.FlixelGame;
 /**
  * Platform-specific haptic (vibration) feedback for mobile devices.
  *
- * <p>Access the active implementation via {@link Flixel#haptics Flixel.haptics}.
+ * <p>Access the active implementation via {@link Flixel#haptics}.
  * On platforms without a vibration motor (desktop, web), the default no-op implementation is used
  * and all calls are safely ignored. Check {@link #isSupported()} first if your game logic depends
  * on knowing whether feedback will actually fire.
  *
  * <p>Launchers on supported platforms (for example, Android) install a real implementation before
  * {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)} runs.
- * You should not need to assign {@link Flixel#haptics Flixel.haptics}
+ * You should not need to assign {@link Flixel#haptics}
  * from game code unless you are providing a custom backend.
  *
  * <p>Example:

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHaptics.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHaptics.java
@@ -24,18 +24,19 @@
 package org.flixelgdx.backend;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
 
 /**
  * Platform-specific haptic (vibration) feedback for mobile devices.
  *
- * <p>Access the active implementation via {@link org.flixelgdx.Flixel#haptics Flixel.haptics}.
+ * <p>Access the active implementation via {@link Flixel#haptics Flixel.haptics}.
  * On platforms without a vibration motor (desktop, web), the default no-op implementation is used
  * and all calls are safely ignored. Check {@link #isSupported()} first if your game logic depends
  * on knowing whether feedback will actually fire.
  *
  * <p>Launchers on supported platforms (for example, Android) install a real implementation before
- * {@link org.flixelgdx.Flixel#start(org.flixelgdx.FlixelGame, org.flixelgdx.backend.FlixelGameRunner) Flixel.start(...)} runs.
- * You should not need to assign {@link org.flixelgdx.Flixel#haptics Flixel.haptics}
+ * {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)} runs.
+ * You should not need to assign {@link Flixel#haptics Flixel.haptics}
  * from game code unless you are providing a custom backend.
  *
  * <p>Example:

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelMonitor.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelMonitor.java
@@ -25,6 +25,7 @@ package org.flixelgdx.backend;
 
 import org.flixelgdx.collections.FlixelList;
 import org.flixelgdx.graphics.FlixelDisplayMode;
+import org.flixelgdx.graphics.FlixelGraphicsManager;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -103,7 +104,7 @@ public interface FlixelMonitor {
    * Returns every video mode this monitor can switch to when going fullscreen, for building a
    * resolution picker in a settings menu.
    *
-   * <p>Unlike {@link org.flixelgdx.graphics.FlixelGraphicsManager#getDisplayModes()
+   * <p>Unlike {@link FlixelGraphicsManager#getDisplayModes()
    * Flixel.graphics.getDisplayModes()}, which returns a global flat list, this method returns only
    * the modes that belong to this specific monitor. On platforms that do not expose per-monitor
    * mode lists (web, mobile, or any non-desktop target), the list is always empty.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelRuntimeDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelRuntimeDevice.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>All of this is inherently platform-specific. A desktop JVM can inspect its heap and classpath;
  * a web browser cannot. So, like the other backend seams ({@link FlixelWindow},
  * {@link FlixelHostIntegration}), this is an interface the active backend fills in. Read it through
- * {@link Flixel#runtime Flixel.runtime}.
+ * {@link Flixel#runtime}.
  *
  * <p>Every method has a safe default, so a backend only overrides what it can actually report, and
  * the no-op device ({@link FlixelNoopRuntimeDevice}) keeps calls safe before a backend is installed

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelRuntimeDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelRuntimeDevice.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.backend;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.logging.FlixelNoopStackTraceProvider;
 import org.flixelgdx.logging.FlixelStackTraceProvider;
 import org.jetbrains.annotations.NotNull;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>All of this is inherently platform-specific. A desktop JVM can inspect its heap and classpath;
  * a web browser cannot. So, like the other backend seams ({@link FlixelWindow},
  * {@link FlixelHostIntegration}), this is an interface the active backend fills in. Read it through
- * {@link org.flixelgdx.Flixel#runtime Flixel.runtime}.
+ * {@link Flixel#runtime Flixel.runtime}.
  *
  * <p>Every method has a safe default, so a backend only overrides what it can actually report, and
  * the no-op device ({@link FlixelNoopRuntimeDevice}) keeps calls safe before a backend is installed
@@ -161,7 +162,7 @@ public interface FlixelRuntimeDevice {
 
   /**
    * Sets the platform-specific stack trace provider. Called by the platform launcher before
-   * {@link org.flixelgdx.Flixel#start} so the logger resolves call-site information correctly.
+   * {@link Flixel#start} so the logger resolves call-site information correctly.
    *
    * @param provider The provider to install.
    */
@@ -178,7 +179,7 @@ public interface FlixelRuntimeDevice {
    * <p>The default implementation is a no-op, so platforms that cannot intercept crashes degrade
    * gracefully without errors.
    *
-   * <p>This is called once by {@link org.flixelgdx.FlixelGame} during {@code create()}, before the
+   * <p>This is called once by {@link FlixelGame} during {@code create()}, before the
    * initial state is loaded.
    *
    * @param handler The crash handler to install.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelWindow.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelWindow.java
@@ -28,6 +28,7 @@ import org.flixelgdx.FlixelConfig;
 import org.flixelgdx.FlixelGame;
 import org.flixelgdx.functional.FlixelShakeable;
 import org.flixelgdx.graphics.FlixelDisplayMode;
+import org.flixelgdx.graphics.FlixelGraphicsManager;
 import org.flixelgdx.tween.FlixelTween;
 
 /**
@@ -37,7 +38,7 @@ import org.flixelgdx.tween.FlixelTween;
  * the window size, fullscreen, and closing all live here. Where a control has no meaning on a
  * platform (for example, moving a browser tab), it simply does nothing, so the same code is safe
  * everywhere. Anything about the drawing surface itself (frame rate, vertical sync, display modes,
- * pixel density) lives on {@link org.flixelgdx.graphics.FlixelGraphicsManager Flixel.graphics}
+ * pixel density) lives on {@link FlixelGraphicsManager Flixel.graphics}
  * instead.
  *
  * <p>Use {@link Flixel#window} after {@link Flixel#start(FlixelGame, FlixelGameRunner)}. The implementation only
@@ -130,7 +131,7 @@ public interface FlixelWindow extends FlixelShakeable {
 
   /**
    * Applies transparent fills to all cameras without touching the restore snapshot.
-   * Called after {@link org.flixelgdx.FlixelGame#resetCameras()} when transparency stays enabled.
+   * Called after {@link FlixelGame#resetCameras()} when transparency stays enabled.
    */
   default void applyTransparencyBackdropOnly() {}
 
@@ -416,7 +417,7 @@ public interface FlixelWindow extends FlixelShakeable {
    * Switches to fullscreen at the given display mode, when supported.
    *
    * <p>Obtain a mode from
-   * {@link org.flixelgdx.graphics.FlixelGraphicsManager#getDisplayModes() Flixel.graphics.getDisplayModes()}.
+   * {@link FlixelGraphicsManager#getDisplayModes() Flixel.graphics.getDisplayModes()}.
    * On web this requests the browser's fullscreen state; on mobile it toggles immersive mode. Return
    * to a window with {@link #setWindowed(int, int)}.
    *
@@ -445,7 +446,7 @@ public interface FlixelWindow extends FlixelShakeable {
    * Switches fullscreen mode on or off.
    *
    * <p>When enabling, uses the current display mode from
-   * {@link org.flixelgdx.graphics.FlixelGraphicsManager#getDisplayMode() Flixel.graphics.getDisplayMode()}.
+   * {@link FlixelGraphicsManager#getDisplayMode() Flixel.graphics.getDisplayMode()}.
    * When disabling, restores the window to the design size set in {@link FlixelConfig}.
    *
    * @param enabled {@code true} to enter fullscreen, {@code false} to return to windowed mode.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugDrawable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugDrawable.java
@@ -28,7 +28,7 @@ import org.flixelgdx.FlixelObject;
 
 /**
  * Interface for objects that can draw a debug bounding box in the
- * {@link org.flixelgdx.debug.FlixelDebugOverlay FlixelDebugOverlay}. Any class that
+ * {@link FlixelDebugOverlay FlixelDebugOverlay}. Any class that
  * implements this will automatically appear when visual debug drawing is enabled,
  * without being hard-coded into the overlay.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugDrawable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugDrawable.java
@@ -28,7 +28,7 @@ import org.flixelgdx.FlixelObject;
 
 /**
  * Interface for objects that can draw a debug bounding box in the
- * {@link FlixelDebugOverlay FlixelDebugOverlay}. Any class that
+ * {@link FlixelDebugOverlay}. Any class that
  * implements this will automatically appear when visual debug drawing is enabled,
  * without being hard-coded into the overlay.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -110,7 +110,7 @@ public class FlixelDebugManager {
   /**
    * The active debug overlay. Defaults to {@link FlixelNoopDebugOverlay#INSTANCE} so this field
    * is never {@code null}, meaning callers do not need a null check. When debug mode starts,
-   * {@link Flixel Flixel} replaces this with a real overlay instance.
+   * {@link Flixel} replaces this with a real overlay instance.
    *
    * <p>Access keybinds and visibility via this field:
    * <pre>{@code

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -110,7 +110,7 @@ public class FlixelDebugManager {
   /**
    * The active debug overlay. Defaults to {@link FlixelNoopDebugOverlay#INSTANCE} so this field
    * is never {@code null}, meaning callers do not need a null check. When debug mode starts,
-   * {@link org.flixelgdx.Flixel Flixel} replaces this with a real overlay instance.
+   * {@link Flixel Flixel} replaces this with a real overlay instance.
    *
    * <p>Access keybinds and visibility via this field:
    * <pre>{@code
@@ -159,7 +159,7 @@ public class FlixelDebugManager {
 
   /**
    * Creates the debug overlay using the registered factory and assigns it to {@link #overlay}.
-   * Called internally by {@link org.flixelgdx.FlixelGame} during startup when debug mode is enabled.
+   * Called internally by {@link FlixelGame} during startup when debug mode is enabled.
    *
    * @return The newly created overlay.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -511,14 +511,14 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   /**
    * Override to tell the framework's input layer that another UI layer (typically the imgui
    * debug overlay) is currently capturing the mouse. When this returns {@code true},
-   * {@link FlixelMouseInputManager#pressed(int) FlixelMouseInputManager.pressed(int)} and
+   * {@link FlixelMouseInputManager#pressed(int)} and
    * the matching {@code justPressed} / {@code justReleased} helpers will report {@code false}
    * for the game's regular input checks, and the debug camera tools / sprite picker also skip
    * their work, so clicking inside (for example) a Dear ImGui window does not bleed through
    * into the game logic. Defaults to {@code false}.
    *
    * <p>The overlay's own mouse tools (sprite picker, camera pan) use the regular
-   * {@link FlixelMouseInputManager#pressed(int) FlixelMouseInputManager.pressed(int)} helpers, which
+   * {@link FlixelMouseInputManager#pressed(int)} helpers, which
    * already report {@code false} while the cursor is over a debug panel, so a click there never grabs
    * a sprite or pans the camera.
    *
@@ -531,7 +531,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   /**
    * Override to tell the framework's input layer that another UI layer is currently consuming
    * keyboard input. When this returns {@code true},
-   * {@link FlixelKeyInputManager#pressed(int) FlixelKeyInputManager.pressed(int)} and
+   * {@link FlixelKeyInputManager#pressed(int)} and
    * the matching {@code justPressed} / {@code justReleased} helpers will report {@code false}
    * for the game's regular input checks, so typing in (for example) a Dear ImGui text field
    * cannot also capture game input and activate game-level actions like {@code ui_accept}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -908,7 +908,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   protected abstract void drawUI();
 
   /**
-   * Called from {@link org.flixelgdx.FlixelGame#resize(int, int)} so backends can keep
+   * Called from {@link FlixelGame#resize(int, int)} so backends can keep
    * their renderer state in sync with the window. The base class does not need to do anything.
    *
    * @param width New window width in pixels.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelHeadlessDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelHeadlessDebugOverlay.java
@@ -28,7 +28,7 @@ package org.flixelgdx.debug;
  * log buffers, pause/camera tools, sprite picking) runs, but {@link #drawUI()} is a no-op.
  *
  * <p>Use this as the default overlay factory via
- * {@link FlixelDebugManager#setOverlayFactory FlixelDebugManager.setOverlayFactory(Supplier)}
+ * {@link FlixelDebugManager#setOverlayFactory}
  * when a platform does not ship a richer debugger yet (for example headless tests or backends
  * without Dear ImGui). Desktop launchers typically replace it with a platform-specific subclass.
  */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelNoopDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelNoopDebugOverlay.java
@@ -25,7 +25,7 @@ package org.flixelgdx.debug;
 
 /**
  * A fully inert debug overlay used as the default value of
- * {@link org.flixelgdx.debug.FlixelDebugManager#overlay FlixelDebugManager.overlay} so callers
+ * {@link FlixelDebugManager#overlay FlixelDebugManager.overlay} so callers
  * never need to null-check the field.
  *
  * <p>All lifecycle methods ({@link #update(float)}, {@link #resize(int, int)}, {@link #drawUI()})

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelNoopDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelNoopDebugOverlay.java
@@ -25,7 +25,7 @@ package org.flixelgdx.debug;
 
 /**
  * A fully inert debug overlay used as the default value of
- * {@link FlixelDebugManager#overlay FlixelDebugManager.overlay} so callers
+ * {@link FlixelDebugManager#overlay} so callers
  * never need to null-check the field.
  *
  * <p>All lifecycle methods ({@link #update(float)}, {@link #resize(int, int)}, {@link #drawUI()})

--- a/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelFiles.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelFiles.java
@@ -47,7 +47,7 @@ import org.jetbrains.annotations.NotNull;
  *   <li>{@link #absolute(String)} - a file named by its full path on the underlying file system.</li>
  * </ul>
  *
- * <p>Access it through {@link Flixel#files Flixel.files}. The active backend is
+ * <p>Access it through {@link Flixel#files}. The active backend is
  * installed there before {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}. Until then, and
  * on headless sessions, a safe default ({@link FlixelNoopFiles}) hands back empty handles so reads
  * never crash.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelFiles.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelFiles.java
@@ -23,6 +23,9 @@
  */
 package org.flixelgdx.file;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
+import org.flixelgdx.backend.FlixelGameRunner;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -44,8 +47,8 @@ import org.jetbrains.annotations.NotNull;
  *   <li>{@link #absolute(String)} - a file named by its full path on the underlying file system.</li>
  * </ul>
  *
- * <p>Access it through {@link org.flixelgdx.Flixel#files Flixel.files}. The active backend is
- * installed there before {@link org.flixelgdx.Flixel#start(org.flixelgdx.FlixelGame, org.flixelgdx.backend.FlixelGameRunner) Flixel.start(...)}. Until then, and
+ * <p>Access it through {@link Flixel#files Flixel.files}. The active backend is
+ * installed there before {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}. Until then, and
  * on headless sessions, a safe default ({@link FlixelNoopFiles}) hands back empty handles so reads
  * never crash.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelNoopFiles.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelNoopFiles.java
@@ -23,10 +23,12 @@
  */
 package org.flixelgdx.file;
 
+import org.flixelgdx.Flixel;
+
 /**
  * A {@link FlixelFiles} that hands back empty {@link FlixelNoopFile} handles for every root.
  *
- * <p>This is the safe default installed on {@link org.flixelgdx.Flixel#files Flixel.files} before a
+ * <p>This is the safe default installed on {@link Flixel#files Flixel.files} before a
  * backend provides a real file system, and on headless sessions. Every root returns a handle that
  * reports "nothing here", so file lookups and reads are always safe to call. It inherits every
  * method from {@link FlixelFiles}, whose defaults already return the no-op handle.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelNoopFiles.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/file/FlixelNoopFiles.java
@@ -28,7 +28,7 @@ import org.flixelgdx.Flixel;
 /**
  * A {@link FlixelFiles} that hands back empty {@link FlixelNoopFile} handles for every root.
  *
- * <p>This is the safe default installed on {@link Flixel#files Flixel.files} before a
+ * <p>This is the safe default installed on {@link Flixel#files} before a
  * backend provides a real file system, and on headless sessions. Every root returns a handle that
  * reports "nothing here", so file lookups and reads are always safe to call. It inherits every
  * method from {@link FlixelFiles}, whose defaults already return the no-op handle.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelAngleable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelAngleable.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelObject;
+
 /**
  * Something with a rotation angle in degrees that angle tweens and motion integration can drive.
  *
@@ -32,7 +34,7 @@ public interface FlixelAngleable {
 
   /**
    * The angle in degrees of this object. Does not affect axis-aligned collision on
-   * {@link org.flixelgdx.FlixelObject FlixelObject}.
+   * {@link FlixelObject FlixelObject}.
    *
    * @return The current angle in degrees.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelAngleable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelAngleable.java
@@ -34,7 +34,7 @@ public interface FlixelAngleable {
 
   /**
    * The angle in degrees of this object. Does not affect axis-aligned collision on
-   * {@link FlixelObject FlixelObject}.
+   * {@link FlixelObject}.
    *
    * @return The current angle in degrees.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelKillable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelKillable.java
@@ -29,8 +29,8 @@ import org.flixelgdx.FlixelBasic;
  * Flixel-style kill and revive.
  *
  * <p>A killed object should not run normal updates or draws, but can be
- * revived later without reallocating. See {@link FlixelBasic#kill() FlixelBasic.kill()} and
- * {@link FlixelBasic#revive() FlixelBasic.revive()}.
+ * revived later without reallocating. See {@link FlixelBasic#kill()} and
+ * {@link FlixelBasic#revive()}.
  */
 public interface FlixelKillable {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelKillable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelKillable.java
@@ -23,12 +23,14 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelBasic;
+
 /**
  * Flixel-style kill and revive.
  *
  * <p>A killed object should not run normal updates or draws, but can be
- * revived later without reallocating. See {@link org.flixelgdx.FlixelBasic#kill() FlixelBasic.kill()} and
- * {@link org.flixelgdx.FlixelBasic#revive() FlixelBasic.revive()}.
+ * revived later without reallocating. See {@link FlixelBasic#kill() FlixelBasic.kill()} and
+ * {@link FlixelBasic#revive() FlixelBasic.revive()}.
  */
 public interface FlixelKillable {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPhysical.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPhysical.java
@@ -23,10 +23,12 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelObject;
+
 /**
  * Kinematic physics contract that extends {@link FlixelPositional} with velocity, acceleration, drag,
  * max velocity, angular motion, and collision-immovable control. This is the full motion surface shared
- * by {@link org.flixelgdx.FlixelObject FlixelObject}.
+ * by {@link FlixelObject FlixelObject}.
  *
  * <p>Motion tweens and physics code that need both position and kinematics should accept this type
  * rather than {@link FlixelPositional}, which covers only spatial layout.
@@ -237,15 +239,15 @@ public interface FlixelPhysical extends FlixelPositional {
   void setMaxAngularVelocity(float mav);
 
   /**
-   * When {@code true}, {@link org.flixelgdx.FlixelObject#updateMotion(float) FlixelObject.updateMotion(float)} runs each frame on
-   * {@link org.flixelgdx.FlixelObject FlixelObject}.
+   * When {@code true}, {@link FlixelObject#updateMotion(float) FlixelObject.updateMotion(float)} runs each frame on
+   * {@link FlixelObject FlixelObject}.
    *
    * @return Whether integrated motion is enabled.
    */
   boolean getMoves();
 
   /**
-   * Enables or disables automatic motion integration on {@link org.flixelgdx.FlixelObject FlixelObject}.
+   * Enables or disables automatic motion integration on {@link FlixelObject FlixelObject}.
    *
    * @param moves {@code true} to integrate velocity each frame.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPhysical.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPhysical.java
@@ -28,7 +28,7 @@ import org.flixelgdx.FlixelObject;
 /**
  * Kinematic physics contract that extends {@link FlixelPositional} with velocity, acceleration, drag,
  * max velocity, angular motion, and collision-immovable control. This is the full motion surface shared
- * by {@link FlixelObject FlixelObject}.
+ * by {@link FlixelObject}.
  *
  * <p>Motion tweens and physics code that need both position and kinematics should accept this type
  * rather than {@link FlixelPositional}, which covers only spatial layout.
@@ -240,14 +240,14 @@ public interface FlixelPhysical extends FlixelPositional {
 
   /**
    * When {@code true}, {@link FlixelObject#updateMotion(float) FlixelObject.updateMotion(float)} runs each frame on
-   * {@link FlixelObject FlixelObject}.
+   * {@link FlixelObject}.
    *
    * @return Whether integrated motion is enabled.
    */
   boolean getMoves();
 
   /**
-   * Enables or disables automatic motion integration on {@link FlixelObject FlixelObject}.
+   * Enables or disables automatic motion integration on {@link FlixelObject}.
    *
    * @param moves {@code true} to integrate velocity each frame.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPhysical.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPhysical.java
@@ -239,7 +239,7 @@ public interface FlixelPhysical extends FlixelPositional {
   void setMaxAngularVelocity(float mav);
 
   /**
-   * When {@code true}, {@link FlixelObject#updateMotion(float) FlixelObject.updateMotion(float)} runs each frame on
+   * When {@code true}, {@link FlixelObject#updateMotion(float)} runs each frame on
    * {@link FlixelObject}.
    *
    * @return Whether integrated motion is enabled.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPositional.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPositional.java
@@ -23,8 +23,10 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelObject;
+
 /**
- * Spatial surface shared by {@link org.flixelgdx.FlixelObject FlixelObject}: world position, hitbox size, and
+ * Spatial surface shared by {@link FlixelObject FlixelObject}: world position, hitbox size, and
  * scroll factors. Code that only needs to read or set where something sits in the world (camera follow,
  * mouse overlap, motion tweens that only care about placement) should accept this type.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPositional.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelPositional.java
@@ -26,7 +26,7 @@ package org.flixelgdx.functional;
 import org.flixelgdx.FlixelObject;
 
 /**
- * Spatial surface shared by {@link FlixelObject FlixelObject}: world position, hitbox size, and
+ * Spatial surface shared by {@link FlixelObject}: world position, hitbox size, and
  * scroll factors. Code that only needs to read or set where something sits in the world (camera follow,
  * mouse overlap, motion tweens that only care about placement) should accept this type.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShaderable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShaderable.java
@@ -31,8 +31,8 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Marks an object that can have a {@link FlixelShader} applied to it.
  *
- * <p>Implemented by both {@link FlixelSprite FlixelSprite} (per-sprite batch
- * interruption) and {@link FlixelCamera FlixelCamera} (full-scene FBO
+ * <p>Implemented by both {@link FlixelSprite} (per-sprite batch
+ * interruption) and {@link FlixelCamera} (full-scene FBO
  * post-processing). Both follow the same ownership contract: the shader is NOT owned by the
  * implementing object. The caller is responsible for calling {@link FlixelShader#destroy()} when
  * the shader is no longer needed.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShaderable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShaderable.java
@@ -23,14 +23,16 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelCamera;
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.util.FlixelShader;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Marks an object that can have a {@link FlixelShader} applied to it.
  *
- * <p>Implemented by both {@link org.flixelgdx.FlixelSprite FlixelSprite} (per-sprite batch
- * interruption) and {@link org.flixelgdx.FlixelCamera FlixelCamera} (full-scene FBO
+ * <p>Implemented by both {@link FlixelSprite FlixelSprite} (per-sprite batch
+ * interruption) and {@link FlixelCamera FlixelCamera} (full-scene FBO
  * post-processing). Both follow the same ownership contract: the shader is NOT owned by the
  * implementing object. The caller is responsible for calling {@link FlixelShader#destroy()} when
  * the shader is no longer needed.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShakeable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShakeable.java
@@ -31,13 +31,13 @@ import org.flixelgdx.tween.settings.FlixelShakeUnit;
 import org.flixelgdx.tween.type.FlixelShakeTween;
 
 /**
- * Something {@link FlixelShakeTween FlixelShakeTween} can jitter and restore without caring whether
+ * Something {@link FlixelShakeTween} can jitter and restore without caring whether
  * the underlying channel is a sprite graphic offset, a world position, or a desktop window position.
  *
- * <p>Implementations choose what X and Y mean: {@link FlixelSprite FlixelSprite} uses graphic
- * {@linkplain org.flixelgdx.FlixelSprite#getOffsetX() offset}; {@link FlixelObject FlixelObject}
+ * <p>Implementations choose what X and Y mean: {@link FlixelSprite} uses graphic
+ * {@linkplain org.flixelgdx.FlixelSprite#getOffsetX() offset}; {@link FlixelObject}
  * uses world {@linkplain org.flixelgdx.functional.FlixelPositional position};
- * {@link FlixelWindow FlixelWindow} uses window placement in screen coordinates.
+ * {@link FlixelWindow} uses window placement in screen coordinates.
  *
  * @see org.flixelgdx.tween.type.FlixelShakeTween
  */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShakeable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelShakeable.java
@@ -24,16 +24,18 @@
 package org.flixelgdx.functional;
 
 import org.flixelgdx.Flixel;
-
+import org.flixelgdx.FlixelObject;
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.backend.FlixelWindow;
 import org.flixelgdx.tween.settings.FlixelShakeUnit;
+import org.flixelgdx.tween.type.FlixelShakeTween;
 
 /**
- * Something {@link org.flixelgdx.tween.type.FlixelShakeTween FlixelShakeTween} can jitter and restore without caring whether
+ * Something {@link FlixelShakeTween FlixelShakeTween} can jitter and restore without caring whether
  * the underlying channel is a sprite graphic offset, a world position, or a desktop window position.
  *
- * <p>Implementations choose what X and Y mean: {@link org.flixelgdx.FlixelSprite FlixelSprite} uses graphic
- * {@linkplain org.flixelgdx.FlixelSprite#getOffsetX() offset}; {@link org.flixelgdx.FlixelObject FlixelObject}
+ * <p>Implementations choose what X and Y mean: {@link FlixelSprite FlixelSprite} uses graphic
+ * {@linkplain org.flixelgdx.FlixelSprite#getOffsetX() offset}; {@link FlixelObject FlixelObject}
  * uses world {@linkplain org.flixelgdx.functional.FlixelPositional position};
  * {@link FlixelWindow FlixelWindow} uses window placement in screen coordinates.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelVisible.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelVisible.java
@@ -27,7 +27,7 @@ import org.flixelgdx.FlixelBasic;
 
 /**
  * Something that can be shown or hidden for drawing. Matches the usual {@code visible} flag on
- * {@link FlixelBasic FlixelBasic}.
+ * {@link FlixelBasic}.
  */
 public interface FlixelVisible {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelVisible.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelVisible.java
@@ -23,9 +23,11 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelBasic;
+
 /**
  * Something that can be shown or hidden for drawing. Matches the usual {@code visible} flag on
- * {@link org.flixelgdx.FlixelBasic FlixelBasic}.
+ * {@link FlixelBasic FlixelBasic}.
  */
 public interface FlixelVisible {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/IFlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/IFlixelBasic.java
@@ -23,16 +23,19 @@
  */
 package org.flixelgdx.functional;
 
+import org.flixelgdx.FlixelBasic;
+import org.flixelgdx.FlixelState;
 import org.flixelgdx.collections.FlixelPoolable;
+import org.flixelgdx.group.FlixelBasicGroup;
 
 /**
- * Full {@link org.flixelgdx.FlixelBasic FlixelBasic}-style contract: per-frame update and draw hooks,
+ * Full {@link FlixelBasic FlixelBasic}-style contract: per-frame update and draw hooks,
  * existence and active flags (see {@link FlixelExistable}), visibility, kill and revive, teardown
  * ({@link FlixelDestroyable}), and the {@link FlixelPoolable} reset hook. Extend
- * {@link org.flixelgdx.FlixelBasic FlixelBasic} when you want the default field-based implementation,
+ * {@link FlixelBasic FlixelBasic} when you want the default field-based implementation,
  * or implement this interface on your own type when you need a custom base class but still want to add
- * instances to a {@link org.flixelgdx.FlixelState FlixelState} or
- * {@link org.flixelgdx.group.FlixelBasicGroup FlixelBasicGroup}.
+ * instances to a {@link FlixelState FlixelState} or
+ * {@link FlixelBasicGroup FlixelBasicGroup}.
  *
  * @see org.flixelgdx.FlixelBasic
  * @see org.flixelgdx.group.FlixelBasicGroup

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/IFlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/IFlixelBasic.java
@@ -29,13 +29,13 @@ import org.flixelgdx.collections.FlixelPoolable;
 import org.flixelgdx.group.FlixelBasicGroup;
 
 /**
- * Full {@link FlixelBasic FlixelBasic}-style contract: per-frame update and draw hooks,
+ * Full {@link FlixelBasic}-style contract: per-frame update and draw hooks,
  * existence and active flags (see {@link FlixelExistable}), visibility, kill and revive, teardown
  * ({@link FlixelDestroyable}), and the {@link FlixelPoolable} reset hook. Extend
- * {@link FlixelBasic FlixelBasic} when you want the default field-based implementation,
+ * {@link FlixelBasic} when you want the default field-based implementation,
  * or implement this interface on your own type when you need a custom base class but still want to add
- * instances to a {@link FlixelState FlixelState} or
- * {@link FlixelBasicGroup FlixelBasicGroup}.
+ * instances to a {@link FlixelState} or
+ * {@link FlixelBasicGroup}.
  *
  * @see org.flixelgdx.FlixelBasic
  * @see org.flixelgdx.group.FlixelBasicGroup

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelBatch.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelBatch.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.graphics;
 
 import org.flixelgdx.functional.FlixelDestroyable;
+import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.math.FlixelAffine;
 import org.flixelgdx.math.FlixelMatrix;
 import org.flixelgdx.util.FlixelBlendMode;
@@ -36,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * The 2D sprite batch: collects textured quads and submits them to the GPU in as few draw calls
  * as possible.
  *
- * <p>Every {@link org.flixelgdx.functional.FlixelDrawable FlixelDrawable} in the framework renders
+ * <p>Every {@link FlixelDrawable FlixelDrawable} in the framework renders
  * through the shared batch returned by {@link FlixelGraphicsManager#getBatch()}. The batch is
  * implemented by the active graphics backend, so game code drawing through this interface runs
  * unchanged on every platform.
@@ -146,7 +147,7 @@ public interface FlixelBatch extends FlixelDestroyable {
    *
    * <p>Each vertex is five floats in this exact order: {@code x}, {@code y} (world position),
    * {@code u}, {@code v} (texture coordinates in {@code [0, 1]}), and a packed color float from
-   * {@link org.flixelgdx.util.FlixelColor#toFloatBits()}. Four consecutive vertices form one quad,
+   * {@link FlixelColor#toFloatBits()}. Four consecutive vertices form one quad,
    * wound bottom-left, bottom-right, top-right, top-left. The batch's tint, blend mode, shader, and
    * transforms still apply, exactly as they do for the other overloads.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelBatch.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelBatch.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * The 2D sprite batch: collects textured quads and submits them to the GPU in as few draw calls
  * as possible.
  *
- * <p>Every {@link FlixelDrawable FlixelDrawable} in the framework renders
+ * <p>Every {@link FlixelDrawable} in the framework renders
  * through the shared batch returned by {@link FlixelGraphicsManager#getBatch()}. The batch is
  * implemented by the active graphics backend, so game code drawing through this interface runs
  * unchanged on every platform.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphic.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.graphics;
 
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.asset.FlixelAsset;
 import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.asset.FlixelAssetMode;
@@ -52,7 +53,7 @@ import java.util.Objects;
  *     to zero and {@link FlixelAssetManager#clearNonPersist()} runs, depending on the
  *     {@link FlixelAssetMode configured asset mode}.</li>
  *   <li><b>Owned</b> - Created with a dedicated {@link FlixelTexture} (e.g. from
- *     {@link org.flixelgdx.FlixelSprite#makeGraphic FlixelSprite.makeGraphic}). The texture is
+ *     {@link FlixelSprite#makeGraphic FlixelSprite.makeGraphic}). The texture is
  *     destroyed directly when the graphic is evicted. {@link #isOwned()} is {@code true}.</li>
  * </ul>
  *
@@ -252,7 +253,7 @@ public class FlixelGraphic implements FlixelAsset<FlixelGraphic> {
 
   /**
    * Returns {@code true} if this graphic wraps a dedicated texture (e.g. from
-   * {@link org.flixelgdx.FlixelSprite#makeGraphic FlixelSprite.makeGraphic}) that is destroyed
+   * {@link FlixelSprite#makeGraphic FlixelSprite.makeGraphic}) that is destroyed
    * directly when the graphic is evicted.
    *
    * @return {@code true} if owned.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphic.java
@@ -53,7 +53,7 @@ import java.util.Objects;
  *     to zero and {@link FlixelAssetManager#clearNonPersist()} runs, depending on the
  *     {@link FlixelAssetMode configured asset mode}.</li>
  *   <li><b>Owned</b> - Created with a dedicated {@link FlixelTexture} (e.g. from
- *     {@link FlixelSprite#makeGraphic FlixelSprite.makeGraphic}). The texture is
+ *     {@link FlixelSprite#makeGraphic}). The texture is
  *     destroyed directly when the graphic is evicted. {@link #isOwned()} is {@code true}.</li>
  * </ul>
  *
@@ -253,7 +253,7 @@ public class FlixelGraphic implements FlixelAsset<FlixelGraphic> {
 
   /**
    * Returns {@code true} if this graphic wraps a dedicated texture (e.g. from
-   * {@link FlixelSprite#makeGraphic FlixelSprite.makeGraphic}) that is destroyed
+   * {@link FlixelSprite#makeGraphic}) that is destroyed
    * directly when the graphic is evicted.
    *
    * @return {@code true} if owned.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicsManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicsManager.java
@@ -23,7 +23,10 @@
  */
 package org.flixelgdx.graphics;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelCamera;
 import org.flixelgdx.FlixelGame;
+import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.collections.FlixelList;
 import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.util.FlixelShader;
@@ -34,7 +37,7 @@ import java.nio.ByteBuffer;
 
 /**
  * The graphics device: the one interface a graphics backend implements and the surface game code
- * draws through, reached from {@link org.flixelgdx.Flixel#graphics Flixel.graphics}.
+ * draws through, reached from {@link Flixel#graphics Flixel.graphics}.
  *
  * <p>Each backend (for example, bgfx on native, WebGPU or WebGL in the browser) implements this
  * interface, so the same game code runs unchanged no matter which one is active. The underlying GPU
@@ -288,7 +291,7 @@ public interface FlixelGraphicsManager {
    * mip levels, and a compressed pixel format), not a plain image to unpack into RGBA. The backend
    * hands the whole container to the GPU driver, which keeps the compressed data resident and saves
    * both memory and upload bandwidth. This is how {@code .ktx2} siblings load when a backend
-   * supports them; see {@link org.flixelgdx.asset.FlixelAssetManager#setCompressedTexturesEnabled(boolean)}.
+   * supports them; see {@link FlixelAssetManager#setCompressedTexturesEnabled(boolean)}.
    *
    * <p>Returns {@code null} when the running backend cannot consume compressed containers, so the
    * asset system can fall back to the plain image. The default is {@code null} (unsupported).
@@ -426,7 +429,7 @@ public interface FlixelGraphicsManager {
    * Loads a shader compiled at build time and compiles the variant matching the active renderer.
    *
    * <p>Each backend that supports precompiled shaders overrides this method to locate and load the
-   * right variant for its rendering API. Game code uses {@link org.flixelgdx.util.FlixelShader#load}
+   * right variant for its rendering API. Game code uses {@link FlixelShader#load}
    * rather than calling this directly.
    *
    * <p>The default returns {@link FlixelUnsupportedShader} so headless and pre-startup sessions
@@ -532,7 +535,7 @@ public interface FlixelGraphicsManager {
   /**
    * Adds a shader to the global post-processing chain applied to all game cameras together.
    *
-   * <p>Unlike per-camera shaders (see {@link org.flixelgdx.FlixelCamera#setShader(FlixelShader)}),
+   * <p>Unlike per-camera shaders (see {@link FlixelCamera#setShader(FlixelShader)}),
    * a global shader captures the combined output of every game camera into a single full-screen
    * framebuffer and applies the effect in one pass. This means barrel distortion, scanlines, and
    * similar effects align correctly across camera boundaries. The global overlay is drawn after the

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicsManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicsManager.java
@@ -37,7 +37,7 @@ import java.nio.ByteBuffer;
 
 /**
  * The graphics device: the one interface a graphics backend implements and the surface game code
- * draws through, reached from {@link Flixel#graphics Flixel.graphics}.
+ * draws through, reached from {@link Flixel#graphics}.
  *
  * <p>Each backend (for example, bgfx on native, WebGPU or WebGL in the browser) implements this
  * interface, so the same game code runs unchanged no matter which one is active. The underlying GPU

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelNoopGraphicsManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelNoopGraphicsManager.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
  * targets.
  *
  * <p>Every operation is a no-op and every query returns the neutral default defined by the
- * interface, so {@link Flixel#graphics Flixel.graphics} is always safe to call even
+ * interface, so {@link Flixel#graphics} is always safe to call even
  * with no GPU present. {@link #getApi()} reports {@link FlixelGraphicsApi#Noop}.
  */
 public enum FlixelNoopGraphicsManager implements FlixelGraphicsManager {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelNoopGraphicsManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelNoopGraphicsManager.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.graphics;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelList;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
  * targets.
  *
  * <p>Every operation is a no-op and every query returns the neutral default defined by the
- * interface, so {@link org.flixelgdx.Flixel#graphics Flixel.graphics} is always safe to call even
+ * interface, so {@link Flixel#graphics Flixel.graphics} is always safe to call even
  * with no GPU present. {@link #getApi()} reports {@link FlixelGraphicsApi#Noop}.
  */
 public enum FlixelNoopGraphicsManager implements FlixelGraphicsManager {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.NotNull;
  * Maps a rectangular world view onto a rectangle of the screen: the combination of an
  * orthographic 2D camera and a scaling policy.
  *
- * <p>Every {@link FlixelCamera FlixelCamera} owns one of these. The
+ * <p>Every {@link FlixelCamera} owns one of these. The
  * {@link Scaling} policy decides what happens when the window's shape does not match the
  * game's design resolution: {@link Scaling#FIT} letterboxes, {@link Scaling#EXTEND} grows the
  * visible world to fill the screen, and {@link Scaling#STRETCH} distorts. The viewport also

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelViewport.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.graphics;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelCamera;
 import org.flixelgdx.FlixelConfig;
 import org.flixelgdx.math.FlixelMatrix;
 import org.flixelgdx.math.FlixelRect;
@@ -34,7 +35,7 @@ import org.jetbrains.annotations.NotNull;
  * Maps a rectangular world view onto a rectangle of the screen: the combination of an
  * orthographic 2D camera and a scaling policy.
  *
- * <p>Every {@link org.flixelgdx.FlixelCamera FlixelCamera} owns one of these. The
+ * <p>Every {@link FlixelCamera FlixelCamera} owns one of these. The
  * {@link Scaling} policy decides what happens when the window's shape does not match the
  * game's design resolution: {@link Scaling#FIT} letterboxes, {@link Scaling#EXTEND} grows the
  * visible world to fill the screen, and {@link Scaling#STRETCH} distorts. The viewport also

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.group;
 
+import org.flixelgdx.FlixelBasic;
 import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.graphics.FlixelBatch;
@@ -45,7 +46,7 @@ import java.util.function.Predicate;
  * made up of several member sprites. It implements {@link FlixelBasicGroupable}
  * for managing members while inheriting all sprite properties from {@link FlixelSprite}.
  * <p>
- * Because FlixelSpriteGroup extends {@link org.flixelgdx.FlixelSprite FlixelSprite}, groups can be nested
+ * Because FlixelSpriteGroup extends {@link FlixelSprite FlixelSprite}, groups can be nested
  * inside other groups, enabling complex hierarchical sprite compositions. Any property
  * change on the group (position, alpha, color, scale, rotation, flip) automatically
  * propagates to all members.
@@ -65,7 +66,7 @@ import java.util.function.Predicate;
  * </ul>
  *
  * <p>{@link #remove} and {@link #detach} restore local coordinates and unlink the sprite; they do not call
- * {@link FlixelSprite#destroy()}. Use {@link org.flixelgdx.FlixelBasic#kill() FlixelBasic.kill()} / {@link org.flixelgdx.FlixelBasic#revive() FlixelBasic.revive()} or
+ * {@link FlixelSprite#destroy()}. Use {@link FlixelBasic#kill() FlixelBasic.kill()} / {@link FlixelBasic#revive() FlixelBasic.revive()} or
  * {@link #recycle()} for reuse. {@link #clear()} unlinks all members without destroying them.
  * {@link #destroy()} on this group destroys every member (releases graphics) and resets group state.
  */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -66,7 +66,7 @@ import java.util.function.Predicate;
  * </ul>
  *
  * <p>{@link #remove} and {@link #detach} restore local coordinates and unlink the sprite; they do not call
- * {@link FlixelSprite#destroy()}. Use {@link FlixelBasic#kill() FlixelBasic.kill()} / {@link FlixelBasic#revive() FlixelBasic.revive()} or
+ * {@link FlixelSprite#destroy()}. Use {@link FlixelBasic#kill()} / {@link FlixelBasic#revive()} or
  * {@link #recycle()} for reuse. {@link #clear()} unlinks all members without destroying them.
  * {@link #destroy()} on this group destroys every member (releases graphics) and resets group state.
  */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -46,7 +46,7 @@ import java.util.function.Predicate;
  * made up of several member sprites. It implements {@link FlixelBasicGroupable}
  * for managing members while inheriting all sprite properties from {@link FlixelSprite}.
  * <p>
- * Because FlixelSpriteGroup extends {@link FlixelSprite FlixelSprite}, groups can be nested
+ * Because FlixelSpriteGroup extends {@link FlixelSprite}, groups can be nested
  * inside other groups, enabling complex hierarchical sprite compositions. Any property
  * change on the group (position, alpha, color, scale, rotation, flip) automatically
  * propagates to all members.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputDevice.java
@@ -23,13 +23,14 @@
  */
 package org.flixelgdx.input;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.input.keyboard.FlixelKey;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
 
 /**
  * The low-level input backend: the one interface each platform implements so the framework can read
  * the keyboard and pointer without naming a specific windowing library. Reached through
- * {@link org.flixelgdx.Flixel#input Flixel.input}.
+ * {@link Flixel#input Flixel.input}.
  *
  * <p>Input arrives two complementary ways. Framework managers (keyboard, mouse, touch) <b>listen</b>:
  * they register a {@link FlixelKeyboardListener}, {@link FlixelMouseListener}, or

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputDevice.java
@@ -30,7 +30,7 @@ import org.flixelgdx.input.mouse.FlixelMouseButton;
 /**
  * The low-level input backend: the one interface each platform implements so the framework can read
  * the keyboard and pointer without naming a specific windowing library. Reached through
- * {@link Flixel#input Flixel.input}.
+ * {@link Flixel#input}.
  *
  * <p>Input arrives two complementary ways. Framework managers (keyboard, mouse, touch) <b>listen</b>:
  * they register a {@link FlixelKeyboardListener}, {@link FlixelMouseListener}, or

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputManager.java
@@ -30,7 +30,7 @@ import org.flixelgdx.FlixelGame;
  *
  * <p>Call {@link #update()} once near the start of the frame, then {@link #endFrame()} after game
  * logic and rendering so edge-triggered helpers (for example {@code justPressed}) stay valid for
- * the full frame, matching {@link FlixelGame FlixelGame}.
+ * the full frame, matching {@link FlixelGame}.
  */
 public interface FlixelInputManager {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputManager.java
@@ -23,12 +23,14 @@
  */
 package org.flixelgdx.input;
 
+import org.flixelgdx.FlixelGame;
+
 /**
  * Shared per-frame contract for polled input managers (keyboard, mouse, gamepads).
  *
  * <p>Call {@link #update()} once near the start of the frame, then {@link #endFrame()} after game
  * logic and rendering so edge-triggered helpers (for example {@code justPressed}) stay valid for
- * the full frame, matching {@link org.flixelgdx.FlixelGame FlixelGame}.
+ * the full frame, matching {@link FlixelGame FlixelGame}.
  */
 public interface FlixelInputManager {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelMouseListener.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelMouseListener.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.input;
 
+import org.flixelgdx.FlixelCamera;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
 
 /**
@@ -37,7 +38,7 @@ import org.flixelgdx.input.mouse.FlixelMouseButton;
  * listeners in the chain should see it. Returning {@code false} lets it propagate.
  *
  * <p>Screen coordinates use the top-left origin: X grows right, Y grows down. Convert to world
- * space through a {@link org.flixelgdx.FlixelCamera FlixelCamera} when needed.
+ * space through a {@link FlixelCamera FlixelCamera} when needed.
  *
  * @see FlixelInputDevice#addMouseListener(FlixelMouseListener)
  * @see FlixelKeyboardListener

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelMouseListener.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelMouseListener.java
@@ -38,7 +38,7 @@ import org.flixelgdx.input.mouse.FlixelMouseButton;
  * listeners in the chain should see it. Returning {@code false} lets it propagate.
  *
  * <p>Screen coordinates use the top-left origin: X grows right, Y grows down. Convert to world
- * space through a {@link FlixelCamera FlixelCamera} when needed.
+ * space through a {@link FlixelCamera} when needed.
  *
  * @see FlixelInputDevice#addMouseListener(FlixelMouseListener)
  * @see FlixelKeyboardListener

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelNoopInputDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelNoopInputDevice.java
@@ -29,7 +29,7 @@ import org.flixelgdx.Flixel;
  * Safe default {@link FlixelInputDevice} for headless and not-yet-initialized sessions.
  *
  * <p>Every poll reports "nothing pressed" and it drops any processor handed to it, so framework code
- * can read {@link Flixel#input Flixel.input} unconditionally before a real backend is
+ * can read {@link Flixel#input} unconditionally before a real backend is
  * installed. It relies entirely on the interface's neutral defaults.
  */
 public enum FlixelNoopInputDevice implements FlixelInputDevice {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelNoopInputDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelNoopInputDevice.java
@@ -23,11 +23,13 @@
  */
 package org.flixelgdx.input;
 
+import org.flixelgdx.Flixel;
+
 /**
  * Safe default {@link FlixelInputDevice} for headless and not-yet-initialized sessions.
  *
  * <p>Every poll reports "nothing pressed" and it drops any processor handed to it, so framework code
- * can read {@link org.flixelgdx.Flixel#input Flixel.input} unconditionally before a real backend is
+ * can read {@link Flixel#input Flixel.input} unconditionally before a real backend is
  * installed. It relies entirely on the interface's neutral defaults.
  */
 public enum FlixelNoopInputDevice implements FlixelInputDevice {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.input.action;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.collections.FlixelMap;
 import org.flixelgdx.math.FlixelVector;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +38,7 @@ import java.util.Objects;
  * <h2>How values combine</h2>
  *
  * <p>Each frame, key halves add {@code -1}, {@code 0}, or {@code +1} per axis;
- * {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads} axis bindings add smooth stick values.
+ * {@link Flixel#gamepads Flixel.gamepads} axis bindings add smooth stick values.
  * Steam {@link FlixelSteamActionReader#getAnalogX} / {@code getAnalogY} are added on top. The
  * result is clamped to a maximum length of {@code 1} so diagonals do not exceed unit speed when
  * mixing keys and sticks.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * <h2>How values combine</h2>
  *
  * <p>Each frame, key halves add {@code -1}, {@code 0}, or {@code +1} per axis;
- * {@link Flixel#gamepads Flixel.gamepads} axis bindings add smooth stick values.
+ * {@link Flixel#gamepads} axis bindings add smooth stick values.
  * Steam {@link FlixelSteamActionReader#getAnalogX} / {@code getAnalogY} are added on top. The
  * result is clamped to a maximum length of {@code 1} so diagonals do not exceed unit speed when
  * mixing keys and sticks.
@@ -67,7 +67,7 @@ import java.util.Objects;
  * {@link #flickThreshold}. It resets to {@code false} as long as the stick stays past the
  * threshold, and fires again only after the stick returns below the threshold and crosses it again.
  * This mirrors the single-frame contract of
- * {@link FlixelActionDigital#justPressed() FlixelActionDigital.justPressed()} and is useful for
+ * {@link FlixelActionDigital#justPressed()} and is useful for
  * menu navigation where each stick deflection should trigger exactly one action.
  *
  * <p>{@link #flickedRepeating()} extends that with hold-repeat: it fires on the initial flick,
@@ -321,7 +321,7 @@ public class FlixelActionAnalog extends FlixelAction {
    *
    * <p>Stays {@code false} while the stick remains past the threshold, and fires again only after
    * the stick drops below it and crosses it once more. This mirrors the single-frame contract of
-   * {@link FlixelActionDigital#justPressed() FlixelActionDigital.justPressed()}, making it safe to
+   * {@link FlixelActionDigital#justPressed()}, making it safe to
    * use for menu navigation where one deflection should trigger exactly one action.
    *
    * <p>Key and button bindings contribute {@code +-1.0} per axis, so any bound key press that

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -55,7 +55,7 @@ import java.util.Objects;
  * <p>State is refreshed in {@link FlixelActionSet#update(float)} (via
  * {@link FlixelActionSets#update(float)}). {@link FlixelActionSet#endFrame()} (via
  * {@link FlixelActionSets#endFrameAll()}) runs after
- * {@link FlixelGame#endFrame() FlixelGame.endFrame()} finalizes keys and mouse, matching
+ * {@link FlixelGame#endFrame()} finalizes keys and mouse, matching
  * their {@code justPressed} timing.
  *
  * <h2>Optional callback</h2>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.input.action;
 
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.collections.FlixelMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -54,7 +55,7 @@ import java.util.Objects;
  * <p>State is refreshed in {@link FlixelActionSet#update(float)} (via
  * {@link FlixelActionSets#update(float)}). {@link FlixelActionSet#endFrame()} (via
  * {@link FlixelActionSets#endFrameAll()}) runs after
- * {@link org.flixelgdx.FlixelGame#endFrame() FlixelGame.endFrame()} finalizes keys and mouse, matching
+ * {@link FlixelGame#endFrame() FlixelGame.endFrame()} finalizes keys and mouse, matching
  * their {@code justPressed} timing.
  *
  * <h2>Optional callback</h2>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
@@ -36,8 +36,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Groups logical {@link FlixelAction} instances (digital and analog) and advances them on the same frame
- * contract as {@link FlixelInputManager}. Actions read {@link Flixel#keys Flixel.keys},
- * {@link Flixel#mouse Flixel.mouse}, {@link Flixel#gamepads Flixel.gamepads}, and {@code Gdx.input}
+ * contract as {@link FlixelInputManager}. Actions read {@link Flixel#keys},
+ * {@link Flixel#mouse}, {@link Flixel#gamepads}, and {@code Gdx.input}
  * during {@link #update(float)}. This class does not hook platform input events directly. Framework keyboard and mouse managers stay the single entry
  * points for those devices.
  *
@@ -50,7 +50,7 @@ import org.jetbrains.annotations.Nullable;
  *   <li>By default the set registers with {@link FlixelActionSets}; {@link FlixelGame} calls
  *       {@link FlixelActionSets#update(float)} after {@code Flixel.gamepads.update()} and {@link FlixelActionSets#endFrameAll()}
  *       after keys, mouse, and gamepads {@code endFrame()} in {@code render()}.</li>
- *   <li>From {@link FlixelState#update(float) FlixelState.update(float)} (or similar), read {@code jump.justPressed()},
+ *   <li>From {@link FlixelState#update(float)} (or similar), read {@code jump.justPressed()},
  *       {@code move.getX()}, etc.</li>
  *   <li>When the screen or mode ends, call {@link #destroy()} so the set unregisters and clears members.</li>
  * </ol>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Groups logical {@link FlixelAction} instances (digital and analog) and advances them on the same frame
- * contract as {@link FlixelInputManager FlixelInputManager}. Actions read {@link Flixel#keys Flixel.keys},
+ * contract as {@link FlixelInputManager}. Actions read {@link Flixel#keys Flixel.keys},
  * {@link Flixel#mouse Flixel.mouse}, {@link Flixel#gamepads Flixel.gamepads}, and {@code Gdx.input}
  * during {@link #update(float)}. This class does not hook platform input events directly. Framework keyboard and mouse managers stay the single entry
  * points for those devices.
@@ -47,7 +47,7 @@ import org.jetbrains.annotations.Nullable;
  *   <li>Construct a subclass (or this type) after {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}.</li>
  *   <li>In the subclass constructor, create {@link FlixelActionDigital} / {@link FlixelActionAnalog} instances,
  *       call {@link #add(FlixelAction)} for each, and add {@link FlixelDigitalBinding} / {@link FlixelAnalogBinding} instances.</li>
- *   <li>By default the set registers with {@link FlixelActionSets}; {@link FlixelGame FlixelGame} calls
+ *   <li>By default the set registers with {@link FlixelActionSets}; {@link FlixelGame} calls
  *       {@link FlixelActionSets#update(float)} after {@code Flixel.gamepads.update()} and {@link FlixelActionSets#endFrameAll()}
  *       after keys, mouse, and gamepads {@code endFrame()} in {@code render()}.</li>
  *   <li>From {@link FlixelState#update(float) FlixelState.update(float)} (or similar), read {@code jump.justPressed()},

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
@@ -23,30 +23,34 @@
  */
 package org.flixelgdx.input.action;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
+import org.flixelgdx.FlixelState;
+import org.flixelgdx.backend.FlixelGameRunner;
 import org.flixelgdx.collections.FlixelArray;
-
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.functional.FlixelUpdatable;
+import org.flixelgdx.input.FlixelInputManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Groups logical {@link FlixelAction} instances (digital and analog) and advances them on the same frame
- * contract as {@link org.flixelgdx.input.FlixelInputManager FlixelInputManager}. Actions read {@link org.flixelgdx.Flixel#keys Flixel.keys},
- * {@link org.flixelgdx.Flixel#mouse Flixel.mouse}, {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads}, and {@code Gdx.input}
+ * contract as {@link FlixelInputManager FlixelInputManager}. Actions read {@link Flixel#keys Flixel.keys},
+ * {@link Flixel#mouse Flixel.mouse}, {@link Flixel#gamepads Flixel.gamepads}, and {@code Gdx.input}
  * during {@link #update(float)}. This class does not hook platform input events directly. Framework keyboard and mouse managers stay the single entry
  * points for those devices.
  *
  * <h2>Lifecycle (normal games)</h2>
  *
  * <ol>
- *   <li>Construct a subclass (or this type) after {@link org.flixelgdx.Flixel#start(org.flixelgdx.FlixelGame, org.flixelgdx.backend.FlixelGameRunner) Flixel.start(...)}.</li>
+ *   <li>Construct a subclass (or this type) after {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}.</li>
  *   <li>In the subclass constructor, create {@link FlixelActionDigital} / {@link FlixelActionAnalog} instances,
  *       call {@link #add(FlixelAction)} for each, and add {@link FlixelDigitalBinding} / {@link FlixelAnalogBinding} instances.</li>
- *   <li>By default the set registers with {@link FlixelActionSets}; {@link org.flixelgdx.FlixelGame FlixelGame} calls
+ *   <li>By default the set registers with {@link FlixelActionSets}; {@link FlixelGame FlixelGame} calls
  *       {@link FlixelActionSets#update(float)} after {@code Flixel.gamepads.update()} and {@link FlixelActionSets#endFrameAll()}
  *       after keys, mouse, and gamepads {@code endFrame()} in {@code render()}.</li>
- *   <li>From {@link org.flixelgdx.FlixelState#update(float) FlixelState.update(float)} (or similar), read {@code jump.justPressed()},
+ *   <li>From {@link FlixelState#update(float) FlixelState.update(float)} (or similar), read {@code jump.justPressed()},
  *       {@code move.getX()}, etc.</li>
  *   <li>When the screen or mode ends, call {@link #destroy()} so the set unregisters and clears members.</li>
  * </ol>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * <h2>When {@code updateAll} runs</h2>
  *
- * <p>Order inside {@link FlixelGame#update(float) FlixelGame.update(float)}: {@code Flixel.keys.update()},
+ * <p>Order inside {@link FlixelGame#update(float)}: {@code Flixel.keys.update()},
  * {@code Flixel.mouse.update()}, {@code Flixel.gamepads.update()}, then {@link #update(float)}. Gameplay code in
  * {@link FlixelState} runs after that, so {@code jump.justPressed()} reflects this frame's input.
  *
@@ -72,7 +72,7 @@ public final class FlixelActionSets {
   }
 
   /**
-   * Invoked from {@link FlixelGame#update(float) FlixelGame.update(float)} after gamepad polling.
+   * Invoked from {@link FlixelGame#update(float)} after gamepad polling.
    *
    * @param elapsed Seconds since last frame (same as game update).
    */
@@ -83,7 +83,7 @@ public final class FlixelActionSets {
   }
 
   /**
-   * Invoked from {@link FlixelGame#endFrame() FlixelGame.endFrame()} after keys, mouse, and gamepads
+   * Invoked from {@link FlixelGame#endFrame()} after keys, mouse, and gamepads
    * have finalized their own per-frame state.
    */
   public static void endFrameAll() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
@@ -31,15 +31,15 @@ import org.flixelgdx.input.FlixelInputManager;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Global registry of {@link FlixelActionSet} instances. {@link FlixelGame FlixelGame} invokes
+ * Global registry of {@link FlixelActionSet} instances. {@link FlixelGame} invokes
  * {@link #update(float)} and {@link #endFrameAll()} so every registered set stays on the same contract as
- * {@link FlixelInputManager FlixelInputManager} (keys, mouse, gamepads).
+ * {@link FlixelInputManager} (keys, mouse, gamepads).
  *
  * <h2>When {@code updateAll} runs</h2>
  *
  * <p>Order inside {@link FlixelGame#update(float) FlixelGame.update(float)}: {@code Flixel.keys.update()},
  * {@code Flixel.mouse.update()}, {@code Flixel.gamepads.update()}, then {@link #update(float)}. Gameplay code in
- * {@link FlixelState FlixelState} runs after that, so {@code jump.justPressed()} reflects this frame's input.
+ * {@link FlixelState} runs after that, so {@code jump.justPressed()} reflects this frame's input.
  *
  * <h2>When {@code endFrameAll} runs</h2>
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
@@ -23,21 +23,23 @@
  */
 package org.flixelgdx.input.action;
 
+import org.flixelgdx.FlixelGame;
+import org.flixelgdx.FlixelState;
 import org.flixelgdx.collections.FlixelArray;
-
 import org.flixelgdx.functional.FlixelDrawable;
+import org.flixelgdx.input.FlixelInputManager;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Global registry of {@link FlixelActionSet} instances. {@link org.flixelgdx.FlixelGame FlixelGame} invokes
+ * Global registry of {@link FlixelActionSet} instances. {@link FlixelGame FlixelGame} invokes
  * {@link #update(float)} and {@link #endFrameAll()} so every registered set stays on the same contract as
- * {@link org.flixelgdx.input.FlixelInputManager FlixelInputManager} (keys, mouse, gamepads).
+ * {@link FlixelInputManager FlixelInputManager} (keys, mouse, gamepads).
  *
  * <h2>When {@code updateAll} runs</h2>
  *
- * <p>Order inside {@link org.flixelgdx.FlixelGame#update(float) FlixelGame.update(float)}: {@code Flixel.keys.update()},
+ * <p>Order inside {@link FlixelGame#update(float) FlixelGame.update(float)}: {@code Flixel.keys.update()},
  * {@code Flixel.mouse.update()}, {@code Flixel.gamepads.update()}, then {@link #update(float)}. Gameplay code in
- * {@link org.flixelgdx.FlixelState FlixelState} runs after that, so {@code jump.justPressed()} reflects this frame's input.
+ * {@link FlixelState FlixelState} runs after that, so {@code jump.justPressed()} reflects this frame's input.
  *
  * <h2>When {@code endFrameAll} runs</h2>
  *
@@ -70,7 +72,7 @@ public final class FlixelActionSets {
   }
 
   /**
-   * Invoked from {@link org.flixelgdx.FlixelGame#update(float) FlixelGame.update(float)} after gamepad polling.
+   * Invoked from {@link FlixelGame#update(float) FlixelGame.update(float)} after gamepad polling.
    *
    * @param elapsed Seconds since last frame (same as game update).
    */
@@ -81,7 +83,7 @@ public final class FlixelActionSets {
   }
 
   /**
-   * Invoked from {@link org.flixelgdx.FlixelGame#endFrame() FlixelGame.endFrame()} after keys, mouse, and gamepads
+   * Invoked from {@link FlixelGame#endFrame() FlixelGame.endFrame()} after keys, mouse, and gamepads
    * have finalized their own per-frame state.
    */
   public static void endFrameAll() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
@@ -63,9 +63,9 @@ public interface FlixelDigitalBinding {
   boolean evaluate();
 
   /**
-   * Keyboard key binding using {@link Flixel#keys Flixel.keys}.
+   * Keyboard key binding using {@link Flixel#keys}.
    *
-   * @param keycode Key constant (for example {@link FlixelKey#SPACE FlixelKey.SPACE}).
+   * @param keycode Key constant (for example {@link FlixelKey#SPACE}).
    * @return Binding that fires while the key is held.
    */
   static FlixelDigitalBinding key(int keycode) {
@@ -73,7 +73,7 @@ public interface FlixelDigitalBinding {
   }
 
   /**
-   * Mouse button binding using {@link Flixel#mouse Flixel.mouse}.
+   * Mouse button binding using {@link Flixel#mouse}.
    *
    * @param button Mouse button index (for example {@link FlixelMouseButton#LEFT}).
    * @return Binding that fires while the button is held.
@@ -83,7 +83,7 @@ public interface FlixelDigitalBinding {
   }
 
   /**
-   * Gamepad button binding using {@link Flixel#gamepads Flixel.gamepads}.
+   * Gamepad button binding using {@link Flixel#gamepads}.
    *
    * @param slot Gamepad slot (0 and up), or {@link #GAMEPAD_SLOT_ANY} to match any connected slot.
    * @param button Logical button token from {@link FlixelGamepadButton}.
@@ -102,7 +102,7 @@ public interface FlixelDigitalBinding {
   }
 
   /**
-   * Touch pointer binding using {@link Flixel#touches Flixel.touches}.
+   * Touch pointer binding using {@link Flixel#touches}.
    *
    * <pre>{@code
    * // Fire while the first finger is down.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
@@ -25,6 +25,7 @@ package org.flixelgdx.input.action;
 
 import org.flixelgdx.Flixel;
 import org.flixelgdx.input.gamepad.FlixelGamepadButton;
+import org.flixelgdx.input.keyboard.FlixelKey;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
 import org.flixelgdx.input.touch.FlixelTouch;
 import org.flixelgdx.input.touch.FlixelTouchManager;
@@ -62,9 +63,9 @@ public interface FlixelDigitalBinding {
   boolean evaluate();
 
   /**
-   * Keyboard key binding using {@link org.flixelgdx.Flixel#keys Flixel.keys}.
+   * Keyboard key binding using {@link Flixel#keys Flixel.keys}.
    *
-   * @param keycode Key constant (for example {@link org.flixelgdx.input.keyboard.FlixelKey#SPACE FlixelKey.SPACE}).
+   * @param keycode Key constant (for example {@link FlixelKey#SPACE FlixelKey.SPACE}).
    * @return Binding that fires while the key is held.
    */
   static FlixelDigitalBinding key(int keycode) {
@@ -72,7 +73,7 @@ public interface FlixelDigitalBinding {
   }
 
   /**
-   * Mouse button binding using {@link org.flixelgdx.Flixel#mouse Flixel.mouse}.
+   * Mouse button binding using {@link Flixel#mouse Flixel.mouse}.
    *
    * @param button Mouse button index (for example {@link FlixelMouseButton#LEFT}).
    * @return Binding that fires while the button is held.
@@ -82,7 +83,7 @@ public interface FlixelDigitalBinding {
   }
 
   /**
-   * Gamepad button binding using {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads}.
+   * Gamepad button binding using {@link Flixel#gamepads Flixel.gamepads}.
    *
    * @param slot Gamepad slot (0 and up), or {@link #GAMEPAD_SLOT_ANY} to match any connected slot.
    * @param button Logical button token from {@link FlixelGamepadButton}.
@@ -101,7 +102,7 @@ public interface FlixelDigitalBinding {
   }
 
   /**
-   * Touch pointer binding using {@link org.flixelgdx.Flixel#touches Flixel.touches}.
+   * Touch pointer binding using {@link Flixel#touches Flixel.touches}.
    *
    * <pre>{@code
    * // Fire while the first finger is down.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -27,6 +27,7 @@ import org.flixelgdx.Flixel;
 import org.flixelgdx.collections.FlixelIntArray;
 import org.flixelgdx.collections.FlixelIntSet;
 import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.flixelgdx.input.FlixelInputDevice;
 import org.flixelgdx.input.FlixelInputManager;
 import org.flixelgdx.input.FlixelKeyboardListener;
 
@@ -36,12 +37,12 @@ import org.flixelgdx.input.FlixelKeyboardListener;
  * <p>Tracks pressed keys by implementing {@link FlixelKeyboardListener} directly. This is the
  * authoritative source of "is key X currently pressed", which keeps state correct across every
  * platform backend. Some backends (notably the web one) do not reliably report every key through
- * polling, so the framework cannot rebuild its set from {@link org.flixelgdx.Flixel#input Flixel.input}
+ * polling, so the framework cannot rebuild its set from {@link Flixel#input Flixel.input}
  * each frame; doing so would erase any state the listener callbacks just wrote and break
  * {@link #justPressed(int)} / {@link #justReleased(int)} there. Instead, {@link #update()} simply
  * records this frame's snapshot for "just" detection without ever touching {@link #currentPressedKeys}.
  *
- * <p>This manager is registered with the active {@link org.flixelgdx.input.FlixelInputDevice FlixelInputDevice}
+ * <p>This manager is registered with the active {@link FlixelInputDevice FlixelInputDevice}
  * automatically in {@code FlixelGame.create()}.
  */
 public class FlixelKeyInputManager implements FlixelInputManager, FlixelKeyboardListener {
@@ -88,7 +89,7 @@ public class FlixelKeyInputManager implements FlixelInputManager, FlixelKeyboard
    * real time, so this method intentionally does nothing.
    *
    * <p>Earlier versions rebuilt {@link #currentPressedKeys} from
-   * {@link org.flixelgdx.Flixel#input Flixel.input.isKeyPressed} every frame, which clobbered any
+   * {@link Flixel#input Flixel.input.isKeyPressed} every frame, which clobbered any
    * state the listener callbacks had just written and silently broke {@link #justPressed(int)},
    * {@link #justReleased(int)}, and the "first" helpers on the web backend (where not every key is
    * exposed through polling). The listener is now the only writer.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -37,7 +37,7 @@ import org.flixelgdx.input.FlixelKeyboardListener;
  * <p>Tracks pressed keys by implementing {@link FlixelKeyboardListener} directly. This is the
  * authoritative source of "is key X currently pressed", which keeps state correct across every
  * platform backend. Some backends (notably the web one) do not reliably report every key through
- * polling, so the framework cannot rebuild its set from {@link Flixel#input Flixel.input}
+ * polling, so the framework cannot rebuild its set from {@link Flixel#input}
  * each frame; doing so would erase any state the listener callbacks just wrote and break
  * {@link #justPressed(int)} / {@link #justReleased(int)} there. Instead, {@link #update()} simply
  * records this frame's snapshot for "just" detection without ever touching {@link #currentPressedKeys}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -42,7 +42,7 @@ import org.flixelgdx.input.FlixelKeyboardListener;
  * {@link #justPressed(int)} / {@link #justReleased(int)} there. Instead, {@link #update()} simply
  * records this frame's snapshot for "just" detection without ever touching {@link #currentPressedKeys}.
  *
- * <p>This manager is registered with the active {@link FlixelInputDevice FlixelInputDevice}
+ * <p>This manager is registered with the active {@link FlixelInputDevice}
  * automatically in {@code FlixelGame.create()}.
  */
 public class FlixelKeyInputManager implements FlixelInputManager, FlixelKeyboardListener {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseButton.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseButton.java
@@ -27,7 +27,7 @@ import org.flixelgdx.input.FlixelMouseListener;
 
 /**
  * Mouse button codes for {@link FlixelMouseInputManager} and the pointer events on
- * {@link FlixelMouseListener FlixelMouseListener}.
+ * {@link FlixelMouseListener}.
  *
  * <p>These are plain integer constants so they cost nothing and read clearly at the call site, for
  * example {@code Flixel.mouse.pressed(FlixelMouseButton.LEFT)}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseButton.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseButton.java
@@ -23,9 +23,11 @@
  */
 package org.flixelgdx.input.mouse;
 
+import org.flixelgdx.input.FlixelMouseListener;
+
 /**
  * Mouse button codes for {@link FlixelMouseInputManager} and the pointer events on
- * {@link org.flixelgdx.input.FlixelMouseListener FlixelMouseListener}.
+ * {@link FlixelMouseListener FlixelMouseListener}.
  *
  * <p>These are plain integer constants so they cost nothing and read clearly at the call site, for
  * example {@code Flixel.mouse.pressed(FlixelMouseButton.LEFT)}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseInputManager.java
@@ -166,7 +166,7 @@ public class FlixelMouseInputManager implements FlixelInputManager, FlixelMouseL
 
   /**
    * Call at end of frame after game logic (with
-   * {@link FlixelKeyInputManager#endFrame() FlixelKeyInputManager.endFrame()}). Resets
+   * {@link FlixelKeyInputManager#endFrame()}). Resets
    * {@link #getScrollDeltaX()} and {@link #getScrollDeltaY()} to zero for the next frame.
    */
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseInputManager.java
@@ -31,6 +31,7 @@ import org.flixelgdx.debug.FlixelDebugOverlay;
 import org.flixelgdx.functional.FlixelPositional;
 import org.flixelgdx.input.FlixelInputManager;
 import org.flixelgdx.input.FlixelMouseListener;
+import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.flixelgdx.math.FlixelVector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -165,7 +166,7 @@ public class FlixelMouseInputManager implements FlixelInputManager, FlixelMouseL
 
   /**
    * Call at end of frame after game logic (with
-   * {@link org.flixelgdx.input.keyboard.FlixelKeyInputManager#endFrame() FlixelKeyInputManager.endFrame()}). Resets
+   * {@link FlixelKeyInputManager#endFrame() FlixelKeyInputManager.endFrame()}). Resets
    * {@link #getScrollDeltaX()} and {@link #getScrollDeltaY()} to zero for the next frame.
    */
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouchManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouchManager.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Multitouch input manager whose state is driven by {@link FlixelTouchListener} callbacks.
  *
- * <p>Access via {@link Flixel#touches Flixel.touches} after the framework is
+ * <p>Access via {@link Flixel#touches} after the framework is
  * initialized. The manager tracks up to {@link #getMaxPointers()} simultaneous fingers in the
  * {@link #list} array. Each slot is a reused {@link FlixelTouch} instance; slot {@code 0} always
  * corresponds to pointer index {@code 0} (the first finger), slot {@code 1} to index {@code 1},
@@ -252,7 +252,7 @@ public class FlixelTouchManager implements FlixelInputManager, FlixelTouchListen
   /**
    * Clears per-frame edge flags ({@link FlixelTouch#justPressed()},
    * {@link FlixelTouch#justReleased()}, {@link FlixelTouch#justCancelled()}) for all pointers.
-   * Called once per frame by {@link FlixelGame#endFrame() FlixelGame.endFrame()} after game logic and drawing finish.
+   * Called once per frame by {@link FlixelGame#endFrame()} after game logic and drawing finish.
    */
   @Override
   public void endFrame() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouchManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/touch/FlixelTouchManager.java
@@ -25,6 +25,7 @@ package org.flixelgdx.input.touch;
 
 import org.flixelgdx.Flixel;
 import org.flixelgdx.FlixelCamera;
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.input.FlixelInputManager;
 import org.flixelgdx.input.FlixelTouchListener;
 import org.flixelgdx.math.FlixelVector;
@@ -33,7 +34,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Multitouch input manager whose state is driven by {@link FlixelTouchListener} callbacks.
  *
- * <p>Access via {@link org.flixelgdx.Flixel#touches Flixel.touches} after the framework is
+ * <p>Access via {@link Flixel#touches Flixel.touches} after the framework is
  * initialized. The manager tracks up to {@link #getMaxPointers()} simultaneous fingers in the
  * {@link #list} array. Each slot is a reused {@link FlixelTouch} instance; slot {@code 0} always
  * corresponds to pointer index {@code 0} (the first finger), slot {@code 1} to index {@code 1},
@@ -251,7 +252,7 @@ public class FlixelTouchManager implements FlixelInputManager, FlixelTouchListen
   /**
    * Clears per-frame edge flags ({@link FlixelTouch#justPressed()},
    * {@link FlixelTouch#justReleased()}, {@link FlixelTouch#justCancelled()}) for all pointers.
-   * Called once per frame by {@link org.flixelgdx.FlixelGame#endFrame() FlixelGame.endFrame()} after game logic and drawing finish.
+   * Called once per frame by {@link FlixelGame#endFrame() FlixelGame.endFrame()} after game logic and drawing finish.
    */
   @Override
   public void endFrame() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogConsoleSink.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogConsoleSink.java
@@ -32,7 +32,7 @@ import org.flixelgdx.backend.FlixelGameRunner;
  * {@code System.out} is not appropriate or where ANSI colors from the default path do not render
  * (for example, browser devtools with styled {@code console.log}).
  *
- * <p>Assign to {@link FlixelLogger#logConsoleSink FlixelLogger.logConsoleSink}
+ * <p>Assign to {@link FlixelLogger#logConsoleSink}
  * (via {@code Flixel.log.logConsoleSink}) before
  * {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}
  * from the platform launcher. When set, the logger calls this instead of writing ANSI text to

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogConsoleSink.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogConsoleSink.java
@@ -23,6 +23,10 @@
  */
 package org.flixelgdx.logging;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
+import org.flixelgdx.backend.FlixelGameRunner;
+
 /**
  * Optional sink for a single structured log line to the host console. Used on platforms where
  * {@code System.out} is not appropriate or where ANSI colors from the default path do not render
@@ -30,7 +34,7 @@ package org.flixelgdx.logging;
  *
  * <p>Assign to {@link FlixelLogger#logConsoleSink FlixelLogger.logConsoleSink}
  * (via {@code Flixel.log.logConsoleSink}) before
- * {@link org.flixelgdx.Flixel#start(org.flixelgdx.FlixelGame, org.flixelgdx.backend.FlixelGameRunner) Flixel.start(...)}
+ * {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}
  * from the platform launcher. When set, the logger calls this instead of writing ANSI text to
  * standard output; file logging and in-game log listeners are unchanged.
  */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogFileHandler.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogFileHandler.java
@@ -23,6 +23,9 @@
  */
 package org.flixelgdx.logging;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
+import org.flixelgdx.backend.FlixelGameRunner;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,7 +42,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Assign an implementation to {@link FlixelLogger#logFileHandler FlixelLogger.logFileHandler}
  * (via {@code Flixel.log.logFileHandler}) before
- * {@link org.flixelgdx.Flixel#start(org.flixelgdx.FlixelGame, org.flixelgdx.backend.FlixelGameRunner) Flixel.start(...)}
+ * {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}
  * in the platform launcher.
  *
  * @see FlixelLogger

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogFileHandler.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogFileHandler.java
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>On platforms where file logging is not feasible (for example, web/TeaVM), no
  * handler needs to be registered and the logger will simply skip file output.
  *
- * <p>Assign an implementation to {@link FlixelLogger#logFileHandler FlixelLogger.logFileHandler}
+ * <p>Assign an implementation to {@link FlixelLogger#logFileHandler}
  * (via {@code Flixel.log.logFileHandler}) before
  * {@link Flixel#start(FlixelGame, FlixelGameRunner) Flixel.start(...)}
  * in the platform launcher.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRasterizer.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRasterizer.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.text;
 
+import org.flixelgdx.Flixel;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * so text never crashes.
  *
  * <p>Install via {@link FlixelFontRegistry#setRasterizer(FlixelFontRasterizer)} before
- * {@link org.flixelgdx.Flixel#start Flixel.start}; backends do this for you.
+ * {@link Flixel#start Flixel.start}; backends do this for you.
  */
 public interface FlixelFontRasterizer {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRasterizer.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRasterizer.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
  * so text never crashes.
  *
  * <p>Install via {@link FlixelFontRegistry#setRasterizer(FlixelFontRasterizer)} before
- * {@link Flixel#start Flixel.start}; backends do this for you.
+ * {@link Flixel#start}; backends do this for you.
  */
 public interface FlixelFontRasterizer {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -271,7 +271,7 @@ public abstract class FlixelTween implements FlixelPoolable {
    * {@link FlixelColorTween} will handle the color interpolation and apply it to the sprite smoothly, rather
    * than causing a flash or jump in color.
    *
-   * @param colorable The tint target; often a {@link FlixelSprite FlixelSprite}.
+   * @param colorable The tint target; often a {@link FlixelSprite}.
    * @param from The starting color.
    * @param to The ending color.
    * @param tweenSettings The settings that configure and determine how the tween should animate.
@@ -292,7 +292,7 @@ public abstract class FlixelTween implements FlixelPoolable {
    * {@link FlixelColorTween} will handle the color interpolation and apply it to the sprite smoothly, rather
    * than causing a flash or jump in color.
    *
-   * @param colorable The tint target; often a {@link FlixelSprite FlixelSprite}.
+   * @param colorable The tint target; often a {@link FlixelSprite}.
    * @param from The starting color.
    * @param to The ending color.
    * @param tweenSettings The settings that configure and determine how the tween should animate.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.tween;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelPoolable;
 import org.flixelgdx.functional.FlixelAngleable;
@@ -269,7 +271,7 @@ public abstract class FlixelTween implements FlixelPoolable {
    * {@link FlixelColorTween} will handle the color interpolation and apply it to the sprite smoothly, rather
    * than causing a flash or jump in color.
    *
-   * @param colorable The tint target; often a {@link org.flixelgdx.FlixelSprite FlixelSprite}.
+   * @param colorable The tint target; often a {@link FlixelSprite FlixelSprite}.
    * @param from The starting color.
    * @param to The ending color.
    * @param tweenSettings The settings that configure and determine how the tween should animate.
@@ -290,7 +292,7 @@ public abstract class FlixelTween implements FlixelPoolable {
    * {@link FlixelColorTween} will handle the color interpolation and apply it to the sprite smoothly, rather
    * than causing a flash or jump in color.
    *
-   * @param colorable The tint target; often a {@link org.flixelgdx.FlixelSprite FlixelSprite}.
+   * @param colorable The tint target; often a {@link FlixelSprite FlixelSprite}.
    * @param from The starting color.
    * @param to The ending color.
    * @param tweenSettings The settings that configure and determine how the tween should animate.
@@ -823,8 +825,8 @@ public abstract class FlixelTween implements FlixelPoolable {
    * second call is automatically wired to fire after the tween returned by the first step, the
    * third after the tween returned by the second, and so on.
    *
-   * <p>Note that {@code then} does not fire for {@link org.flixelgdx.tween.settings.FlixelTweenType#LOOPING LOOPING}
-   * or {@link org.flixelgdx.tween.settings.FlixelTweenType#PINGPONG PINGPONG} tweens, since those
+   * <p>Note that {@code then} does not fire for {@link FlixelTweenType#LOOPING LOOPING}
+   * or {@link FlixelTweenType#PINGPONG PINGPONG} tweens, since those
    * repeat indefinitely and never reach a true final completion.
    *
    * <p>Example - three tweens that run one after another:
@@ -987,7 +989,7 @@ public abstract class FlixelTween implements FlixelPoolable {
 
   /**
    * Cancels every active tween on the global manager. Does not clear pools; pair with {@link #clearTweenPools()} if you
-   * want a full reset (as {@link org.flixelgdx.Flixel#switchState Flixel.switchState} does when {@code clearTweens} is true).
+   * want a full reset (as {@link Flixel#switchState Flixel.switchState} does when {@code clearTweens} is true).
    */
   public static void cancelActiveTweens() {
     FlixelArray<FlixelTween> list = globalManager.getActiveTweens();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -989,7 +989,7 @@ public abstract class FlixelTween implements FlixelPoolable {
 
   /**
    * Cancels every active tween on the global manager. Does not clear pools; pair with {@link #clearTweenPools()} if you
-   * want a full reset (as {@link Flixel#switchState Flixel.switchState} does when {@code clearTweens} is true).
+   * want a full reset (as {@link Flixel#switchState} does when {@code clearTweens} is true).
    */
   public static void cancelActiveTweens() {
     FlixelArray<FlixelTween> list = globalManager.getActiveTweens();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTweenManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTweenManager.java
@@ -216,7 +216,7 @@ public class FlixelTweenManager {
 
   /**
    * Completes matching tweens in one step (large delta). Non-{@link FlixelTweenType#isLooping() looping} tweens only.
-   * {@link FlixelTweenSettings#getOnComplete() FlixelTweenSettings.getOnComplete()} runs when
+   * {@link FlixelTweenSettings#getOnComplete()} runs when
    * {@link FlixelTween#finish()} is invoked after the tween reports finished.
    *
    * @param object The object to complete tweens of.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTweenManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTweenManager.java
@@ -216,7 +216,7 @@ public class FlixelTweenManager {
 
   /**
    * Completes matching tweens in one step (large delta). Non-{@link FlixelTweenType#isLooping() looping} tweens only.
-   * {@link org.flixelgdx.tween.settings.FlixelTweenSettings#getOnComplete() FlixelTweenSettings.getOnComplete()} runs when
+   * {@link FlixelTweenSettings#getOnComplete() FlixelTweenSettings.getOnComplete()} runs when
    * {@link FlixelTween#finish()} is invoked after the tween reports finished.
    *
    * @param object The object to complete tweens of.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelGoalTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelGoalTween.java
@@ -26,6 +26,7 @@ package org.flixelgdx.tween.type;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelFloatArray;
 import org.flixelgdx.tween.FlixelTween;
+import org.flixelgdx.tween.FlixelTweenManager;
 import org.flixelgdx.tween.settings.FlixelTweenSettings;
 import org.jetbrains.annotations.Nullable;
 
@@ -64,7 +65,7 @@ public class FlixelGoalTween extends FlixelTween {
 
   /**
    * Logical subject for {@link #isTweenOf(Object, String)}; must be set before {@link #start()} /
-   * {@link org.flixelgdx.tween.FlixelTweenManager#addTween(FlixelTween) FlixelTweenManager.addTween(FlixelTween)}.
+   * {@link FlixelTweenManager#addTween(FlixelTween) FlixelTweenManager.addTween(FlixelTween)}.
    */
   protected @Nullable Object tweenObject;
 
@@ -97,7 +98,7 @@ public class FlixelGoalTween extends FlixelTween {
    * Sets the object {@code this} tween logically animates (required before {@link #start()}).
    *
    * <p>This has to be set because {@link #isTweenOf(Object, String)} needs to know the object to tween.
-   * This method is purely for logic purposes used by {@link org.flixelgdx.tween.FlixelTweenManager FlixelTweenManager}, not
+   * This method is purely for logic purposes used by {@link FlixelTweenManager FlixelTweenManager}, not
    * for tweening purposes.
    *
    * @param tweenObject The object to tween.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelGoalTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelGoalTween.java
@@ -98,7 +98,7 @@ public class FlixelGoalTween extends FlixelTween {
    * Sets the object {@code this} tween logically animates (required before {@link #start()}).
    *
    * <p>This has to be set because {@link #isTweenOf(Object, String)} needs to know the object to tween.
-   * This method is purely for logic purposes used by {@link FlixelTweenManager FlixelTweenManager}, not
+   * This method is purely for logic purposes used by {@link FlixelTweenManager}, not
    * for tweening purposes.
    *
    * @param tweenObject The object to tween.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelGoalTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelGoalTween.java
@@ -65,7 +65,7 @@ public class FlixelGoalTween extends FlixelTween {
 
   /**
    * Logical subject for {@link #isTweenOf(Object, String)}; must be set before {@link #start()} /
-   * {@link FlixelTweenManager#addTween(FlixelTween) FlixelTweenManager.addTween(FlixelTween)}.
+   * {@link FlixelTweenManager#addTween(FlixelTween)}.
    */
   protected @Nullable Object tweenObject;
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelAsciiCodes.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelAsciiCodes.java
@@ -26,7 +26,7 @@ package org.flixelgdx.util;
 import org.flixelgdx.logging.FlixelLogger;
 
 /**
- * ANSI escape sequences for console text styling used by {@link FlixelLogger FlixelLogger},
+ * ANSI escape sequences for console text styling used by {@link FlixelLogger},
  * although you may find this class useful for other purposes.
  */
 public final class FlixelAsciiCodes {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelAsciiCodes.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelAsciiCodes.java
@@ -23,8 +23,10 @@
  */
 package org.flixelgdx.util;
 
+import org.flixelgdx.logging.FlixelLogger;
+
 /**
- * ANSI escape sequences for console text styling used by {@link org.flixelgdx.logging.FlixelLogger FlixelLogger},
+ * ANSI escape sequences for console text styling used by {@link FlixelLogger FlixelLogger},
  * although you may find this class useful for other purposes.
  */
 public final class FlixelAsciiCodes {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelBar.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelBar.java
@@ -43,7 +43,7 @@ import java.util.Objects;
 /**
  * A UI bar for progress, health, stamina, experience, cooldowns, loading, or any value mapped to a
  * numeric range. It extends {@link FlixelSprite} so you can add instances to a
- * {@link FlixelSpriteGroup FlixelSpriteGroup}, use sprite transforms (position, scale,
+ * {@link FlixelSpriteGroup}, use sprite transforms (position, scale,
  * rotation, tint, alpha) with the rest of your HUD, and rely on the same camera and lifecycle rules
  * as other sprites.
  *
@@ -61,7 +61,7 @@ import java.util.Objects;
  *
  * <p><b>Smoothing</b>: {@link #setLerp(float)} applies frame-rate independent smoothing to the displayed
  * value so the bar can lag slightly behind the target, similar to camera follow smoothing in
- * {@link FlixelCamera FlixelCamera}.
+ * {@link FlixelCamera}.
  *
  * <p><b>Appearance</b>: Solid colors, custom empty and filled regions, optional two-color gradients,
  * optional border, and threshold-based fill colors with optional color smoothing when the fill percent

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelBar.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelBar.java
@@ -31,6 +31,7 @@ import org.flixelgdx.functional.supplier.FloatSupplier;
 import org.flixelgdx.graphics.FlixelBatch;
 import org.flixelgdx.graphics.FlixelFrame;
 import org.flixelgdx.graphics.FlixelTexture;
+import org.flixelgdx.group.FlixelSpriteGroup;
 import org.flixelgdx.math.FlixelMath;
 import org.flixelgdx.text.FlixelText;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +43,7 @@ import java.util.Objects;
 /**
  * A UI bar for progress, health, stamina, experience, cooldowns, loading, or any value mapped to a
  * numeric range. It extends {@link FlixelSprite} so you can add instances to a
- * {@link org.flixelgdx.group.FlixelSpriteGroup FlixelSpriteGroup}, use sprite transforms (position, scale,
+ * {@link FlixelSpriteGroup FlixelSpriteGroup}, use sprite transforms (position, scale,
  * rotation, tint, alpha) with the rest of your HUD, and rely on the same camera and lifecycle rules
  * as other sprites.
  *
@@ -60,7 +61,7 @@ import java.util.Objects;
  *
  * <p><b>Smoothing</b>: {@link #setLerp(float)} applies frame-rate independent smoothing to the displayed
  * value so the bar can lag slightly behind the target, similar to camera follow smoothing in
- * {@link org.flixelgdx.FlixelCamera FlixelCamera}.
+ * {@link FlixelCamera FlixelCamera}.
  *
  * <p><b>Appearance</b>: Solid colors, custom empty and filled regions, optional two-color gradients,
  * optional border, and threshold-based fill colors with optional color smoothing when the fill percent

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelColor.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelColor.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.util;
 
+import org.flixelgdx.graphics.FlixelBatch;
+import org.flixelgdx.graphics.FlixelTexture;
 import org.flixelgdx.math.FlixelMath;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -231,7 +233,7 @@ public class FlixelColor {
    *
    * <p>The bits are laid out as ABGR8888 (alpha in the highest byte), the order the sprite batch's
    * per-vertex color expects. This is meant for building custom vertex arrays passed to
-   * {@link org.flixelgdx.graphics.FlixelBatch#draw(org.flixelgdx.graphics.FlixelTexture, float[], int, int)};
+   * {@link FlixelBatch#draw(FlixelTexture, float[], int, int)};
    * for normal drawing, tint through the batch or sprite instead.
    *
    * @return This color packed as ABGR8888, reinterpreted as a float.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
@@ -43,8 +43,8 @@ import java.util.function.Consumer;
  * tree (counting active members, iterating {@link FlixelDebugDrawable} instances for bounding-box drawing, etc.).
  *
  * <p>Recursion descends into any member that implements {@link FlixelGroupable}, which
- * covers {@link FlixelBasicGroup FlixelBasicGroup}, {@link FlixelSpriteGroup FlixelSpriteGroup},
- * and nested {@link FlixelGroup FlixelGroup} instances whose elements are {@link IFlixelBasic}.
+ * covers {@link FlixelBasicGroup}, {@link FlixelSpriteGroup},
+ * and nested {@link FlixelGroup} instances whose elements are {@link IFlixelBasic}.
  */
 public final class FlixelDebugUtil {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
@@ -29,7 +29,10 @@ import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.debug.FlixelDebugDrawable;
 import org.flixelgdx.functional.FlixelVisible;
 import org.flixelgdx.functional.IFlixelBasic;
+import org.flixelgdx.group.FlixelBasicGroup;
+import org.flixelgdx.group.FlixelGroup;
 import org.flixelgdx.group.FlixelGroupable;
+import org.flixelgdx.group.FlixelSpriteGroup;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -40,8 +43,8 @@ import java.util.function.Consumer;
  * tree (counting active members, iterating {@link FlixelDebugDrawable} instances for bounding-box drawing, etc.).
  *
  * <p>Recursion descends into any member that implements {@link FlixelGroupable}, which
- * covers {@link org.flixelgdx.group.FlixelBasicGroup FlixelBasicGroup}, {@link org.flixelgdx.group.FlixelSpriteGroup FlixelSpriteGroup},
- * and nested {@link org.flixelgdx.group.FlixelGroup FlixelGroup} instances whose elements are {@link IFlixelBasic}.
+ * covers {@link FlixelBasicGroup FlixelBasicGroup}, {@link FlixelSpriteGroup FlixelSpriteGroup},
+ * and nested {@link FlixelGroup FlixelGroup} instances whose elements are {@link IFlixelBasic}.
  */
 public final class FlixelDebugUtil {
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * Helper class related to {@link FlixelSprite FlixelSprite}.
+ * Helper class related to {@link FlixelSprite}.
  *
  * <p>These utilities are designed to work with FlixelGDX's normal Batch-based draw flow.
  * Everything draws through the shared batch; no separate shape renderer is involved.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * Helper class related to {@link org.flixelgdx.FlixelSprite FlixelSprite}.
+ * Helper class related to {@link FlixelSprite FlixelSprite}.
  *
  * <p>These utilities are designed to work with FlixelGDX's normal Batch-based draw flow.
  * Everything draws through the shared batch; no separate shape renderer is involved.
@@ -71,7 +71,7 @@ public final class FlixelSpriteUtil {
    * {@link FlixelGraphic}, and registers it with the asset manager; callers must not destroy
    * the texture, since its lifecycle follows the asset manager.
    *
-   * @param assets Non-null manager, typically {@link org.flixelgdx.Flixel#assets Flixel.assets}.
+   * @param assets Non-null manager, typically {@link Flixel#assets Flixel.assets}.
    * @return The shared white pixel frame; never {@code null}.
    */
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
@@ -71,7 +71,7 @@ public final class FlixelSpriteUtil {
    * {@link FlixelGraphic}, and registers it with the asset manager; callers must not destroy
    * the texture, since its lifecycle follows the asset manager.
    *
-   * @param assets Non-null manager, typically {@link Flixel#assets Flixel.assets}.
+   * @param assets Non-null manager, typically {@link Flixel#assets}.
    * @return The shared white pixel frame; never {@code null}.
    */
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
@@ -150,7 +150,7 @@ public class FlixelString implements CharSequence {
 
   /**
    * Trims the internal storage to the current length. Suitable for teardown paths (for example
-   * {@link FlixelText#destroy() FlixelText.destroy()}) but not for per-frame use.
+   * {@link FlixelText#destroy()}) but not for per-frame use.
    */
   public void trimToSize() {
     buffer.trimToSize();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.util;
 
 import org.flixelgdx.collections.FlixelCharArray;
+import org.flixelgdx.text.FlixelText;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -149,7 +150,7 @@ public class FlixelString implements CharSequence {
 
   /**
    * Trims the internal storage to the current length. Suitable for teardown paths (for example
-   * {@link org.flixelgdx.text.FlixelText#destroy() FlixelText.destroy()}) but not for per-frame use.
+   * {@link FlixelText#destroy() FlixelText.destroy()}) but not for per-frame use.
    */
   public void trimToSize() {
     buffer.trimToSize();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/save/FlixelSave.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/save/FlixelSave.java
@@ -28,6 +28,7 @@ import org.flixelgdx.FlixelConfig;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelMap;
 import org.flixelgdx.file.FlixelFile;
+import org.flixelgdx.file.FlixelFiles;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.json.FlixelJson;
 import org.flixelgdx.json.FlixelJsonValue;
@@ -42,7 +43,7 @@ import java.util.Objects;
  *
  * <p>Bind to a uniquely identified save slot, manipulate the structured {@link #data} map, and
  * flush changes to disk. Saves serialize to a JSON file through the
- * {@link org.flixelgdx.file.FlixelFiles Flixel.files} seam's {@code pref} root, so the same
+ * {@link FlixelFiles Flixel.files} seam's {@code pref} root, so the same
  * code works on every platform that can write files: desktop saves to the computers local app data
  * folder, web backends map the root to browser storage, etc.
  *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimer.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimer.java
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Advance time by calling {@link FlixelTimerManager#update(float)} once per frame (done automatically for
  * {@link #getGlobalManager()}). The elapsed argument should already include
- * {@link Flixel#timeScale Flixel.timeScale}.
+ * {@link Flixel#timeScale}.
  *
  * <p>Prefer {@link FlixelTimerManager#start(float, FlixelTimerListener, int)}, {@link FlixelTimer#wait(float, FlixelTimerListener)},
  * or {@link FlixelTimer#loop(float, FlixelTimerListener, int)} so pooled instances are reused.
@@ -47,7 +47,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class FlixelTimer implements FlixelUpdatable, FlixelDestroyable, FlixelPoolable {
 
-  /** Global timer manager, updated from {@link FlixelGame#update(float) FlixelGame.update(float)}. */
+  /** Global timer manager, updated from {@link FlixelGame#update(float)}. */
   @NotNull
   private static final FlixelTimerManager GLOBAL_MANAGER = new FlixelTimerManager();
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimer.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimer.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.util.timer;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.collections.FlixelPoolable;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.functional.FlixelUpdatable;
@@ -34,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Advance time by calling {@link FlixelTimerManager#update(float)} once per frame (done automatically for
  * {@link #getGlobalManager()}). The elapsed argument should already include
- * {@link org.flixelgdx.Flixel#timeScale Flixel.timeScale}.
+ * {@link Flixel#timeScale Flixel.timeScale}.
  *
  * <p>Prefer {@link FlixelTimerManager#start(float, FlixelTimerListener, int)}, {@link FlixelTimer#wait(float, FlixelTimerListener)},
  * or {@link FlixelTimer#loop(float, FlixelTimerListener, int)} so pooled instances are reused.
@@ -45,7 +47,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class FlixelTimer implements FlixelUpdatable, FlixelDestroyable, FlixelPoolable {
 
-  /** Global timer manager, updated from {@link org.flixelgdx.FlixelGame#update(float) FlixelGame.update(float)}. */
+  /** Global timer manager, updated from {@link FlixelGame#update(float) FlixelGame.update(float)}. */
   @NotNull
   private static final FlixelTimerManager GLOBAL_MANAGER = new FlixelTimerManager();
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
@@ -37,8 +37,8 @@ import org.jetbrains.annotations.Nullable;
  * HaxeFlixel plugin-style managers so {@link #active}, {@link #exists}, {@link #kill}, and {@link #destroy} gate
  * {@link #update(float)} the same way as other Flixel objects.
  *
- * <p>Use {@link FlixelTimer#getGlobalManager()} with {@link FlixelGame FlixelGame} (already wired) or
- * construct a dedicated manager for isolated groups (for example add it to a {@link FlixelState FlixelState}).
+ * <p>Use {@link FlixelTimer#getGlobalManager()} with {@link FlixelGame} (already wired) or
+ * construct a dedicated manager for isolated groups (for example add it to a {@link FlixelState}).
  *
  * <p>Timers are backed by a {@link FlixelPool} to avoid per-delay allocations. {@link #start(float, FlixelTimerListener, int)}
  * obtains from the pool; {@link FlixelTimer#cancel()} and completed runs return instances to the pool.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
@@ -24,6 +24,8 @@
 package org.flixelgdx.util.timer;
 
 import org.flixelgdx.FlixelBasic;
+import org.flixelgdx.FlixelGame;
+import org.flixelgdx.FlixelState;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.collections.FlixelPool;
 import org.flixelgdx.graphics.FlixelBatch;
@@ -35,8 +37,8 @@ import org.jetbrains.annotations.Nullable;
  * HaxeFlixel plugin-style managers so {@link #active}, {@link #exists}, {@link #kill}, and {@link #destroy} gate
  * {@link #update(float)} the same way as other Flixel objects.
  *
- * <p>Use {@link FlixelTimer#getGlobalManager()} with {@link org.flixelgdx.FlixelGame FlixelGame} (already wired) or
- * construct a dedicated manager for isolated groups (for example add it to a {@link org.flixelgdx.FlixelState FlixelState}).
+ * <p>Use {@link FlixelTimer#getGlobalManager()} with {@link FlixelGame FlixelGame} (already wired) or
+ * construct a dedicated manager for isolated groups (for example add it to a {@link FlixelState FlixelState}).
  *
  * <p>Timers are backed by a {@link FlixelPool} to avoid per-delay allocations. {@link #start(float, FlixelTimerListener, int)}
  * obtains from the pool; {@link FlixelTimer#cancel()} and completed runs return instances to the pool.

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopAlerter.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopAlerter.java
@@ -31,7 +31,7 @@ import org.lwjgl.sdl.SDLMessageBox;
  * The desktop alert dialog provider, backed by SDL's simple message boxes.
  *
  * <p>These are blocking modal dialogs; reserve them for critical events. Non-blocking OS toasts go
- * through {@link Flixel#host Flixel.host} instead.
+ * through {@link Flixel#host} instead.
  */
 public class FlixelDesktopAlerter implements FlixelAlerter {
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopAlerter.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelDesktopAlerter.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.backend.desktop;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.backend.FlixelAlerter;
 import org.lwjgl.sdl.SDLMessageBox;
 
@@ -30,7 +31,7 @@ import org.lwjgl.sdl.SDLMessageBox;
  * The desktop alert dialog provider, backed by SDL's simple message boxes.
  *
  * <p>These are blocking modal dialogs; reserve them for critical events. Non-blocking OS toasts go
- * through {@link org.flixelgdx.Flixel#host Flixel.host} instead.
+ * through {@link Flixel#host Flixel.host} instead.
  */
 public class FlixelDesktopAlerter implements FlixelAlerter {
 

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlWindow.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/FlixelSdlWindow.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
 /**
  * The desktop window, wrapping the SDL3 window the {@link FlixelDesktopRunner} created.
  *
- * <p>Exposes the window controls game code reaches through {@link org.flixelgdx.Flixel#window
+ * <p>Exposes the window controls game code reaches through {@link Flixel#window
  * Flixel.window}: title, size, position, fullscreen, decoration, focus, opacity, and closing.
  *
  * <p>Window position is cached locally rather than queried from SDL on each read. The cache is

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiBgfxRenderer.java
@@ -25,6 +25,7 @@ package org.flixelgdx.backend.desktop.debug;
 
 import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
 import org.flixelgdx.math.FlixelMatrix;
+import org.flixelgdx.util.FlixelBlendMode;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.bgfx.BGFX;
 import org.lwjgl.bgfx.BGFXTransientIndexBuffer;
@@ -69,7 +70,7 @@ public final class FlixelImGuiBgfxRenderer {
       BGFX.BGFX_SAMPLER_POINT | BGFX.BGFX_SAMPLER_U_CLAMP | BGFX.BGFX_SAMPLER_V_CLAMP;
 
   /**
-   * Standard straight-alpha "over" blend, matching {@link org.flixelgdx.util.FlixelBlendMode#NORMAL}.
+   * Standard straight-alpha "over" blend, matching {@link FlixelBlendMode#NORMAL}.
    * Color blends with source alpha; the destination alpha accumulates so the overlay composites
    * correctly onto an alpha-capable back buffer.
    */

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -1227,7 +1227,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
 
   /**
    * Renders the Tracker panel: a collapsible header per registered
-   * {@link FlixelDebugTrackerEntry FlixelDebugTrackerEntry}, each with a
+   * {@link FlixelDebugTrackerEntry}, each with a
    * {@code name -> value} table like the Watch panel. When no trackers are registered it stays visible
    * with a hint, mirroring the Watch panel's empty state.
    */

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/debug/FlixelImGuiDebugOverlay.java
@@ -32,6 +32,7 @@ import org.flixelgdx.backend.desktop.graphics.FlixelBgfxGraphics;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.debug.FlixelDebugManager;
 import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.flixelgdx.debug.FlixelDebugTrackerEntry;
 import org.flixelgdx.graphics.FlixelTexture;
 import org.flixelgdx.input.keyboard.FlixelKey;
 import org.flixelgdx.input.mouse.FlixelMouseCursor;
@@ -1226,7 +1227,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
 
   /**
    * Renders the Tracker panel: a collapsible header per registered
-   * {@link org.flixelgdx.debug.FlixelDebugTrackerEntry FlixelDebugTrackerEntry}, each with a
+   * {@link FlixelDebugTrackerEntry FlixelDebugTrackerEntry}, each with a
    * {@code name -> value} table like the Watch panel. When no trackers are registered it stays visible
    * with a hint, mirroring the Watch panel's empty state.
    */

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelKtx2Loader.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelKtx2Loader.java
@@ -29,6 +29,7 @@ import org.flixelgdx.asset.FlixelAssetLoader;
 import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.file.FlixelFile;
 import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.graphics.FlixelGraphicsManager;
 import org.flixelgdx.graphics.FlixelTexture;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,7 +45,7 @@ import java.nio.ByteOrder;
  * time versus an uncompressed texture.
  *
  * <p>The read happens off the main thread ({@link #loadRaw}); the GPU upload happens on the main
- * thread ({@link #finishRaw}) through {@link org.flixelgdx.graphics.FlixelGraphicsManager#createCompressedTexture
+ * thread ({@link #finishRaw}) through {@link FlixelGraphicsManager#createCompressedTexture
  * createCompressedTexture}, which the bgfx backend implements with its own container parser. Once a
  * {@code .ktx2} loader is registered, the asset manager transparently prefers a {@code .ktx2}
  * sibling over the plain image when one exists and compressed textures are enabled.

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelDesktopInputDevice.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelDesktopInputDevice.java
@@ -58,7 +58,7 @@ public class FlixelDesktopInputDevice implements FlixelInputDevice {
   /**
    * Feeds a key-down event from the runner.
    *
-   * @param flixelKey The mapped {@link FlixelKey FlixelKey} code.
+   * @param flixelKey The mapped {@link FlixelKey} code.
    */
   public void onKeyDown(int flixelKey) {
     if (flixelKey >= 0 && flixelKey < keyDown.length) {
@@ -72,7 +72,7 @@ public class FlixelDesktopInputDevice implements FlixelInputDevice {
   /**
    * Feeds a key-up event from the runner.
    *
-   * @param flixelKey The mapped {@link FlixelKey FlixelKey} code.
+   * @param flixelKey The mapped {@link FlixelKey} code.
    */
   public void onKeyUp(int flixelKey) {
     if (flixelKey >= 0 && flixelKey < keyDown.length) {

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelDesktopInputDevice.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelDesktopInputDevice.java
@@ -23,16 +23,18 @@
  */
 package org.flixelgdx.backend.desktop.input;
 
+import org.flixelgdx.backend.desktop.FlixelDesktopRunner;
 import org.flixelgdx.collections.FlixelArray;
 import org.flixelgdx.input.FlixelInputDevice;
 import org.flixelgdx.input.FlixelKeyboardListener;
 import org.flixelgdx.input.FlixelMouseListener;
 import org.flixelgdx.input.FlixelTouchListener;
+import org.flixelgdx.input.keyboard.FlixelKey;
 
 /**
  * The desktop input device, driven by SDL3 events pumped from the game loop.
  *
- * <p>The {@link org.flixelgdx.backend.desktop.FlixelDesktopRunner runner} translates SDL keyboard
+ * <p>The {@link FlixelDesktopRunner runner} translates SDL keyboard
  * and mouse events into the {@code on*} calls here, which update the cached state (for
  * {@link #isKeyPressed(int)} / pointer getters) and forward to the registered
  * {@link FlixelKeyboardListener} and {@link FlixelMouseListener} instances that the framework's
@@ -56,7 +58,7 @@ public class FlixelDesktopInputDevice implements FlixelInputDevice {
   /**
    * Feeds a key-down event from the runner.
    *
-   * @param flixelKey The mapped {@link org.flixelgdx.input.keyboard.FlixelKey FlixelKey} code.
+   * @param flixelKey The mapped {@link FlixelKey FlixelKey} code.
    */
   public void onKeyDown(int flixelKey) {
     if (flixelKey >= 0 && flixelKey < keyDown.length) {
@@ -70,7 +72,7 @@ public class FlixelDesktopInputDevice implements FlixelInputDevice {
   /**
    * Feeds a key-up event from the runner.
    *
-   * @param flixelKey The mapped {@link org.flixelgdx.input.keyboard.FlixelKey FlixelKey} code.
+   * @param flixelKey The mapped {@link FlixelKey FlixelKey} code.
    */
   public void onKeyUp(int flixelKey) {
     if (flixelKey >= 0 && flixelKey < keyDown.length) {

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelSdlGamepad.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelSdlGamepad.java
@@ -36,7 +36,7 @@ import org.lwjgl.sdl.SDLGamepad;
  * and axis numbering for an Xbox pad, a DualShock, a Switch Pro controller, and so on), so the
  * native indices this reports are SDL's standard {@code SDL_GAMEPAD_BUTTON_*} and
  * {@code SDL_GAMEPAD_AXIS_*} values. {@link FlixelSdlGamepadProvider} pairs that with one fixed
- * {@link FlixelGamepadMapping FlixelGamepadMapping}, which is why every
+ * {@link FlixelGamepadMapping}, which is why every
  * SDL pad shares a single mapping rather than needing a per-device database lookup.
  *
  * <p>Axis values come back from SDL as signed 16-bit integers; sticks span the full range and

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelSdlGamepad.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/input/FlixelSdlGamepad.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.backend.desktop.input;
 
 import org.flixelgdx.input.gamepad.FlixelGamepad;
+import org.flixelgdx.input.gamepad.FlixelGamepadMapping;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.sdl.SDLGamepad;
@@ -35,7 +36,7 @@ import org.lwjgl.sdl.SDLGamepad;
  * and axis numbering for an Xbox pad, a DualShock, a Switch Pro controller, and so on), so the
  * native indices this reports are SDL's standard {@code SDL_GAMEPAD_BUTTON_*} and
  * {@code SDL_GAMEPAD_AXIS_*} values. {@link FlixelSdlGamepadProvider} pairs that with one fixed
- * {@link org.flixelgdx.input.gamepad.FlixelGamepadMapping FlixelGamepadMapping}, which is why every
+ * {@link FlixelGamepadMapping FlixelGamepadMapping}, which is why every
  * SDL pad shares a single mapping rather than needing a per-device database lookup.
  *
  * <p>Axis values come back from SDL as signed 16-bit integers; sticks span the full range and

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/asset/FlixelHtml5AssetManager.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/asset/FlixelHtml5AssetManager.java
@@ -32,6 +32,7 @@ import org.flixelgdx.asset.FlixelBaseAssetManager;
 import org.flixelgdx.collections.FlixelMap;
 import org.flixelgdx.file.FlixelFile;
 import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.graphics.FlixelGraphicsManager;
 import org.flixelgdx.graphics.FlixelImage;
 import org.flixelgdx.graphics.FlixelTexture;
 import org.jetbrains.annotations.NotNull;
@@ -74,7 +75,7 @@ import java.nio.ByteOrder;
  *
  * <p>The decoded pixels are stored behind a {@code FLXI} header in
  * {@code window.__flixelDecodedImages}, the same compact format the web graphics backend unpacks
- * via {@link org.flixelgdx.graphics.FlixelGraphicsManager#decodeImage decodeImage}. This keeps the
+ * via {@link FlixelGraphicsManager#decodeImage decodeImage}. This keeps the
  * pixel extraction path in one place and means the only web-specific code is the Promise-polling
  * loop in {@link #update}.
  */
@@ -100,7 +101,7 @@ public class FlixelHtml5AssetManager extends FlixelBaseAssetManager {
   /**
    * Creates the manager and replaces the default image loaders with web-aware ones that read
    * pre-decoded pixels from the browser's decode cache rather than calling
-   * {@link org.flixelgdx.graphics.FlixelGraphicsManager#decodeImage decodeImage} inline.
+   * {@link FlixelGraphicsManager#decodeImage decodeImage} inline.
    */
   public FlixelHtml5AssetManager() {
     WebImageLoader loader = new WebImageLoader();

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/graphics/FlixelWebGlShaderProgram.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/graphics/FlixelWebGlShaderProgram.java
@@ -29,6 +29,7 @@ import org.flixelgdx.graphics.FlixelShaderProgram;
 import org.flixelgdx.math.FlixelMatrix;
 import org.flixelgdx.math.FlixelVector;
 import org.flixelgdx.util.FlixelColor;
+import org.flixelgdx.util.FlixelShader;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.webgl.WebGLProgram;
 import org.teavm.jso.webgl.WebGLRenderingContext;
@@ -38,7 +39,7 @@ import org.teavm.jso.webgl.WebGLUniformLocation;
  * A compiled WebGL shader program the web backend draws custom-shaded sprites with.
  *
  * <p>The tricky part on the web is <em>when</em> a uniform can be uploaded. Game code sets uniforms
- * (for example in {@link org.flixelgdx.util.FlixelShader#applyUniforms()}) at a point where this
+ * (for example in {@link FlixelShader#applyUniforms()}) at a point where this
  * program is not the one currently bound, and WebGL only accepts a uniform for the program that is
  * active. So rather than upload immediately, this class remembers each uniform's latest value and
  * uploads them all in {@link #apply(WebGLRenderingContext)}, which the batch calls right after it

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/input/FlixelHtml5InputDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/input/FlixelHtml5InputDevice.java
@@ -28,6 +28,7 @@ import org.flixelgdx.input.FlixelInputDevice;
 import org.flixelgdx.input.FlixelKeyboardListener;
 import org.flixelgdx.input.FlixelMouseListener;
 import org.flixelgdx.input.FlixelTouchListener;
+import org.flixelgdx.input.mouse.FlixelMouseButton;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.browser.Window;
 import org.teavm.jso.dom.events.Event;
@@ -219,7 +220,7 @@ public class FlixelHtml5InputDevice implements FlixelInputDevice {
   }
 
   /**
-   * Remaps a browser mouse button index to its {@link org.flixelgdx.input.mouse.FlixelMouseButton}
+   * Remaps a browser mouse button index to its {@link FlixelMouseButton}
    * equivalent. The browser orders middle and right buttons as {@code 1} and {@code 2}; the
    * framework uses {@code 1} for right and {@code 2} for middle, so those two are swapped.
    *

--- a/flixelgdx-jvm/src/main/java/org/flixelgdx/backend/jvm/file/FlixelJvmFile.java
+++ b/flixelgdx-jvm/src/main/java/org/flixelgdx/backend/jvm/file/FlixelJvmFile.java
@@ -41,7 +41,7 @@ import java.nio.file.Files;
  * classpath files are read through the class loader (and are read-only).
  *
  * <p>Instances are created by {@link FlixelJvmFiles}; game code obtains them through
- * {@link Flixel#files Flixel.files} and never constructs them directly.
+ * {@link Flixel#files} and never constructs them directly.
  */
 public class FlixelJvmFile implements FlixelFile {
 

--- a/flixelgdx-jvm/src/main/java/org/flixelgdx/backend/jvm/file/FlixelJvmFile.java
+++ b/flixelgdx-jvm/src/main/java/org/flixelgdx/backend/jvm/file/FlixelJvmFile.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.backend.jvm.file;
 
+import org.flixelgdx.Flixel;
 import org.flixelgdx.file.FlixelFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,7 +41,7 @@ import java.nio.file.Files;
  * classpath files are read through the class loader (and are read-only).
  *
  * <p>Instances are created by {@link FlixelJvmFiles}; game code obtains them through
- * {@link org.flixelgdx.Flixel#files Flixel.files} and never constructs them directly.
+ * {@link Flixel#files Flixel.files} and never constructs them directly.
  */
 public class FlixelJvmFile implements FlixelFile {
 


### PR DESCRIPTION
## Description

Every `{@link org.flixelgdx.some.package.ClassName}` reference across the framework has been replaced with `{@link ClassName}` backed by a proper `import` statement at the top of the file, following the rule in AGENTS.md that says \"don't write out the full package: import it as a qualifier.\". `package-info.java` files were left untouched because they cannot have import statements.

84 files were updated. The transformation was mechanical: the FQN in each `@link` tag was replaced with the simple class name, and if that class was not already imported (and is not in the same package), a new import was added. Spotless re-sorted the import blocks, and Javadoc, checkstyle, and all unit tests pass cleanly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Spotless, checkstyle, `javadoc`, and `test` tasks all exit 0 after the change.