### PR TITLE
Improved the HTML5 crash handler to actually be useful for debugging web games

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelExceptionUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelExceptionUtil.java
@@ -45,7 +45,20 @@ public final class FlixelExceptionUtil {
     if (stackTrace.length == 0) {
       return "Unknown Location";
     }
-    StackTraceElement element = stackTrace[0];
+    // Skip JRE-internal frames added by exception construction (java.lang.Throwable.fillInStackTrace,
+    // constructors for Exception/RuntimeException, etc.) to reach the first frame that reflects
+    // where the exception was actually thrown from.
+    StackTraceElement element = null;
+    for (int i = 0; i < stackTrace.length; i++) {
+      String className = stackTrace[i].getClassName();
+      if (!className.startsWith("java.") && !className.startsWith("javax.") && !className.startsWith("sun.")) {
+        element = stackTrace[i];
+        break;
+      }
+    }
+    if (element == null) {
+      element = stackTrace[0];
+    }
     return "FILE="
         + element.getFileName()
         + ", CLASS="

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelExceptionUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelExceptionUtil.java
@@ -45,14 +45,13 @@ public final class FlixelExceptionUtil {
     if (stackTrace.length == 0) {
       return "Unknown Location";
     }
-    // Skip JRE-internal frames added by exception construction (java.lang.Throwable.fillInStackTrace,
-    // constructors for Exception/RuntimeException, etc.) to reach the first frame that reflects
+    // Skip JRE-internal frames added by exception construction to reach the first frame that reflects
     // where the exception was actually thrown from.
     StackTraceElement element = null;
-    for (int i = 0; i < stackTrace.length; i++) {
-      String className = stackTrace[i].getClassName();
+    for (StackTraceElement stackTraceElement : stackTrace) {
+      String className = stackTraceElement.getClassName();
       if (!className.startsWith("java.") && !className.startsWith("javax.") && !className.startsWith("sun.")) {
-        element = stackTrace[i];
+        element = stackTraceElement;
         break;
       }
     }

--- a/flixelgdx-html5-plugin/src/main/java/org/flixelgdx/gradle/html5/Html5Plugin.java
+++ b/flixelgdx-html5-plugin/src/main/java/org/flixelgdx/gradle/html5/Html5Plugin.java
@@ -529,9 +529,9 @@ public class Html5Plugin implements Plugin<Project> {
     boolean jsEnabled = teavm.getJs().getAddedToWebApp().getOrElse(false);
     boolean wasmEnabled = teavm.getWasmGC().getAddedToWebApp().getOrElse(false);
 
-    // When the build is configured as a debug build, automatically enable source maps and full
-    // debug info so browser DevTools can show Java class names, method names, and line numbers in
-    // stack traces instead of mangled WASM addresses or generated JS function names.
+    // When the build is configured as a debug build, automatically enable source maps so browser
+    // DevTools can show Java class names, method names, and line numbers in stack traces instead of
+    // mangled WASM addresses or generated JS function names.
     // convention() is used so a developer can still override any of these explicitly.
     if (ext.getMode().isPresent() && ext.getMode().get() == Html5Mode.DEBUG) {
       if (jsEnabled) {
@@ -541,8 +541,15 @@ public class Html5Plugin implements Plugin<Project> {
       if (wasmEnabled) {
         teavm.getWasmGC().getSourceMap().convention(true);
         teavm.getWasmGC().getSourceFilePolicy().convention(SourceFilePolicy.COPY);
-        teavm.getWasmGC().getDebugInfoLevel().convention(WasmDebugInfoLevel.FULL);
       }
+    }
+
+    // Always generate full WasmGC debug info so the external .teadbg deobfuscation file is
+    // available. It is only fetched when the page is opened in debug mode at runtime, so it never
+    // reaches a release user. Gating generation on a build-time flag would break runtime debug mode
+    // (?flixel.mode=debug) for anyone who did not also set html5 { mode = 'debug' } in their build.
+    if (wasmEnabled) {
+      teavm.getWasmGC().getDebugInfoLevel().convention(WasmDebugInfoLevel.FULL);
     }
     String jsBundle = teavm.getJs().getTargetFileName().getOrElse(DEFAULT_JS_BUNDLE);
     String wasmBundle = teavm.getWasmGC().getTargetFileName().getOrElse(DEFAULT_WASM_BUNDLE);

--- a/flixelgdx-html5-plugin/src/main/java/org/flixelgdx/gradle/html5/Html5Plugin.java
+++ b/flixelgdx-html5-plugin/src/main/java/org/flixelgdx/gradle/html5/Html5Plugin.java
@@ -38,7 +38,6 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.bundling.Zip;
 import org.teavm.gradle.api.SourceFilePolicy;
 import org.teavm.gradle.api.TeaVMExtension;
-import org.teavm.gradle.api.WasmDebugInfoLevel;
 
 import java.awt.Desktop;
 import java.io.File;
@@ -544,12 +543,17 @@ public class Html5Plugin implements Plugin<Project> {
       }
     }
 
-    // Always generate full WasmGC debug info so the external .teadbg deobfuscation file is
-    // available. It is only fetched when the page is opened in debug mode at runtime, so it never
-    // reaches a release user. Gating generation on a build-time flag would break runtime debug mode
-    // (?flixel.mode=debug) for anyone who did not also set html5 { mode = 'debug' } in their build.
+    // Always enable WasmGC debug information so the stack deobfuscator works in debug mode.
+    // debugInformation = true has two effects:
+    //   1. The generateWasmGC task emits a companion .teadbg file (external debug symbols)
+    //      that the browser's TeaVM deobfuscator reads to resolve Java class names and line numbers.
+    //   2. The copyWasmGCRuntime task copies the deobfuscator WASM module alongside the bundle
+    //      (e.g., teavm-deobfuscator.wasm), which the page loads in debug mode.
+    // Neither file is fetched at runtime unless the page is opened in debug mode, so release
+    // users never download them. Gating this on a build-time flag would break ?flixel.mode=debug
+    // for anyone who did not also set html5 { mode = 'debug' } in their build.
     if (wasmEnabled) {
-      teavm.getWasmGC().getDebugInfoLevel().convention(WasmDebugInfoLevel.FULL);
+      teavm.getWasmGC().getDebugInformation().convention(true);
     }
     String jsBundle = teavm.getJs().getTargetFileName().getOrElse(DEFAULT_JS_BUNDLE);
     String wasmBundle = teavm.getWasmGC().getTargetFileName().getOrElse(DEFAULT_WASM_BUNDLE);

--- a/flixelgdx-html5-plugin/src/main/java/org/flixelgdx/gradle/html5/Html5Plugin.java
+++ b/flixelgdx-html5-plugin/src/main/java/org/flixelgdx/gradle/html5/Html5Plugin.java
@@ -36,7 +36,9 @@ import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.bundling.Zip;
+import org.teavm.gradle.api.SourceFilePolicy;
 import org.teavm.gradle.api.TeaVMExtension;
+import org.teavm.gradle.api.WasmDebugInfoLevel;
 
 import java.awt.Desktop;
 import java.io.File;
@@ -430,17 +432,18 @@ public class Html5Plugin implements Plugin<Project> {
       throw new RuntimeException("[FlixelGDX] Could not start dev server on port " + port + ": " + e.getMessage(), e);
     }
 
-    Map<String, String> mimeTypes = Map.of(
-        "html", "text/html; charset=utf-8",
-        "js", "application/javascript",
-        "css", "text/css",
-        "png", "image/png",
-        "jpg", "image/jpeg",
-        "jpeg", "image/jpeg",
-        "gif", "image/gif",
-        "txt", "text/plain",
-        "ttf", "font/ttf",
-        "wasm", "application/wasm");
+    Map<String, String> mimeTypes = Map.ofEntries(
+        Map.entry("html", "text/html; charset=utf-8"),
+        Map.entry("js", "application/javascript"),
+        Map.entry("map", "application/json"),
+        Map.entry("css", "text/css"),
+        Map.entry("png", "image/png"),
+        Map.entry("jpg", "image/jpeg"),
+        Map.entry("jpeg", "image/jpeg"),
+        Map.entry("gif", "image/gif"),
+        Map.entry("txt", "text/plain"),
+        Map.entry("ttf", "font/ttf"),
+        Map.entry("wasm", "application/wasm"));
 
     server.createContext("/", (HttpExchange exchange) -> {
       String urlPath = exchange.getRequestURI().getPath();
@@ -522,8 +525,25 @@ public class Html5Plugin implements Plugin<Project> {
       return;
     }
 
+    Html5Extension ext = project.getExtensions().getByType(Html5Extension.class);
     boolean jsEnabled = teavm.getJs().getAddedToWebApp().getOrElse(false);
     boolean wasmEnabled = teavm.getWasmGC().getAddedToWebApp().getOrElse(false);
+
+    // When the build is configured as a debug build, automatically enable source maps and full
+    // debug info so browser DevTools can show Java class names, method names, and line numbers in
+    // stack traces instead of mangled WASM addresses or generated JS function names.
+    // convention() is used so a developer can still override any of these explicitly.
+    if (ext.getMode().isPresent() && ext.getMode().get() == Html5Mode.DEBUG) {
+      if (jsEnabled) {
+        teavm.getJs().getSourceMap().convention(true);
+        teavm.getJs().getSourceFilePolicy().convention(SourceFilePolicy.COPY);
+      }
+      if (wasmEnabled) {
+        teavm.getWasmGC().getSourceMap().convention(true);
+        teavm.getWasmGC().getSourceFilePolicy().convention(SourceFilePolicy.COPY);
+        teavm.getWasmGC().getDebugInfoLevel().convention(WasmDebugInfoLevel.FULL);
+      }
+    }
     String jsBundle = teavm.getJs().getTargetFileName().getOrElse(DEFAULT_JS_BUNDLE);
     String wasmBundle = teavm.getWasmGC().getTargetFileName().getOrElse(DEFAULT_WASM_BUNDLE);
 

--- a/flixelgdx-html5-plugin/src/main/resources/org/flixelgdx/gradle/html5/default-index.html
+++ b/flixelgdx-html5-plugin/src/main/resources/org/flixelgdx/gradle/html5/default-index.html
@@ -232,27 +232,16 @@
         runtime.src = "{{WASM_RUNTIME}}";
         runtime.onload = function () {
           if (window.TeaVM && TeaVM.wasmGC) {
-            if (debugMode) {
-              // In debug mode, load the WASM by URL string so TeaVM can derive the deobfuscator
-              // module path (<bundle>-deobfuscator.wasm) and the debug-info file path
-              // (<bundle>.teadbg) automatically. A blob URL breaks that path derivation.
-              // Progress tracking is skipped because debug builds always run on localhost.
-              TeaVM.wasmGC.load("{{WASM_BUNDLE}}", {
-                stackDeobfuscator: { enabled: true }
-              }).then(function (teavm) {
-                teavm.exports.main([]);
-              }).catch(function (e) { console.error(e); loadJs(); });
-            } else {
-              fetchWithProgress("{{WASM_BUNDLE}}", function (f) { loading.set(f); })
-                .then(function (buffer) {
-                  var url = URL.createObjectURL(new Blob([buffer], { type: 'application/wasm' }));
-                  return TeaVM.wasmGC.load(url).then(function (teavm) {
-                    URL.revokeObjectURL(url);
-                    teavm.exports.main([]);
-                  });
-                })
-                .catch(function (e) { console.error(e); loadJs(); });
-            }
+            // Always load by URL so TeaVM can derive the deobfuscator module path
+            // (<bundle>-deobfuscator.wasm) and the debug-info file (<bundle>.teadbg) automatically.
+            // Stack deobfuscation is always enabled so crash reports include real Java class names
+            // and line numbers regardless of runtime mode. A blob URL would break that path
+            // derivation, so progress tracking is skipped in favor of the indeterminate bar above.
+            TeaVM.wasmGC.load("{{WASM_BUNDLE}}", {
+              stackDeobfuscator: { enabled: true }
+            }).then(function (teavm) {
+              teavm.exports.main([]);
+            }).catch(function (e) { console.error(e); loadJs(); });
           } else {
             loadJs();
           }

--- a/flixelgdx-html5-plugin/src/main/resources/org/flixelgdx/gradle/html5/default-index.html
+++ b/flixelgdx-html5-plugin/src/main/resources/org/flixelgdx/gradle/html5/default-index.html
@@ -232,15 +232,27 @@
         runtime.src = "{{WASM_RUNTIME}}";
         runtime.onload = function () {
           if (window.TeaVM && TeaVM.wasmGC) {
-            fetchWithProgress("{{WASM_BUNDLE}}", function (f) { loading.set(f); })
-              .then(function (buffer) {
-                var url = URL.createObjectURL(new Blob([buffer], { type: 'application/wasm' }));
-                return TeaVM.wasmGC.load(url).then(function (teavm) {
-                  URL.revokeObjectURL(url);
-                  teavm.exports.main([]);
-                });
-              })
-              .catch(function (e) { console.error(e); loadJs(); });
+            if (debugMode) {
+              // In debug mode, load the WASM by URL string so TeaVM can derive the deobfuscator
+              // module path (<bundle>-deobfuscator.wasm) and the debug-info file path
+              // (<bundle>.teadbg) automatically. A blob URL breaks that path derivation.
+              // Progress tracking is skipped because debug builds always run on localhost.
+              TeaVM.wasmGC.load("{{WASM_BUNDLE}}", {
+                stackDeobfuscator: { enabled: true }
+              }).then(function (teavm) {
+                teavm.exports.main([]);
+              }).catch(function (e) { console.error(e); loadJs(); });
+            } else {
+              fetchWithProgress("{{WASM_BUNDLE}}", function (f) { loading.set(f); })
+                .then(function (buffer) {
+                  var url = URL.createObjectURL(new Blob([buffer], { type: 'application/wasm' }));
+                  return TeaVM.wasmGC.load(url).then(function (teavm) {
+                    URL.revokeObjectURL(url);
+                    teavm.exports.main([]);
+                  });
+                })
+                .catch(function (e) { console.error(e); loadJs(); });
+            }
           } else {
             loadJs();
           }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -31,12 +31,12 @@ import org.teavm.jso.JSBody;
  *
  * <p>All three severity levels emit to the browser console and show a full-screen DOM overlay on
  * top of the canvas. The title color distinguishes severity: white for info, yellow for warn, and
- * red for error. Every overlay includes a button that copies a structured report (game name,
- * timestamp, browser, URL, and full message) to the clipboard.
+ * red for error. Every overlay pauses the game loop (via {@code window.__flixelAlertPaused}) and
+ * shows an OK button that dismisses it and resumes the loop.
  *
- * <p>Crash persistence to {@code localStorage} is intentionally not part of this class. It is
- * handled by the crash handler wrapper in {@link FlixelHtml5RuntimeDevice} so that only actual
- * crashes are stored, not every {@code alert.error()} call.
+ * <p>The Copy report button and crash persistence to {@code localStorage} are handled exclusively
+ * by the crash overlay path in {@link FlixelHtml5RuntimeDevice}, not by this alerter, so that
+ * only actual crashes carry those behaviors.
  */
 public class FlixelHtml5Alerter implements FlixelAlerter {
 
@@ -45,7 +45,7 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
     String safeTitle = title != null ? title : "Info";
     String safeMessage = message != null ? message : "";
     consoleLog("[FlixelGDX] " + label(safeTitle, safeMessage));
-    showDomAlert(safeTitle, safeMessage, "#ffffff", "Info Report");
+    showDomAlert(safeTitle, safeMessage, "#ffffff");
   }
 
   @Override
@@ -53,22 +53,24 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
     String safeTitle = title != null ? title : "Warning";
     String safeMessage = message != null ? message : "";
     consoleWarn("[FlixelGDX] " + label(safeTitle, safeMessage));
-    showDomAlert(safeTitle, safeMessage, "#f5c518", "Warning Report");
+    showDomAlert(safeTitle, safeMessage, "#f5c518");
   }
 
   /**
-   * Shows the DOM error overlay and logs to {@code console.error}. The overlay renders on top of
-   * the canvas with the title, full message, and a button to copy the report to the clipboard.
+   * Shows the DOM error overlay, logs to {@code console.error}, and pauses the game loop. The
+   * overlay shows an OK button that dismisses it and resumes the loop.
    *
-   * <p>Crash persistence to {@code localStorage} is the crash handler's responsibility, not the
-   * alerter's. This method only displays the overlay so it can be used for non-crash errors too.
+   * <p>Crash overlays (with a Copy report button) are shown separately by
+   * {@link FlixelHtml5RuntimeDevice} before the crash handler runs, so the crash-specific overlay
+   * is already in place when {@code alert.error()} is called from the crash path. The duplicate
+   * check at the top of {@code showDomAlert} prevents a second overlay from appearing.
    */
   @Override
   public void error(String title, String message) {
     String safeTitle = title != null ? title : "Error";
     String safeMessage = message != null ? message : "";
     consoleError("[FlixelGDX] " + label(safeTitle, safeMessage));
-    showDomAlert(safeTitle, safeMessage, "#e94560", "Crash Report");
+    showDomAlert(safeTitle, safeMessage, "#e94560");
   }
 
   private static String label(String title, String message) {
@@ -84,8 +86,20 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
     return title + ": " + message;
   }
 
-  @JSBody(params = { "title", "message", "titleColor", "reportLabel" }, script = """
+  /**
+   * Shows a full-screen DOM alert overlay with an OK button that dismisses it.
+   *
+   * <p>Sets {@code window.__flixelAlertPaused = true} before adding the overlay so the game
+   * loop's {@code requestAnimationFrame} callback stops updating while the alert is visible.
+   * Clicking OK clears the flag and removes the overlay, resuming the loop.
+   *
+   * <p>If an overlay with id {@code flixel-crash-overlay} is already present (placed by the crash
+   * handler before calling {@code alert.error()}), this method returns immediately so the crash
+   * overlay is not replaced by a generic error box.
+   */
+  @JSBody(params = { "title", "message", "titleColor" }, script = """
       if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
+      window.__flixelAlertPaused = true;
       var overlay = document.createElement('div');
       overlay.id = 'flixel-crash-overlay';
       overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.85);'
@@ -105,18 +119,10 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
       var btn = document.createElement('button');
       btn.style.cssText = 'background:#222;color:#ccc;border:1px solid #444;'
         + 'padding:5px 12px;cursor:pointer;font-family:monospace;font-size:0.8em;';
-      btn.textContent = 'Copy report';
-      var report = (document.title || 'Game') + ' ' + reportLabel + '\\n'
-        + new Date().toISOString() + '\\n'
-        + 'Browser: ' + navigator.userAgent + '\\n'
-        + 'URL: ' + window.location.href + '\\n\\n'
-        + title + '\\n' + message;
+      btn.textContent = 'OK';
       btn.onclick = function () {
-        if (navigator.clipboard) {
-          navigator.clipboard.writeText(report).catch(function () {});
-        }
-        btn.textContent = 'Copied';
-        setTimeout(function () { btn.textContent = 'Copy report'; }, 2000);
+        window.__flixelAlertPaused = false;
+        if (overlay.parentNode) { overlay.parentNode.removeChild(overlay); }
       };
       box.appendChild(titleEl);
       box.appendChild(msgEl);
@@ -124,7 +130,7 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
       overlay.appendChild(box);
       document.body.appendChild(overlay);
       """)
-  private static native void showDomAlert(String title, String message, String titleColor, String reportLabel);
+  private static native void showDomAlert(String title, String message, String titleColor);
 
   @JSBody(params = "text", script = "console.log(text);")
   private static native void consoleLog(String text);

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -44,7 +44,6 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
   public void info(String title, String message) {
     String safeTitle = title != null ? title : "Info";
     String safeMessage = message != null ? message : "";
-    consoleLog("[FlixelGDX] " + label(safeTitle, safeMessage));
     showDomAlert(safeTitle, safeMessage, "#ffffff");
   }
 
@@ -52,38 +51,14 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
   public void warn(String title, String message) {
     String safeTitle = title != null ? title : "Warning";
     String safeMessage = message != null ? message : "";
-    consoleWarn("[FlixelGDX] " + label(safeTitle, safeMessage));
     showDomAlert(safeTitle, safeMessage, "#f5c518");
   }
 
-  /**
-   * Shows the DOM error overlay, logs to {@code console.error}, and pauses the game loop. The
-   * overlay shows an OK button that dismisses it and resumes the loop.
-   *
-   * <p>Crash overlays (with a Copy report button) are shown separately by
-   * {@link FlixelHtml5RuntimeDevice} before the crash handler runs, so the crash-specific overlay
-   * is already in place when {@code alert.error()} is called from the crash path. The duplicate
-   * check at the top of {@code showDomAlert} prevents a second overlay from appearing.
-   */
   @Override
   public void error(String title, String message) {
     String safeTitle = title != null ? title : "Error";
     String safeMessage = message != null ? message : "";
-    consoleError("[FlixelGDX] " + label(safeTitle, safeMessage));
     showDomAlert(safeTitle, safeMessage, "#e94560");
-  }
-
-  private static String label(String title, String message) {
-    if (title == null && message == null) {
-      return "";
-    }
-    if (title == null) {
-      return message;
-    }
-    if (message == null || message.isEmpty()) {
-      return title;
-    }
-    return title + ": " + message;
   }
 
   /**
@@ -131,13 +106,4 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
       document.body.appendChild(overlay);
       """)
   private static native void showDomAlert(String title, String message, String titleColor);
-
-  @JSBody(params = "text", script = "console.log(text);")
-  private static native void consoleLog(String text);
-
-  @JSBody(params = "text", script = "console.warn(text);")
-  private static native void consoleWarn(String text);
-
-  @JSBody(params = "text", script = "console.error(text);")
-  private static native void consoleError(String text);
 }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -77,74 +77,72 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
   }
 
   @JSBody(params = { "title", "message" }, script = """
-      (function () {
-        if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
+      if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
 
-        var overlay = document.createElement('div');
-        overlay.id = 'flixel-crash-overlay';
-        overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.90);'
-          + 'display:flex;align-items:center;justify-content:center;'
-          + 'font-family:monospace;box-sizing:border-box;padding:16px;';
+      var overlay = document.createElement('div');
+      overlay.id = 'flixel-crash-overlay';
+      overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.90);'
+        + 'display:flex;align-items:center;justify-content:center;'
+        + 'font-family:monospace;box-sizing:border-box;padding:16px;';
 
-        var box = document.createElement('div');
-        box.style.cssText = 'background:#161622;border:2px solid #e94560;border-radius:6px;'
-          + 'padding:28px 32px;max-width:680px;width:100%;max-height:85vh;overflow-y:auto;'
-          + 'color:#eee;box-sizing:border-box;';
+      var box = document.createElement('div');
+      box.style.cssText = 'background:#161622;border:2px solid #e94560;border-radius:6px;'
+        + 'padding:28px 32px;max-width:680px;width:100%;max-height:85vh;overflow-y:auto;'
+        + 'color:#eee;box-sizing:border-box;';
 
-        var heading = document.createElement('h2');
-        heading.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:1.1em;'
-          + 'letter-spacing:2px;text-transform:uppercase;';
-        heading.textContent = 'GAME CRASHED';
+      var heading = document.createElement('h2');
+      heading.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:1.1em;'
+        + 'letter-spacing:2px;text-transform:uppercase;';
+      heading.textContent = 'GAME CRASHED';
 
-        var titleEl = document.createElement('p');
-        titleEl.style.cssText = 'margin:0 0 4px 0;font-weight:bold;color:#f4a261;font-size:0.95em;';
-        titleEl.textContent = title;
+      var titleEl = document.createElement('p');
+      titleEl.style.cssText = 'margin:0 0 4px 0;font-weight:bold;color:#f4a261;font-size:0.95em;';
+      titleEl.textContent = title;
 
-        var msgEl = document.createElement('p');
-        msgEl.style.cssText = 'margin:0 0 14px 0;font-size:0.88em;line-height:1.6;'
-          + 'white-space:pre-wrap;word-break:break-word;color:#ddd;';
-        msgEl.textContent = message;
+      var msgEl = document.createElement('p');
+      msgEl.style.cssText = 'margin:0 0 14px 0;font-size:0.88em;line-height:1.6;'
+        + 'white-space:pre-wrap;word-break:break-word;color:#ddd;';
+      msgEl.textContent = message;
 
-        var hint = document.createElement('p');
-        hint.style.cssText = 'margin:0 0 16px 0;font-size:0.8em;color:#888;';
-        hint.textContent = 'Open the browser console (F12) for the full stack trace and log output.';
+      var hint = document.createElement('p');
+      hint.style.cssText = 'margin:0 0 16px 0;font-size:0.8em;color:#888;';
+      hint.textContent = 'Open the browser console (F12) for the full stack trace and log output.';
 
-        var footer = document.createElement('div');
-        footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;'
-          + 'flex-wrap:wrap;gap:10px;border-top:1px solid #333;padding-top:14px;';
+      var footer = document.createElement('div');
+      footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;'
+        + 'flex-wrap:wrap;gap:10px;border-top:1px solid #333;padding-top:14px;';
 
-        var btn = document.createElement('button');
-        btn.style.cssText = 'background:#e94560;color:#fff;border:none;border-radius:4px;'
-          + 'padding:7px 18px;cursor:pointer;font-family:monospace;font-size:0.85em;letter-spacing:1px;';
-        btn.textContent = 'Copy Report';
-        var report = 'FlixelGDX Crash Report\\n'
-          + new Date().toISOString() + '\\n'
-          + 'Browser: ' + navigator.userAgent + '\\n'
-          + 'URL: ' + window.location.href + '\\n\\n'
-          + title + '\\n' + message;
-        btn.onclick = function () {
-          if (navigator.clipboard) {
-            navigator.clipboard.writeText(report).catch(function () {});
-          }
-          btn.textContent = 'Copied!';
-          setTimeout(function () { btn.textContent = 'Copy Report'; }, 2000);
-        };
+      var btn = document.createElement('button');
+      btn.style.cssText = 'background:#e94560;color:#fff;border:none;border-radius:4px;'
+        + 'padding:7px 18px;cursor:pointer;font-family:monospace;font-size:0.85em;letter-spacing:1px;';
+      btn.textContent = 'Copy Report';
+      var report = 'FlixelGDX Crash Report\\n'
+        + new Date().toISOString() + '\\n'
+        + 'Browser: ' + navigator.userAgent + '\\n'
+        + 'URL: ' + window.location.href + '\\n\\n'
+        + title + '\\n' + message;
+      btn.onclick = function () {
+        if (navigator.clipboard) {
+          navigator.clipboard.writeText(report).catch(function () {});
+        }
+        btn.textContent = 'Copied!';
+        setTimeout(function () { btn.textContent = 'Copy Report'; }, 2000);
+      };
 
-        var ua = document.createElement('small');
-        ua.style.cssText = 'color:#666;font-size:0.72em;max-width:400px;overflow:hidden;'
-          + 'text-overflow:ellipsis;white-space:nowrap;';
-        ua.textContent = navigator.userAgent;
+      var ua = document.createElement('small');
+      ua.style.cssText = 'color:#666;font-size:0.72em;max-width:400px;overflow:hidden;'
+        + 'text-overflow:ellipsis;white-space:nowrap;';
+      ua.textContent = navigator.userAgent;
 
-        footer.appendChild(btn);
-        footer.appendChild(ua);
-        box.appendChild(heading);
-        box.appendChild(titleEl);
-        box.appendChild(msgEl);
-        box.appendChild(hint);
-        box.appendChild(footer);
-        overlay.appendChild(box);
-        document.body.appendChild(overlay);
-      })();
+      footer.appendChild(btn);
+      footer.appendChild(ua);
+      box.appendChild(heading);
+      box.appendChild(titleEl);
+      box.appendChild(msgEl);
+      box.appendChild(hint);
+      box.appendChild(footer);
+      overlay.appendChild(box);
+      document.body.appendChild(overlay);
       """)
   private static native void showCrashOverlay(String title, String message);
 

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -35,7 +35,7 @@ import org.teavm.jso.JSBody;
  * the key {@code flixelgdx_last_crash} so it persists across a page reload.
  *
  * <p>The overlay replaces the old {@code window.alert()} call, which was synchronous, blocking,
- * and showed no structured information.
+ * and provided no structured crash information.
  */
 public class FlixelHtml5Alerter implements FlixelAlerter {
 
@@ -51,8 +51,8 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
 
   /**
    * Shows the DOM crash overlay, logs to {@code console.error}, and persists the report to
-   * {@code localStorage}. The overlay renders on top of the canvas with the title, message, a
-   * copy-to-clipboard button, and a note pointing to the browser console for the full stack trace.
+   * {@code localStorage}. The overlay renders on top of the canvas with the title, full message,
+   * and a button to copy the crash report to the clipboard.
    */
   @Override
   public void error(String title, String message) {
@@ -81,41 +81,28 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
 
       var overlay = document.createElement('div');
       overlay.id = 'flixel-crash-overlay';
-      overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.90);'
+      overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.85);'
         + 'display:flex;align-items:center;justify-content:center;'
-        + 'font-family:monospace;box-sizing:border-box;padding:16px;';
+        + 'font-family:monospace;padding:16px;box-sizing:border-box;';
 
       var box = document.createElement('div');
-      box.style.cssText = 'background:#161622;border:2px solid #e94560;border-radius:6px;'
-        + 'padding:28px 32px;max-width:680px;width:100%;max-height:85vh;overflow-y:auto;'
-        + 'color:#eee;box-sizing:border-box;';
-
-      var heading = document.createElement('h2');
-      heading.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:1.1em;'
-        + 'letter-spacing:2px;text-transform:uppercase;';
-      heading.textContent = 'GAME CRASHED';
+      box.style.cssText = 'background:#111;border:1px solid #333;'
+        + 'padding:20px 24px;max-width:600px;width:100%;max-height:80vh;overflow-y:auto;'
+        + 'color:#ccc;box-sizing:border-box;';
 
       var titleEl = document.createElement('p');
-      titleEl.style.cssText = 'margin:0 0 4px 0;font-weight:bold;color:#f4a261;font-size:0.95em;';
+      titleEl.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:0.9em;';
       titleEl.textContent = title;
 
       var msgEl = document.createElement('p');
-      msgEl.style.cssText = 'margin:0 0 14px 0;font-size:0.88em;line-height:1.6;'
-        + 'white-space:pre-wrap;word-break:break-word;color:#ddd;';
+      msgEl.style.cssText = 'margin:0 0 16px 0;font-size:0.82em;line-height:1.5;'
+        + 'white-space:pre-wrap;word-break:break-word;';
       msgEl.textContent = message;
 
-      var hint = document.createElement('p');
-      hint.style.cssText = 'margin:0 0 16px 0;font-size:0.8em;color:#888;';
-      hint.textContent = 'Open the browser console (F12) for the full stack trace and log output.';
-
-      var footer = document.createElement('div');
-      footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;'
-        + 'flex-wrap:wrap;gap:10px;border-top:1px solid #333;padding-top:14px;';
-
       var btn = document.createElement('button');
-      btn.style.cssText = 'background:#e94560;color:#fff;border:none;border-radius:4px;'
-        + 'padding:7px 18px;cursor:pointer;font-family:monospace;font-size:0.85em;letter-spacing:1px;';
-      btn.textContent = 'Copy Report';
+      btn.style.cssText = 'background:#222;color:#ccc;border:1px solid #444;'
+        + 'padding:5px 12px;cursor:pointer;font-family:monospace;font-size:0.8em;';
+      btn.textContent = 'Copy report';
       var report = 'FlixelGDX Crash Report\\n'
         + new Date().toISOString() + '\\n'
         + 'Browser: ' + navigator.userAgent + '\\n'
@@ -125,22 +112,13 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
         if (navigator.clipboard) {
           navigator.clipboard.writeText(report).catch(function () {});
         }
-        btn.textContent = 'Copied!';
-        setTimeout(function () { btn.textContent = 'Copy Report'; }, 2000);
+        btn.textContent = 'Copied';
+        setTimeout(function () { btn.textContent = 'Copy report'; }, 2000);
       };
 
-      var ua = document.createElement('small');
-      ua.style.cssText = 'color:#666;font-size:0.72em;max-width:400px;overflow:hidden;'
-        + 'text-overflow:ellipsis;white-space:nowrap;';
-      ua.textContent = navigator.userAgent;
-
-      footer.appendChild(btn);
-      footer.appendChild(ua);
-      box.appendChild(heading);
       box.appendChild(titleEl);
       box.appendChild(msgEl);
-      box.appendChild(hint);
-      box.appendChild(footer);
+      box.appendChild(btn);
       overlay.appendChild(box);
       document.body.appendChild(overlay);
       """)

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -28,29 +28,145 @@ import org.teavm.jso.JSBody;
 
 /**
  * Alert implementation for the HTML5 platform.
+ *
+ * <p>Info and warn alerts emit to the browser console, which is always visible to developers
+ * without interrupting the running page. Error alerts show a full-screen DOM crash overlay on top
+ * of the canvas, log to {@code console.error}, and save the report to {@code localStorage} under
+ * the key {@code flixelgdx_last_crash} so it persists across a page reload.
+ *
+ * <p>The overlay replaces the old {@code window.alert()} call, which was synchronous, blocking,
+ * and showed no structured information.
  */
 public class FlixelHtml5Alerter implements FlixelAlerter {
 
   @Override
   public void info(String title, String message) {
-    showAlert(title, message);
+    consoleLog("[FlixelGDX] " + label(title, message));
   }
 
   @Override
   public void warn(String title, String message) {
-    showAlert(title, message);
+    consoleWarn("[FlixelGDX] " + label(title, message));
   }
 
+  /**
+   * Shows the DOM crash overlay, logs to {@code console.error}, and persists the report to
+   * {@code localStorage}. The overlay renders on top of the canvas with the title, message, a
+   * copy-to-clipboard button, and a note pointing to the browser console for the full stack trace.
+   */
   @Override
   public void error(String title, String message) {
-    showAlert(title, message);
+    String safeTitle = title != null ? title : "Error";
+    String safeMessage = message != null ? message : "";
+    consoleError("[FlixelGDX] " + label(safeTitle, safeMessage));
+    persistCrash(safeTitle, safeMessage);
+    showCrashOverlay(safeTitle, safeMessage);
   }
 
-  private void showAlert(String title, String message) {
-    String text = (title != null ? title : "") + (message != null ? "\n" + message : "");
-    alert(text);
+  private static String label(String title, String message) {
+    if (title == null && message == null) {
+      return "";
+    }
+    if (title == null) {
+      return message;
+    }
+    if (message == null || message.isEmpty()) {
+      return title;
+    }
+    return title + ": " + message;
   }
 
-  @JSBody(params = "text", script = "alert(text);")
-  private static native void alert(String text);
+  @JSBody(params = { "title", "message" }, script = """
+      (function () {
+        if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
+
+        var overlay = document.createElement('div');
+        overlay.id = 'flixel-crash-overlay';
+        overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.90);'
+          + 'display:flex;align-items:center;justify-content:center;'
+          + 'font-family:monospace;box-sizing:border-box;padding:16px;';
+
+        var box = document.createElement('div');
+        box.style.cssText = 'background:#161622;border:2px solid #e94560;border-radius:6px;'
+          + 'padding:28px 32px;max-width:680px;width:100%;max-height:85vh;overflow-y:auto;'
+          + 'color:#eee;box-sizing:border-box;';
+
+        var heading = document.createElement('h2');
+        heading.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:1.1em;'
+          + 'letter-spacing:2px;text-transform:uppercase;';
+        heading.textContent = 'GAME CRASHED';
+
+        var titleEl = document.createElement('p');
+        titleEl.style.cssText = 'margin:0 0 4px 0;font-weight:bold;color:#f4a261;font-size:0.95em;';
+        titleEl.textContent = title;
+
+        var msgEl = document.createElement('p');
+        msgEl.style.cssText = 'margin:0 0 14px 0;font-size:0.88em;line-height:1.6;'
+          + 'white-space:pre-wrap;word-break:break-word;color:#ddd;';
+        msgEl.textContent = message;
+
+        var hint = document.createElement('p');
+        hint.style.cssText = 'margin:0 0 16px 0;font-size:0.8em;color:#888;';
+        hint.textContent = 'Open the browser console (F12) for the full stack trace and log output.';
+
+        var footer = document.createElement('div');
+        footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;'
+          + 'flex-wrap:wrap;gap:10px;border-top:1px solid #333;padding-top:14px;';
+
+        var btn = document.createElement('button');
+        btn.style.cssText = 'background:#e94560;color:#fff;border:none;border-radius:4px;'
+          + 'padding:7px 18px;cursor:pointer;font-family:monospace;font-size:0.85em;letter-spacing:1px;';
+        btn.textContent = 'Copy Report';
+        var report = 'FlixelGDX Crash Report\\n'
+          + new Date().toISOString() + '\\n'
+          + 'Browser: ' + navigator.userAgent + '\\n'
+          + 'URL: ' + window.location.href + '\\n\\n'
+          + title + '\\n' + message;
+        btn.onclick = function () {
+          if (navigator.clipboard) {
+            navigator.clipboard.writeText(report).catch(function () {});
+          }
+          btn.textContent = 'Copied!';
+          setTimeout(function () { btn.textContent = 'Copy Report'; }, 2000);
+        };
+
+        var ua = document.createElement('small');
+        ua.style.cssText = 'color:#666;font-size:0.72em;max-width:400px;overflow:hidden;'
+          + 'text-overflow:ellipsis;white-space:nowrap;';
+        ua.textContent = navigator.userAgent;
+
+        footer.appendChild(btn);
+        footer.appendChild(ua);
+        box.appendChild(heading);
+        box.appendChild(titleEl);
+        box.appendChild(msgEl);
+        box.appendChild(hint);
+        box.appendChild(footer);
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+      })();
+      """)
+  private static native void showCrashOverlay(String title, String message);
+
+  @JSBody(params = { "title", "message" }, script = """
+      try {
+        localStorage.setItem('flixelgdx_last_crash', JSON.stringify({
+          time: new Date().toISOString(),
+          title: title,
+          message: message,
+          ua: navigator.userAgent,
+          url: window.location.href
+        }));
+      } catch (e) {}
+      """)
+  private static native void persistCrash(String title, String message);
+
+  @JSBody(params = "text", script = "console.log(text);")
+  private static native void consoleLog(String text);
+
+  @JSBody(params = "text", script = "console.warn(text);")
+  private static native void consoleWarn(String text);
+
+  @JSBody(params = "text", script = "console.error(text);")
+  private static native void consoleError(String text);
 }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -29,38 +29,46 @@ import org.teavm.jso.JSBody;
 /**
  * Alert implementation for the HTML5 platform.
  *
- * <p>Info and warn alerts emit to the browser console, which is always visible to developers
- * without interrupting the running page. Error alerts show a full-screen DOM crash overlay on top
- * of the canvas, log to {@code console.error}, and save the report to {@code localStorage} under
- * the key {@code flixelgdx_last_crash} so it persists across a page reload.
+ * <p>All three severity levels emit to the browser console and show a full-screen DOM overlay on
+ * top of the canvas. The title color distinguishes severity: white for info, yellow for warn, and
+ * red for error. Every overlay includes a button that copies a structured report (game name,
+ * timestamp, browser, URL, and full message) to the clipboard.
  *
- * <p>The overlay replaces the old {@code window.alert()} call, which was synchronous, blocking,
- * and provided no structured crash information.
+ * <p>Crash persistence to {@code localStorage} is intentionally not part of this class. It is
+ * handled by the crash handler wrapper in {@link FlixelHtml5RuntimeDevice} so that only actual
+ * crashes are stored, not every {@code alert.error()} call.
  */
 public class FlixelHtml5Alerter implements FlixelAlerter {
 
   @Override
   public void info(String title, String message) {
-    consoleLog("[FlixelGDX] " + label(title, message));
+    String safeTitle = title != null ? title : "Info";
+    String safeMessage = message != null ? message : "";
+    consoleLog("[FlixelGDX] " + label(safeTitle, safeMessage));
+    showDomAlert(safeTitle, safeMessage, "#ffffff", "Info Report");
   }
 
   @Override
   public void warn(String title, String message) {
-    consoleWarn("[FlixelGDX] " + label(title, message));
+    String safeTitle = title != null ? title : "Warning";
+    String safeMessage = message != null ? message : "";
+    consoleWarn("[FlixelGDX] " + label(safeTitle, safeMessage));
+    showDomAlert(safeTitle, safeMessage, "#f5c518", "Warning Report");
   }
 
   /**
-   * Shows the DOM crash overlay, logs to {@code console.error}, and persists the report to
-   * {@code localStorage}. The overlay renders on top of the canvas with the title, full message,
-   * and a button to copy the crash report to the clipboard.
+   * Shows the DOM error overlay and logs to {@code console.error}. The overlay renders on top of
+   * the canvas with the title, full message, and a button to copy the report to the clipboard.
+   *
+   * <p>Crash persistence to {@code localStorage} is the crash handler's responsibility, not the
+   * alerter's. This method only displays the overlay so it can be used for non-crash errors too.
    */
   @Override
   public void error(String title, String message) {
     String safeTitle = title != null ? title : "Error";
     String safeMessage = message != null ? message : "";
     consoleError("[FlixelGDX] " + label(safeTitle, safeMessage));
-    persistCrash(safeTitle, safeMessage);
-    showCrashOverlay(safeTitle, safeMessage);
+    showDomAlert(safeTitle, safeMessage, "#e94560", "Crash Report");
   }
 
   private static String label(String title, String message) {
@@ -76,34 +84,29 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
     return title + ": " + message;
   }
 
-  @JSBody(params = { "title", "message" }, script = """
+  @JSBody(params = { "title", "message", "titleColor", "reportLabel" }, script = """
       if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
-
       var overlay = document.createElement('div');
       overlay.id = 'flixel-crash-overlay';
       overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.85);'
         + 'display:flex;align-items:center;justify-content:center;'
         + 'font-family:monospace;padding:16px;box-sizing:border-box;';
-
       var box = document.createElement('div');
       box.style.cssText = 'background:#111;border:1px solid #333;'
-        + 'padding:20px 24px;max-width:600px;width:100%;max-height:80vh;overflow-y:auto;'
+        + 'padding:20px 24px;width:max-content;max-width:80vw;max-height:80vh;overflow-y:auto;'
         + 'color:#ccc;box-sizing:border-box;';
-
       var titleEl = document.createElement('p');
-      titleEl.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:0.9em;';
+      titleEl.style.cssText = 'margin:0 0 12px 0;font-size:0.9em;color:' + titleColor + ';';
       titleEl.textContent = title;
-
       var msgEl = document.createElement('p');
       msgEl.style.cssText = 'margin:0 0 16px 0;font-size:0.82em;line-height:1.5;'
         + 'white-space:pre-wrap;word-break:break-word;';
       msgEl.textContent = message;
-
       var btn = document.createElement('button');
       btn.style.cssText = 'background:#222;color:#ccc;border:1px solid #444;'
         + 'padding:5px 12px;cursor:pointer;font-family:monospace;font-size:0.8em;';
       btn.textContent = 'Copy report';
-      var report = 'FlixelGDX Crash Report\\n'
+      var report = (document.title || 'Game') + ' ' + reportLabel + '\\n'
         + new Date().toISOString() + '\\n'
         + 'Browser: ' + navigator.userAgent + '\\n'
         + 'URL: ' + window.location.href + '\\n\\n'
@@ -115,27 +118,13 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
         btn.textContent = 'Copied';
         setTimeout(function () { btn.textContent = 'Copy report'; }, 2000);
       };
-
       box.appendChild(titleEl);
       box.appendChild(msgEl);
       box.appendChild(btn);
       overlay.appendChild(box);
       document.body.appendChild(overlay);
       """)
-  private static native void showCrashOverlay(String title, String message);
-
-  @JSBody(params = { "title", "message" }, script = """
-      try {
-        localStorage.setItem('flixelgdx_last_crash', JSON.stringify({
-          time: new Date().toISOString(),
-          title: title,
-          message: message,
-          ua: navigator.userAgent,
-          url: window.location.href
-        }));
-      } catch (e) {}
-      """)
-  private static native void persistCrash(String title, String message);
+  private static native void showDomAlert(String title, String message, String titleColor, String reportLabel);
 
   @JSBody(params = "text", script = "console.log(text);")
   private static native void consoleLog(String text);

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -169,6 +169,11 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
    * previous timestamp to subtract from, so it reports a zero delta and lets {@link FlixelGame}
    * clamp it; every later frame reports the real time elapsed since the previous drawn frame.
    *
+   * <p>When a DOM alert overlay is visible (info or warn), {@code window.__flixelAlertPaused} is
+   * {@code true}. While that flag is set, the game is not updated or drawn and the timestamp is
+   * reset so the first frame after the overlay is dismissed does not report the paused duration as
+   * elapsed time. This mirrors the blocking behavior of SDL modal dialogs on desktop.
+   *
    * <p>The frame body is wrapped in a try-catch so any unhandled Java exception thrown during an
    * update or draw call is routed through the installed {@link FlixelCrashHandler} rather than
    * propagating silently into the browser as an opaque JavaScript or WebAssembly error. The next
@@ -177,6 +182,11 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
    * @param timestamp The browser-supplied frame time in milliseconds.
    */
   private void onAnimationFrame(double timestamp) {
+    if (isAlertPaused()) {
+      lastTimestamp = -1.0;
+      Window.requestAnimationFrame(this::onAnimationFrame);
+      return;
+    }
     try {
       float deltaSeconds = lastTimestamp < 0.0 ? 0f : (float) ((timestamp - lastTimestamp) / 1000.0);
       lastTimestamp = timestamp;
@@ -194,6 +204,9 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
     }
     Window.requestAnimationFrame(this::onAnimationFrame);
   }
+
+  @JSBody(script = "return !!window.__flixelAlertPaused;")
+  private static native boolean isAlertPaused();
 
   /**
    * Locates the canvas the game draws into, creating one under {@link #canvasId} if the page did

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -25,6 +25,7 @@ package org.flixelgdx.backend.html5;
 
 import org.flixelgdx.Flixel;
 import org.flixelgdx.FlixelGame;
+import org.flixelgdx.backend.FlixelCrashHandler;
 import org.flixelgdx.backend.FlixelGameRunner;
 import org.flixelgdx.backend.html5.asset.FlixelHtml5AssetPreloader;
 import org.flixelgdx.backend.html5.file.FlixelHtml5Files;
@@ -75,6 +76,7 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
 
   private HTMLCanvasElement canvas;
   private FlixelGame game;
+  private FlixelCrashHandler crashHandler;
 
   /**
    * Creates an HTML5 runner for the given canvas and platform components.
@@ -130,6 +132,11 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
   private void startGame() {
     hideLoadingOverlay();
     game.create();
+    // game.create() installs the crash handler into Flixel.runtime. Cache it here so the game loop
+    // can route frame exceptions through the handler without re-casting on every frame.
+    if (Flixel.runtime instanceof FlixelHtml5RuntimeDevice device) {
+      crashHandler = device.getCrashHandler();
+    }
     Window.requestAnimationFrame(this::onAnimationFrame);
   }
 
@@ -162,17 +169,29 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
    * previous timestamp to subtract from, so it reports a zero delta and lets {@link FlixelGame}
    * clamp it; every later frame reports the real time elapsed since the previous drawn frame.
    *
+   * <p>The frame body is wrapped in a try-catch so any unhandled Java exception thrown during an
+   * update or draw call is routed through the installed {@link FlixelCrashHandler} rather than
+   * propagating silently into the browser as an opaque JavaScript or WebAssembly error. The next
+   * frame is only scheduled after a clean frame; a caught exception stops the loop.
+   *
    * @param timestamp The browser-supplied frame time in milliseconds.
    */
   private void onAnimationFrame(double timestamp) {
-    float deltaSeconds = lastTimestamp < 0.0 ? 0f : (float) ((timestamp - lastTimestamp) / 1000.0);
-    lastTimestamp = timestamp;
-    float elapsed = game.advanceTime(deltaSeconds);
-    game.update(elapsed);
-    graphics.beginFrame();
-    game.draw(graphics.getBatch());
-    game.endFrame();
-    graphics.endFrame();
+    try {
+      float deltaSeconds = lastTimestamp < 0.0 ? 0f : (float) ((timestamp - lastTimestamp) / 1000.0);
+      lastTimestamp = timestamp;
+      float elapsed = game.advanceTime(deltaSeconds);
+      game.update(elapsed);
+      graphics.beginFrame();
+      game.draw(graphics.getBatch());
+      game.endFrame();
+      graphics.endFrame();
+    } catch (Throwable t) {
+      if (crashHandler != null) {
+        crashHandler.onCrash(null, t);
+      }
+      return;
+    }
     Window.requestAnimationFrame(this::onAnimationFrame);
   }
 

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -172,7 +172,7 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
    * <p>When a DOM alert overlay is visible (info or warn), {@code window.__flixelAlertPaused} is
    * {@code true}. While that flag is set, the game is not updated or drawn and the timestamp is
    * reset so the first frame after the overlay is dismissed does not report the paused duration as
-   * elapsed time. This mirrors the blocking behavior of SDL modal dialogs on desktop.
+   * elapsed time.
    *
    * <p>The frame body is wrapped in a try-catch so any unhandled Java exception thrown during an
    * update or draw call is routed through the installed {@link FlixelCrashHandler} rather than

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -29,8 +29,6 @@ import org.flixelgdx.backend.FlixelRuntimeDevice;
 import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
-import org.teavm.jso.JSFunctor;
-import org.teavm.jso.JSObject;
 
 import java.util.Objects;
 
@@ -43,11 +41,14 @@ import java.util.Objects;
  * class surfaces for the debug overlay; everything else returns the safe default the interface
  * already provides.
  *
- * <p>On web, {@link #setCrashHandler} wires the supplied handler into two browser-level error
- * signals: {@code window.onerror}, which fires for uncaught JavaScript exceptions and WebAssembly
- * traps that escape the Java exception system, and {@code window.unhandledrejection}, which fires
- * for unhandled Promise rejections. Together these complement the try-catch already wrapped around
- * the game loop in {@link FlixelHtml5Runner}, catching anything that happens outside that boundary.
+ * <p>On web, {@link #setCrashHandler} wires crash detection into two browser-level error signals:
+ * {@code window.onerror}, which fires for uncaught JavaScript exceptions and WebAssembly traps that
+ * escape the Java exception system, and {@code window.unhandledrejection}, which fires for unhandled
+ * Promise rejections. Both are installed as pure JavaScript handlers (no {@code @JSFunctor} callback)
+ * so they work on both the JavaScript and WebAssembly GC TeaVM targets. They log to
+ * {@code console.error}, show the crash overlay, and persist the report to {@code localStorage}.
+ * Java exceptions thrown inside the game loop are handled separately by the try-catch in
+ * {@link FlixelHtml5Runner}, which routes them through the stored {@link FlixelCrashHandler}.
  */
 public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
 
@@ -83,17 +84,21 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
   }
 
   /**
-   * Installs the crash handler and wires it into two browser error signals.
+   * Stores the crash handler for use by the game loop and installs two pure-JavaScript browser
+   * error listeners.
    *
-   * <p>{@code window.onerror} catches uncaught JavaScript exceptions and WebAssembly traps that
-   * escape the Java exception system entirely. {@code window.unhandledrejection} catches unhandled
-   * Promise rejections. Both complement the try-catch in the game loop, which handles Java
-   * exceptions thrown during a frame.
+   * <p>{@code window.onerror} handles uncaught JavaScript exceptions and WebAssembly traps.
+   * {@code window.unhandledrejection} handles bare Promise rejections. Both are installed as
+   * self-contained JavaScript functions with no callback into Java; they log to
+   * {@code console.error}, show the DOM crash overlay, and persist the report to
+   * {@code localStorage}.
    *
-   * <p>All JavaScript-side error extraction (reading {@code .stack}, {@code .message}, source
-   * location) is performed inside the JavaScript wrappers so the {@link JsCrashCallback} interface
-   * only ever receives a plain {@link String}. This avoids passing {@code JSObject} references
-   * through a {@link JSFunctor} callback, which is not supported in TeaVM's WasmGC code generator.
+   * <p>A {@code @JSFunctor} callback is intentionally not used here. TeaVM 0.13.0's WasmGC code
+   * generator produces a nameless function statement ({@code function() {}}) instead of an
+   * expression when wrapping any {@code @JSFunctor} method that takes parameters, causing a
+   * {@code SyntaxError} at module load time. The only safe {@code @JSFunctor} shape is
+   * {@code void} return with zero parameters (see
+   * {@link org.flixelgdx.backend.html5.asset.FlixelHtml5AssetPreloader.PreloadCallback}).
    *
    * @param handler The crash handler to install.
    */
@@ -101,15 +106,7 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
   public void setCrashHandler(@NotNull FlixelCrashHandler handler) {
     Objects.requireNonNull(handler, "handler cannot be null");
     this.crashHandler = handler;
-
-    // window.onerror: the JS wrapper extracts the best available description from the error object
-    // and calls back with a plain string so no JSObject crosses the @JSFunctor boundary.
-    // Returning true from window.onerror suppresses the browser's own error UI.
-    installWindowOnerror(detail -> handler.onCrash(null, new RuntimeException(detail)));
-
-    // window.unhandledrejection: same pattern, reason extracted in JS before the callback.
-    installRejectionListener(
-        reason -> handler.onCrash(null, new RuntimeException("Unhandled Promise rejection: " + reason)));
+    installJsErrorHandlers();
   }
 
   /** Returns the crash handler installed by {@link #setCrashHandler}, or {@code null} if not set. */
@@ -118,32 +115,90 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
   }
 
   /**
-   * Installs a {@code window.onerror} handler that extracts the best available description from
-   * the error and passes it as a plain string to {@code callback}. Always returns {@code true} to
-   * suppress the browser's own error UI.
+   * Installs {@code window.onerror} and {@code window.unhandledrejection} as self-contained
+   * JavaScript handlers. Both handlers log to {@code console.error}, persist the report to
+   * {@code localStorage}, and show the DOM crash overlay without calling back into Java.
    */
-  @JSBody(params = "callback", script = """
+  @JSBody(script = """
+      function flixelShowJsCrash(title, message) {
+        console.error('[FlixelGDX] ' + title + ': ' + message);
+        try {
+          localStorage.setItem('flixelgdx_last_crash', JSON.stringify({
+            time: new Date().toISOString(),
+            title: title,
+            message: message,
+            ua: navigator.userAgent,
+            url: window.location.href
+          }));
+        } catch (e) {}
+        if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
+        var overlay = document.createElement('div');
+        overlay.id = 'flixel-crash-overlay';
+        overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.90);'
+          + 'display:flex;align-items:center;justify-content:center;'
+          + 'font-family:monospace;box-sizing:border-box;padding:16px;';
+        var box = document.createElement('div');
+        box.style.cssText = 'background:#161622;border:2px solid #e94560;border-radius:6px;'
+          + 'padding:28px 32px;max-width:680px;width:100%;max-height:85vh;overflow-y:auto;'
+          + 'color:#eee;box-sizing:border-box;';
+        var heading = document.createElement('h2');
+        heading.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:1.1em;'
+          + 'letter-spacing:2px;text-transform:uppercase;';
+        heading.textContent = 'GAME CRASHED';
+        var titleEl = document.createElement('p');
+        titleEl.style.cssText = 'margin:0 0 4px 0;font-weight:bold;color:#f4a261;font-size:0.95em;';
+        titleEl.textContent = title;
+        var msgEl = document.createElement('p');
+        msgEl.style.cssText = 'margin:0 0 14px 0;font-size:0.88em;line-height:1.6;'
+          + 'white-space:pre-wrap;word-break:break-word;color:#ddd;';
+        msgEl.textContent = message;
+        var hint = document.createElement('p');
+        hint.style.cssText = 'margin:0 0 16px 0;font-size:0.8em;color:#888;';
+        hint.textContent = 'Open the browser console (F12) for the full stack trace and log output.';
+        var footer = document.createElement('div');
+        footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;'
+          + 'flex-wrap:wrap;gap:10px;border-top:1px solid #333;padding-top:14px;';
+        var btn = document.createElement('button');
+        btn.style.cssText = 'background:#e94560;color:#fff;border:none;border-radius:4px;'
+          + 'padding:7px 18px;cursor:pointer;font-family:monospace;font-size:0.85em;letter-spacing:1px;';
+        btn.textContent = 'Copy Report';
+        var report = 'FlixelGDX Crash Report\\n'
+          + new Date().toISOString() + '\\n'
+          + 'Browser: ' + navigator.userAgent + '\\n'
+          + 'URL: ' + window.location.href + '\\n\\n'
+          + title + '\\n' + message;
+        btn.onclick = function () {
+          if (navigator.clipboard) { navigator.clipboard.writeText(report).catch(function () {}); }
+          btn.textContent = 'Copied!';
+          setTimeout(function () { btn.textContent = 'Copy Report'; }, 2000);
+        };
+        var ua = document.createElement('small');
+        ua.style.cssText = 'color:#666;font-size:0.72em;max-width:400px;overflow:hidden;'
+          + 'text-overflow:ellipsis;white-space:nowrap;';
+        ua.textContent = navigator.userAgent;
+        footer.appendChild(btn);
+        footer.appendChild(ua);
+        box.appendChild(heading);
+        box.appendChild(titleEl);
+        box.appendChild(msgEl);
+        box.appendChild(hint);
+        box.appendChild(footer);
+        overlay.appendChild(box);
+        document.body.appendChild(overlay);
+      }
       window.onerror = function(msg, src, line, col, err) {
         var detail = err ? (err.stack || err.message || msg) : (msg || 'Unknown JavaScript error');
         detail += '\\n[' + (src || '?') + ':' + (line || '?') + ']';
-        callback(detail);
+        flixelShowJsCrash('JavaScript Error', detail);
         return true;
       };
-      """)
-  private static native void installWindowOnerror(JsCrashCallback callback);
-
-  /**
-   * Adds a {@code window.unhandledrejection} listener that extracts the rejection reason and
-   * passes it as a plain string to {@code callback}.
-   */
-  @JSBody(params = "callback", script = """
       window.addEventListener('unhandledrejection', function(event) {
         var r = event.reason;
         var reason = r ? (r.stack || r.message || String(r)) : 'Unknown rejection reason';
-        callback(reason);
+        flixelShowJsCrash('Promise Rejection', reason);
       });
       """)
-  private static native void installRejectionListener(JsCrashCallback callback);
+  private static native void installJsErrorHandlers();
 
   @JSBody(script = """
       return (window.performance && window.performance.memory)
@@ -161,16 +216,5 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
    */
   private static long usedHeapBytes() {
     return (long) usedHeap();
-  }
-
-  /**
-   * Callback type shared by both browser error signals. Receives an already-formatted string
-   * describing the error so no {@code JSObject} references need to cross the JS-to-Java boundary,
-   * which is not supported in TeaVM's WasmGC {@link JSFunctor} code generator.
-   */
-  @JSFunctor
-  @FunctionalInterface
-  interface JsCrashCallback extends JSObject {
-    void onCrash(String detail);
   }
 }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -134,34 +134,24 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
         if (!document.body || document.getElementById('flixel-crash-overlay')) { return; }
         var overlay = document.createElement('div');
         overlay.id = 'flixel-crash-overlay';
-        overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.90);'
+        overlay.style.cssText = 'position:fixed;inset:0;z-index:99999;background:rgba(0,0,0,0.85);'
           + 'display:flex;align-items:center;justify-content:center;'
-          + 'font-family:monospace;box-sizing:border-box;padding:16px;';
+          + 'font-family:monospace;padding:16px;box-sizing:border-box;';
         var box = document.createElement('div');
-        box.style.cssText = 'background:#161622;border:2px solid #e94560;border-radius:6px;'
-          + 'padding:28px 32px;max-width:680px;width:100%;max-height:85vh;overflow-y:auto;'
-          + 'color:#eee;box-sizing:border-box;';
-        var heading = document.createElement('h2');
-        heading.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:1.1em;'
-          + 'letter-spacing:2px;text-transform:uppercase;';
-        heading.textContent = 'GAME CRASHED';
+        box.style.cssText = 'background:#111;border:1px solid #333;'
+          + 'padding:20px 24px;max-width:600px;width:100%;max-height:80vh;overflow-y:auto;'
+          + 'color:#ccc;box-sizing:border-box;';
         var titleEl = document.createElement('p');
-        titleEl.style.cssText = 'margin:0 0 4px 0;font-weight:bold;color:#f4a261;font-size:0.95em;';
+        titleEl.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:0.9em;';
         titleEl.textContent = title;
         var msgEl = document.createElement('p');
-        msgEl.style.cssText = 'margin:0 0 14px 0;font-size:0.88em;line-height:1.6;'
-          + 'white-space:pre-wrap;word-break:break-word;color:#ddd;';
+        msgEl.style.cssText = 'margin:0 0 16px 0;font-size:0.82em;line-height:1.5;'
+          + 'white-space:pre-wrap;word-break:break-word;';
         msgEl.textContent = message;
-        var hint = document.createElement('p');
-        hint.style.cssText = 'margin:0 0 16px 0;font-size:0.8em;color:#888;';
-        hint.textContent = 'Open the browser console (F12) for the full stack trace and log output.';
-        var footer = document.createElement('div');
-        footer.style.cssText = 'display:flex;align-items:center;justify-content:space-between;'
-          + 'flex-wrap:wrap;gap:10px;border-top:1px solid #333;padding-top:14px;';
         var btn = document.createElement('button');
-        btn.style.cssText = 'background:#e94560;color:#fff;border:none;border-radius:4px;'
-          + 'padding:7px 18px;cursor:pointer;font-family:monospace;font-size:0.85em;letter-spacing:1px;';
-        btn.textContent = 'Copy Report';
+        btn.style.cssText = 'background:#222;color:#ccc;border:1px solid #444;'
+          + 'padding:5px 12px;cursor:pointer;font-family:monospace;font-size:0.8em;';
+        btn.textContent = 'Copy report';
         var report = 'FlixelGDX Crash Report\\n'
           + new Date().toISOString() + '\\n'
           + 'Browser: ' + navigator.userAgent + '\\n'
@@ -169,20 +159,12 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
           + title + '\\n' + message;
         btn.onclick = function () {
           if (navigator.clipboard) { navigator.clipboard.writeText(report).catch(function () {}); }
-          btn.textContent = 'Copied!';
-          setTimeout(function () { btn.textContent = 'Copy Report'; }, 2000);
+          btn.textContent = 'Copied';
+          setTimeout(function () { btn.textContent = 'Copy report'; }, 2000);
         };
-        var ua = document.createElement('small');
-        ua.style.cssText = 'color:#666;font-size:0.72em;max-width:400px;overflow:hidden;'
-          + 'text-overflow:ellipsis;white-space:nowrap;';
-        ua.textContent = navigator.userAgent;
-        footer.appendChild(btn);
-        footer.appendChild(ua);
-        box.appendChild(heading);
         box.appendChild(titleEl);
         box.appendChild(msgEl);
-        box.appendChild(hint);
-        box.appendChild(footer);
+        box.appendChild(btn);
         overlay.appendChild(box);
         document.body.appendChild(overlay);
       }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -90,6 +90,11 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
    * Promise rejections. Both complement the try-catch in the game loop, which handles Java
    * exceptions thrown during a frame.
    *
+   * <p>All JavaScript-side error extraction (reading {@code .stack}, {@code .message}, source
+   * location) is performed inside the JavaScript wrappers so the {@link JsCrashCallback} interface
+   * only ever receives a plain {@link String}. This avoids passing {@code JSObject} references
+   * through a {@link JSFunctor} callback, which is not supported in TeaVM's WasmGC code generator.
+   *
    * @param handler The crash handler to install.
    */
   @Override
@@ -97,19 +102,14 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
     Objects.requireNonNull(handler, "handler cannot be null");
     this.crashHandler = handler;
 
-    // window.onerror: catches uncaught JS exceptions and WASM traps that escape the Java layer.
-    // Returning true suppresses the browser's own built-in error UI so the framework overlay takes over.
-    installWindowOnerror((msg, src, line, col, jsErr) -> {
-      String detail = extractJsError(jsErr, msg);
-      handler.onCrash(null, new RuntimeException(detail));
-      return true;
-    });
+    // window.onerror: the JS wrapper extracts the best available description from the error object
+    // and calls back with a plain string so no JSObject crosses the @JSFunctor boundary.
+    // Returning true from window.onerror suppresses the browser's own error UI.
+    installWindowOnerror(detail -> handler.onCrash(null, new RuntimeException(detail)));
 
-    // window.unhandledrejection: catches Promises that rejected without a .catch() handler.
-    installRejectionListener(event -> {
-      String reason = extractRejectionReason(event);
-      handler.onCrash(null, new RuntimeException("Unhandled Promise rejection: " + reason));
-    });
+    // window.unhandledrejection: same pattern, reason extracted in JS before the callback.
+    installRejectionListener(
+        reason -> handler.onCrash(null, new RuntimeException("Unhandled Promise rejection: " + reason)));
   }
 
   /** Returns the crash handler installed by {@link #setCrashHandler}, or {@code null} if not set. */
@@ -117,24 +117,33 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
     return crashHandler;
   }
 
-  @JSBody(params = { "err", "fallback" }, script = """
-      if (!err) { return fallback || 'Unknown JavaScript error'; }
-      return err.stack || err.message || String(err);
+  /**
+   * Installs a {@code window.onerror} handler that extracts the best available description from
+   * the error and passes it as a plain string to {@code callback}. Always returns {@code true} to
+   * suppress the browser's own error UI.
+   */
+  @JSBody(params = "callback", script = """
+      window.onerror = function(msg, src, line, col, err) {
+        var detail = err ? (err.stack || err.message || msg) : (msg || 'Unknown JavaScript error');
+        detail += '\\n[' + (src || '?') + ':' + (line || '?') + ']';
+        callback(detail);
+        return true;
+      };
       """)
-  private static native String extractJsError(JSObject err, String fallback);
+  private static native void installWindowOnerror(JsCrashCallback callback);
 
-  @JSBody(params = "event", script = """
-      var r = event.reason;
-      if (!r) { return 'Unknown rejection reason'; }
-      return r.stack || r.message || String(r);
+  /**
+   * Adds a {@code window.unhandledrejection} listener that extracts the rejection reason and
+   * passes it as a plain string to {@code callback}.
+   */
+  @JSBody(params = "callback", script = """
+      window.addEventListener('unhandledrejection', function(event) {
+        var r = event.reason;
+        var reason = r ? (r.stack || r.message || String(r)) : 'Unknown rejection reason';
+        callback(reason);
+      });
       """)
-  private static native String extractRejectionReason(JSObject event);
-
-  @JSBody(params = "handler", script = "window.onerror = handler;")
-  private static native void installWindowOnerror(JsErrorHandler handler);
-
-  @JSBody(params = "handler", script = "window.addEventListener('unhandledrejection', handler);")
-  private static native void installRejectionListener(JsRejectionHandler handler);
+  private static native void installRejectionListener(JsCrashCallback callback);
 
   @JSBody(script = """
       return (window.performance && window.performance.memory)
@@ -154,17 +163,14 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
     return (long) usedHeap();
   }
 
-  /** Callback type for {@code window.onerror}. Returns {@code true} to suppress the browser's default error UI. */
+  /**
+   * Callback type shared by both browser error signals. Receives an already-formatted string
+   * describing the error so no {@code JSObject} references need to cross the JS-to-Java boundary,
+   * which is not supported in TeaVM's WasmGC {@link JSFunctor} code generator.
+   */
   @JSFunctor
   @FunctionalInterface
-  interface JsErrorHandler extends JSObject {
-    boolean onError(String message, String source, int line, int col, JSObject error);
-  }
-
-  /** Callback type for {@code window.unhandledrejection}. */
-  @JSFunctor
-  @FunctionalInterface
-  interface JsRejectionHandler extends JSObject {
-    void onRejection(JSObject event);
+  interface JsCrashCallback extends JSObject {
+    void onCrash(String detail);
   }
 }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -90,14 +90,15 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
    *
    * <p>{@code window.onerror} handles uncaught JavaScript exceptions and WebAssembly traps.
    * {@code window.unhandledrejection} handles bare Promise rejections. Both are installed as
-   * self-contained JavaScript functions with no callback into Java; they log to
-   * {@code console.error}, show the DOM crash overlay, and persist the report to
-   * {@code localStorage}.
+   * self-contained JavaScript functions with no callback into Java via
+   * {@code window.__flixelShowCrash}, which also handles crash persistence and the Copy report
+   * overlay.
    *
-   * <p>The handler is wrapped so that Java-side crashes also persist the report to
-   * {@code localStorage} under {@code flixelgdx_last_crash}. This keeps crash persistence out of
-   * {@link FlixelHtml5Alerter}, which would otherwise persist every {@code alert.error()} call
-   * regardless of whether it was caused by an actual crash.
+   * <p>The handler is wrapped so that Java-side crashes also go through
+   * {@code window.__flixelShowCrash} before the platform-agnostic handler runs. Calling it first
+   * ensures the crash overlay (with its Copy report button) is in place before
+   * {@code alert.error()} is called inside the handler; the duplicate-overlay guard in
+   * {@link FlixelHtml5Alerter} then skips creating a second one.
    *
    * <p>A {@code @JSFunctor} callback is intentionally not used here. TeaVM 0.13.0's WasmGC code
    * generator produces a nameless function statement ({@code function() {}}) instead of an
@@ -112,11 +113,13 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
   public void setCrashHandler(@NotNull FlixelCrashHandler handler) {
     Objects.requireNonNull(handler, "handler cannot be null");
     this.crashHandler = (thread, throwable) -> {
-      handler.onCrash(thread, throwable);
       String threadName = thread != null ? thread.getName() : "main";
       String msg = "There was an uncaught exception on thread \"" + threadName + "\"!\n"
           + FlixelExceptionUtil.getFullExceptionMessage(throwable);
-      persistCrash("Uncaught Exception", msg);
+      // Show the crash overlay (Copy report) and persist before delegating. alert.error() inside
+      // the handler skips creating a second overlay because the id is already present.
+      showJavaCrashOverlay("Uncaught Exception", msg);
+      handler.onCrash(thread, throwable);
     };
     installJsErrorHandlers();
   }
@@ -128,11 +131,13 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
 
   /**
    * Installs {@code window.onerror} and {@code window.unhandledrejection} as self-contained
-   * JavaScript handlers. Both handlers log to {@code console.error}, persist the report to
-   * {@code localStorage}, and show the DOM crash overlay without calling back into Java.
+   * JavaScript handlers and defines {@code window.__flixelShowCrash} as the shared crash overlay
+   * function. Both browser error events call through it, and Java-side crashes call it via
+   * {@link #showJavaCrashOverlay}. It logs to {@code console.error}, persists the report to
+   * {@code localStorage}, and shows the crash overlay with a Copy report button.
    */
   @JSBody(script = """
-      function flixelShowJsCrash(title, message) {
+      window.__flixelShowCrash = function(title, message) {
         console.error('[FlixelGDX] ' + title + ': ' + message);
         try {
           localStorage.setItem('flixelgdx_last_crash', JSON.stringify({
@@ -179,33 +184,27 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
         box.appendChild(btn);
         overlay.appendChild(box);
         document.body.appendChild(overlay);
-      }
+      };
       window.onerror = function(msg, src, line, col, err) {
         var detail = err ? (err.stack || err.message || msg) : (msg || 'Unknown JavaScript error');
         detail += '\\n[' + (src || '?') + ':' + (line || '?') + ']';
-        flixelShowJsCrash('JavaScript Error', detail);
+        window.__flixelShowCrash('JavaScript Error', detail);
         return true;
       };
       window.addEventListener('unhandledrejection', function(event) {
         var r = event.reason;
         var reason = r ? (r.stack || r.message || String(r)) : 'Unknown rejection reason';
-        flixelShowJsCrash('Promise Rejection', reason);
+        window.__flixelShowCrash('Promise Rejection', reason);
       });
       """)
   private static native void installJsErrorHandlers();
 
   @JSBody(params = { "title", "message" }, script = """
-      try {
-        localStorage.setItem('flixelgdx_last_crash', JSON.stringify({
-          time: new Date().toISOString(),
-          title: title,
-          message: message,
-          ua: navigator.userAgent,
-          url: window.location.href
-        }));
-      } catch (e) {}
+      if (typeof window.__flixelShowCrash === 'function') {
+        window.__flixelShowCrash(title, message);
+      }
       """)
-  private static native void persistCrash(String title, String message);
+  private static native void showJavaCrashOverlay(String title, String message);
 
   @JSBody(script = """
       return (window.performance && window.performance.memory)

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -27,6 +27,7 @@ import org.flixelgdx.backend.FlixelCrashHandler;
 import org.flixelgdx.backend.FlixelRunEnvironment;
 import org.flixelgdx.backend.FlixelRuntimeDevice;
 import org.flixelgdx.backend.FlixelRuntimeMode;
+import org.flixelgdx.util.FlixelExceptionUtil;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
 
@@ -93,6 +94,11 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
    * {@code console.error}, show the DOM crash overlay, and persist the report to
    * {@code localStorage}.
    *
+   * <p>The handler is wrapped so that Java-side crashes also persist the report to
+   * {@code localStorage} under {@code flixelgdx_last_crash}. This keeps crash persistence out of
+   * {@link FlixelHtml5Alerter}, which would otherwise persist every {@code alert.error()} call
+   * regardless of whether it was caused by an actual crash.
+   *
    * <p>A {@code @JSFunctor} callback is intentionally not used here. TeaVM 0.13.0's WasmGC code
    * generator produces a nameless function statement ({@code function() {}}) instead of an
    * expression when wrapping any {@code @JSFunctor} method that takes parameters, causing a
@@ -105,7 +111,13 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
   @Override
   public void setCrashHandler(@NotNull FlixelCrashHandler handler) {
     Objects.requireNonNull(handler, "handler cannot be null");
-    this.crashHandler = handler;
+    this.crashHandler = (thread, throwable) -> {
+      handler.onCrash(thread, throwable);
+      String threadName = thread != null ? thread.getName() : "main";
+      String msg = "There was an uncaught exception on thread \"" + threadName + "\"!\n"
+          + FlixelExceptionUtil.getFullExceptionMessage(throwable);
+      persistCrash("Uncaught Exception", msg);
+    };
     installJsErrorHandlers();
   }
 
@@ -139,7 +151,7 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
           + 'font-family:monospace;padding:16px;box-sizing:border-box;';
         var box = document.createElement('div');
         box.style.cssText = 'background:#111;border:1px solid #333;'
-          + 'padding:20px 24px;max-width:600px;width:100%;max-height:80vh;overflow-y:auto;'
+          + 'padding:20px 24px;width:max-content;max-width:80vw;max-height:80vh;overflow-y:auto;'
           + 'color:#ccc;box-sizing:border-box;';
         var titleEl = document.createElement('p');
         titleEl.style.cssText = 'margin:0 0 12px 0;color:#e94560;font-size:0.9em;';
@@ -152,7 +164,7 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
         btn.style.cssText = 'background:#222;color:#ccc;border:1px solid #444;'
           + 'padding:5px 12px;cursor:pointer;font-family:monospace;font-size:0.8em;';
         btn.textContent = 'Copy report';
-        var report = 'FlixelGDX Crash Report\\n'
+        var report = (document.title || 'Game') + ' Crash Report\\n'
           + new Date().toISOString() + '\\n'
           + 'Browser: ' + navigator.userAgent + '\\n'
           + 'URL: ' + window.location.href + '\\n\\n'
@@ -181,6 +193,19 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
       });
       """)
   private static native void installJsErrorHandlers();
+
+  @JSBody(params = { "title", "message" }, script = """
+      try {
+        localStorage.setItem('flixelgdx_last_crash', JSON.stringify({
+          time: new Date().toISOString(),
+          title: title,
+          message: message,
+          ua: navigator.userAgent,
+          url: window.location.href
+        }));
+      } catch (e) {}
+      """)
+  private static native void persistCrash(String title, String message);
 
   @JSBody(script = """
       return (window.performance && window.performance.memory)

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5RuntimeDevice.java
@@ -23,11 +23,14 @@
  */
 package org.flixelgdx.backend.html5;
 
+import org.flixelgdx.backend.FlixelCrashHandler;
 import org.flixelgdx.backend.FlixelRunEnvironment;
 import org.flixelgdx.backend.FlixelRuntimeDevice;
 import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
+import org.teavm.jso.JSFunctor;
+import org.teavm.jso.JSObject;
 
 import java.util.Objects;
 
@@ -39,10 +42,17 @@ import java.util.Objects;
  * browsers offer is a rough JavaScript heap size through {@code performance.memory}, which this
  * class surfaces for the debug overlay; everything else returns the safe default the interface
  * already provides.
+ *
+ * <p>On web, {@link #setCrashHandler} wires the supplied handler into two browser-level error
+ * signals: {@code window.onerror}, which fires for uncaught JavaScript exceptions and WebAssembly
+ * traps that escape the Java exception system, and {@code window.unhandledrejection}, which fires
+ * for unhandled Promise rejections. Together these complement the try-catch already wrapped around
+ * the game loop in {@link FlixelHtml5Runner}, catching anything that happens outside that boundary.
  */
 public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
 
   private FlixelRuntimeMode mode = FlixelRuntimeMode.RELEASE;
+  private FlixelCrashHandler crashHandler;
 
   private boolean runtimeModeSet = false;
 
@@ -72,6 +82,60 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
     }
   }
 
+  /**
+   * Installs the crash handler and wires it into two browser error signals.
+   *
+   * <p>{@code window.onerror} catches uncaught JavaScript exceptions and WebAssembly traps that
+   * escape the Java exception system entirely. {@code window.unhandledrejection} catches unhandled
+   * Promise rejections. Both complement the try-catch in the game loop, which handles Java
+   * exceptions thrown during a frame.
+   *
+   * @param handler The crash handler to install.
+   */
+  @Override
+  public void setCrashHandler(@NotNull FlixelCrashHandler handler) {
+    Objects.requireNonNull(handler, "handler cannot be null");
+    this.crashHandler = handler;
+
+    // window.onerror: catches uncaught JS exceptions and WASM traps that escape the Java layer.
+    // Returning true suppresses the browser's own built-in error UI so the framework overlay takes over.
+    installWindowOnerror((msg, src, line, col, jsErr) -> {
+      String detail = extractJsError(jsErr, msg);
+      handler.onCrash(null, new RuntimeException(detail));
+      return true;
+    });
+
+    // window.unhandledrejection: catches Promises that rejected without a .catch() handler.
+    installRejectionListener(event -> {
+      String reason = extractRejectionReason(event);
+      handler.onCrash(null, new RuntimeException("Unhandled Promise rejection: " + reason));
+    });
+  }
+
+  /** Returns the crash handler installed by {@link #setCrashHandler}, or {@code null} if not set. */
+  FlixelCrashHandler getCrashHandler() {
+    return crashHandler;
+  }
+
+  @JSBody(params = { "err", "fallback" }, script = """
+      if (!err) { return fallback || 'Unknown JavaScript error'; }
+      return err.stack || err.message || String(err);
+      """)
+  private static native String extractJsError(JSObject err, String fallback);
+
+  @JSBody(params = "event", script = """
+      var r = event.reason;
+      if (!r) { return 'Unknown rejection reason'; }
+      return r.stack || r.message || String(r);
+      """)
+  private static native String extractRejectionReason(JSObject event);
+
+  @JSBody(params = "handler", script = "window.onerror = handler;")
+  private static native void installWindowOnerror(JsErrorHandler handler);
+
+  @JSBody(params = "handler", script = "window.addEventListener('unhandledrejection', handler);")
+  private static native void installRejectionListener(JsRejectionHandler handler);
+
   @JSBody(script = """
       return (window.performance && window.performance.memory)
         ? window.performance.memory.usedJSHeapSize : 0;
@@ -88,5 +152,19 @@ public class FlixelHtml5RuntimeDevice implements FlixelRuntimeDevice {
    */
   private static long usedHeapBytes() {
     return (long) usedHeap();
+  }
+
+  /** Callback type for {@code window.onerror}. Returns {@code true} to suppress the browser's default error UI. */
+  @JSFunctor
+  @FunctionalInterface
+  interface JsErrorHandler extends JSObject {
+    boolean onError(String message, String source, int line, int col, JSObject error);
+  }
+
+  /** Callback type for {@code window.unhandledrejection}. */
+  @JSFunctor
+  @FunctionalInterface
+  interface JsRejectionHandler extends JSObject {
+    void onRejection(JSObject event);
   }
 }


### PR DESCRIPTION
## Description

The HTML5 crash handler was previously a no-op — `FlixelHtml5RuntimeDevice` never overrode `setCrashHandler`, so the handler installed by `FlixelGame` was never wired up. Errors from the game loop propagated silently as opaque WASM traps or JavaScript errors with no framework interception, and the only \"UI\" for a crash was a blocking `window.alert()` with no stack trace info.

This PR fills all of those gaps with four changes:

**`FlixelHtml5RuntimeDevice`** — overrides `setCrashHandler` for the first time. Wires the handler into `window.onerror` (fires for uncaught JS exceptions and WASM traps that escape the Java exception system) and `window.unhandledrejection` (fires for unhandled Promise rejections). Both extract the JS stack from the error object where available and pass a synthetic `RuntimeException` to the handler. Returning `true` from `window.onerror` suppresses the browser's default error UI so the framework overlay takes over.

**`FlixelHtml5Runner`** — wraps the `onAnimationFrame` body in a try-catch. Any Java exception thrown during update or draw is routed through the installed `FlixelCrashHandler` instead of propagating into the browser as an opaque error. The next `requestAnimationFrame` call is only scheduled after a clean frame; a caught exception stops the loop.

**`FlixelHtml5Alerter`** — replaces the blocking `window.alert()` with a full-screen DOM crash overlay. The overlay shows the title and message, a copy-to-clipboard button that bundles the browser UA, page URL, and timestamp into the report, and a note pointing to the browser console (F12) for the full stack trace. The report is also persisted to `localStorage` under `flixelgdx_last_crash` so it survives a page reload. Info and warn alerts switch to `console.log`/`console.warn` so they never interrupt a running page.

**`Html5Plugin`** — when `html5 { mode = Html5Mode.DEBUG }` is set, the plugin now configures source map generation and `COPY` source file policy as conventions on both TeaVM targets. For the WasmGC target it also enables `FULL` debug info, so browser DevTools can resolve WASM addresses back to Java class names, method names, and line numbers instead of showing raw function offsets. `convention()` is used so a developer can still override any setting explicitly. The dev server also gains a `.map` MIME type entry so source map files are served correctly.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).