### PR TITLE
Replaced String asset paths with FlixelFile handles across the public API

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -53,7 +53,7 @@ import org.jetbrains.annotations.Nullable;
  * flipping, blend modes, per-sprite shaders, and scissor clip rects.
  *
  * <h2>Loading graphics</h2>
- * <p>Use {@link #loadGraphic(String)} for asset-managed textures (the texture is cached and
+ * <p>Use {@link #loadGraphic(FlixelFile)} for asset-managed textures (the texture is cached and
  * reference-counted by {@link FlixelAssetManager}).
  * {@link #makeGraphic(int, int, FlixelColor)} generates a solid-color rectangle on the fly and
  * owns the resulting texture. For Sparrow XML atlases, call
@@ -76,7 +76,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>The {@link FlixelAnimationController} is {@code null} by default to save memory for large
  * sprite counts. Call {@link #ensureAnimation()} to create it lazily, then register clips:
  * <pre>{@code
- * FlixelSprite sprite = new FlixelSprite(0, 0, "player.png");
+ * FlixelSprite sprite = new FlixelSprite(0, 0, Flixel.files.internal("player.png"));
  * sprite.ensureAnimation().add("walk", new int[]{0, 1, 2, 3}, 12, true);
  * sprite.ensureAnimation().playAnimation("walk");
  * }</pre>
@@ -231,12 +231,12 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    *
    * @param x The X coordinate to place the new sprite at.
    * @param y The Y coordinate to place the new sprite at.
-   * @param graphicAssetKey The asset key of the graphic to load, or {@code null} to leave the sprite blank.
+   * @param graphicFile A handle to the graphic to load, or {@code null} to leave the sprite blank.
    */
-  public FlixelSprite(float x, float y, String graphicAssetKey) {
+  public FlixelSprite(float x, float y, @Nullable FlixelFile graphicFile) {
     super(x, y);
-    if (graphicAssetKey != null && !graphicAssetKey.isEmpty()) {
-      loadGraphic(graphicAssetKey);
+    if (graphicFile != null) {
+      loadGraphic(graphicFile);
     }
   }
 
@@ -285,36 +285,49 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   /**
-   * Load's a texture and automatically resizes the size of {@code this} sprite.
+   * Loads a texture from a file handle and automatically resizes {@code this} sprite.
    *
-   * @param file A handle to the {@code .png} to load onto {@code this} sprite.
+   * <p>Obtain a handle from {@code Flixel.files.internal("player.png")} and queue the asset with
+   * {@link FlixelAssetManager#load(String)} before the first frame to avoid a synchronous stall.
+   *
+   * <pre>{@code
+   * FlixelFile file = Flixel.files.internal("player.png");
+   * sprite.loadGraphic(file);
+   * }</pre>
+   *
+   * @param file A handle to the {@code .png} to load onto {@code this} sprite. Must not be {@code null}.
    * @return {@code this} sprite for chaining.
    */
-  public FlixelSprite loadGraphic(FlixelFile file) {
-    return loadGraphic(file.getPath());
+  public FlixelSprite loadGraphic(@NotNull FlixelFile file) {
+    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(file.getPath()).retain().get();
+    FlixelTexture t = g.getTexture();
+    return loadGraphic(g, t.getWidth(), t.getHeight());
   }
 
   /**
-   * Load's a texture and automatically resizes the size of {@code this} sprite.
+   * Loads a texture from a file handle and automatically resizes {@code this} sprite.
    *
-   * @param file A handle to the {@code .png} to load onto {@code this} sprite.
-   * @param frameWidth How wide the sprite should be.
+   * @param file A handle to the {@code .png} to load onto {@code this} sprite. Must not be {@code null}.
+   * @param frameWidth How wide each frame should be.
    * @return {@code this} sprite for chaining.
    */
-  public FlixelSprite loadGraphic(FlixelFile file, int frameWidth) {
-    return loadGraphic(file.getPath(), frameWidth);
+  public FlixelSprite loadGraphic(@NotNull FlixelFile file, int frameWidth) {
+    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(file.getPath()).retain().get();
+    FlixelTexture t = g.getTexture();
+    return loadGraphic(g, frameWidth, t.getHeight());
   }
 
   /**
-   * Load's a texture and automatically resizes the size of {@code this} sprite.
+   * Loads a texture from a file handle and automatically resizes {@code this} sprite.
    *
-   * @param file A handle to the {@code .png} to load onto {@code this} sprite.
-   * @param frameWidth How wide the sprite should be.
-   * @param frameHeight How tall the sprite should be.
+   * @param file A handle to the {@code .png} to load onto {@code this} sprite. Must not be {@code null}.
+   * @param frameWidth How wide each frame should be.
+   * @param frameHeight How tall each frame should be.
    * @return {@code this} sprite for chaining.
    */
-  public FlixelSprite loadGraphic(FlixelFile file, int frameWidth, int frameHeight) {
-    return loadGraphic(file.getPath(), frameWidth, frameHeight);
+  public FlixelSprite loadGraphic(@NotNull FlixelFile file, int frameWidth, int frameHeight) {
+    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(file.getPath()).retain().get();
+    return loadGraphic(g, frameWidth, frameHeight);
   }
 
   /**
@@ -345,47 +358,6 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     updateHitbox(frameWidth, frameHeight);
     setAntialiasing(antialiasing);
     return this;
-  }
-
-  /**
-   * Loads a cached graphic by key. Queue the asset with {@link FlixelAssetManager#load(String)} in
-   * a loading state to avoid synchronous stalls on the first frame.
-   *
-   * @param assetKey The key of the graphic to load.
-   * @return {@code this} sprite for chaining.
-   */
-  public FlixelSprite loadGraphic(String assetKey) {
-    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(assetKey).retain().get();
-    FlixelTexture t = g.getTexture();
-    return loadGraphic(g, t.getWidth(), t.getHeight());
-  }
-
-  /**
-   * Loads a cached graphic by key. Queue the asset with {@link FlixelAssetManager#load(String)} in
-   * a loading state to avoid synchronous stalls on the first frame.
-   *
-   * @param assetKey The key of the graphic to load.
-   * @param frameWidth The width of the graphic.
-   * @return {@code this} sprite for chaining.
-   */
-  public FlixelSprite loadGraphic(String assetKey, int frameWidth) {
-    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(assetKey).retain().get();
-    FlixelTexture t = g.getTexture();
-    return loadGraphic(g, frameWidth, t.getHeight());
-  }
-
-  /**
-   * Loads a cached graphic by key. Queue the asset with {@link FlixelAssetManager#load(String)} in
-   * a loading state to avoid synchronous stalls on the first frame.
-   *
-   * @param assetKey The key of the graphic to load.
-   * @param frameWidth The width of the graphic.
-   * @param frameHeight The height of the graphic.
-   * @return {@code this} sprite for chaining.
-   */
-  public FlixelSprite loadGraphic(String assetKey, int frameWidth, int frameHeight) {
-    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(assetKey).retain().get();
-    return loadGraphic(g, frameWidth, frameHeight);
   }
 
   /**
@@ -465,7 +437,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
 
   /**
    * Installs a retained {@link FlixelGraphic} and parsed Sparrow atlas frames. Called by
-   * {@link FlixelAnimationController#addSparrowFrames(String)} and
+   * {@link FlixelAnimationController#addSparrowFrames(FlixelFile)} and
    * {@link FlixelSpritemapJsonLoader#load}, not a general API for game code.
    *
    * @param newGraphic Graphic from {@link Flixel#assets}{@code .get(...)} with
@@ -501,7 +473,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * <em>appends</em> {@code parsedFrames} to whatever atlas the sprite already has (creating one when
    * it had none) and retains {@code newGraphic} as a {@link #retainSecondaryGraphic secondary graphic}
    * so its texture stays loaded. That lets a single sprite carry frames from more than one sheet,
-   * which is what {@link FlixelAnimationController#addSparrowFrames(String)} builds on. The currently
+   * which is what {@link FlixelAnimationController#addSparrowFrames(FlixelFile)} builds on. The currently
    * displayed frame and the registered clips are left untouched, so a sprite already showing a rig
    * clip or another atlas keeps rendering exactly as before; play one of the newly registered clips to
    * show the merged art.
@@ -528,7 +500,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * {@link FlixelAssetManager#get(String) FlixelAssetManager.get(...)} followed
    * by {@link FlixelAsset#retain() retain()}), so this method only stores the
    * reference and does not call {@link FlixelGraphic#retain()} again. This is an advanced hook used
-   * by atlas-merging code such as {@link FlixelAnimationController#addSparrowFrames(String)} and
+   * by atlas-merging code such as {@link FlixelAnimationController#addSparrowFrames(FlixelFile)} and
    * the Animate rig loader; most game code never calls it directly.
    *
    * @param graphic The graphic to retain for the sprite's lifetime. Must not be {@code null}.
@@ -1177,7 +1149,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   /**
    * Replaces the currently displayed frame directly, bypassing the frame grid and animation
    * system. Useful for one-off sprites that source a frame from an existing atlas without going
-   * through {@link #loadGraphic(String)} or {@link #applySparrowAtlas(FlixelGraphic, FlixelArray)}.
+   * through {@link #loadGraphic(FlixelFile)} or {@link #applySparrowAtlas(FlixelGraphic, FlixelArray)}.
    * Pass {@code null} to clear the displayed frame.
    *
    * @param region The frame to display, or {@code null} to stop rendering.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -68,24 +68,24 @@ import java.util.Objects;
  * <pre>{@code
  * FlixelAnimateSprite fas = new FlixelAnimateSprite();
  * fas.addSpritemapAndAnimation(
- *     "path/to/atlas/spritemap1.png",
- *     "path/to/atlas/spritemap1.json",
- *     "path/to/animation/Animation.json");
+ *     Flixel.files.internal("path/to/atlas/spritemap1.png"),
+ *     Flixel.files.internal("path/to/atlas/spritemap1.json"),
+ *     Flixel.files.internal("path/to/animation/Animation.json"));
  * fas.setScale(0.65f);
  * fas.setAntialiasing(true);
  * fas.updateHitbox();
  * fas.screenCenter();
- * fas.animation.playAnimation("Animation Name");
+ * fas.animation.play("Animation Name");
  * add(fas);
  *
  * // If you group all of your atlas files in individual folders, you can
- * // also just provide a path to a folder and the paths will be automatically
- * // loaded for you!
+ * // also just provide a handle to that folder and the paths will be automatically
+ * // resolved for you!
  * FlixelAnimateSprite.defaultSpritemapFileName = "customSpritemapName";
  * FlixelAnimateSprite.defaultAnimationFileName = "customAnimationName";
  *
  * FlixelAnimateSprite fas = new FlixelAnimateSprite();
- * fas.addSpritemapAndAnimation("path/to/atlas/folder");
+ * fas.addSpritemapAndAnimation(Flixel.files.internal("path/to/atlas/folder"));
  * }
  * </pre>
  *
@@ -97,13 +97,13 @@ import java.util.Objects;
  *
  * <h2>Mixing in a Sparrow atlas</h2>
  * A character can also carry Sparrow XML clips on the same body via
- * {@link FlixelAnimationController#addSparrowFrames(String)}. Rig clips keep rendering from the baked
+ * {@link FlixelAnimationController#addSparrowFrames(FlixelFile)}. Rig clips keep rendering from the baked
  * rig; clips registered against the merged Sparrow frames render through the standard frame path, and
  * the sprite picks the right one per clip automatically.
  *
- * @see #addSpritemapAndAnimation(String)
- * @see #addSpritemapAndAnimation(String, String, String)
- * @see FlixelAnimationController#addSparrowFrames(String)
+ * @see #addSpritemapAndAnimation(FlixelFile)
+ * @see #addSpritemapAndAnimation(FlixelFile, FlixelFile, FlixelFile)
+ * @see FlixelAnimationController#addSparrowFrames(FlixelFile)
  * @see #defaultSpritemapFileName
  * @see #defaultAnimationFileName
  */
@@ -111,16 +111,16 @@ public class FlixelAnimateSprite extends FlixelSprite {
 
   /**
    * The default file name for every spritemap {@code .png} / {@code .json}
-   * loaded with {@link #addSpritemapAndAnimation(String)}. Note that you shouldn't
-   * include an extension, as it's already handled for you. Default value is {@code "spritemap1"}.
+   * loaded with {@link #addSpritemapAndAnimation(FlixelFile)}. Do not include an extension - the
+   * loader appends the right one. Default value is {@code "spritemap1"}.
    */
   @NotNull
   public static String defaultSpritemapFileName = "spritemap1";
 
   /**
    * The default file name for every animation {@code .json} data
-   * loaded with {@link #addSpritemapAndAnimation(String)}. When using this, you don't need to
-   * include {@code .json} at the end, as the loader does it for you. Default value is {@code "Animation"}.
+   * loaded with {@link #addSpritemapAndAnimation(FlixelFile)}. Do not include {@code .json} - the
+   * loader appends it. Default value is {@code "Animation"}.
    */
   @NotNull
   public static String defaultAnimationFileName = "Animation";
@@ -170,28 +170,32 @@ public class FlixelAnimateSprite extends FlixelSprite {
   }
 
   /**
-   * Adds an Adobe Animate texture atlas from a single provided path.
+   * Adds an Adobe Animate texture atlas from a single directory handle.
    *
-   * <p>This method is very useful if you have an exact location where all three core parts of
-   * an atlas are stored, and you just want to provide the path to it. Note that you can set the
-   * default file names of the default spritemap and animation data if you know what it's going
-   * to be every time!
+   * <p>This method is useful when all three core files (PNG, spritemap JSON, animation JSON) live in
+   * the same folder. The file names are resolved from {@link #defaultSpritemapFileName} and
+   * {@link #defaultAnimationFileName}.
    *
-   * @param path The directory where all three core files are stored. Must be a directory.
+   * <pre>{@code
+   * fas.addSpritemapAndAnimation(Flixel.files.internal("path/to/atlas/folder"));
+   * }</pre>
+   *
+   * @param path Handle to the directory where all three core files are stored. Must be a directory.
    * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If the provided path isn't a real directory.
+   * @throws IllegalArgumentException If the provided path is not a real directory or required files are missing.
    * @throws NullPointerException If either {@link #defaultSpritemapFileName} or {@link #defaultAnimationFileName}
    *     are {@code null}.
    * @see #defaultSpritemapFileName
    * @see #defaultAnimationFileName
    */
   @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(String path) {
+  public FlixelAnimateSprite addSpritemapAndAnimation(@NotNull FlixelFile path) {
     Objects.requireNonNull(defaultSpritemapFileName, "defaultSpritemapName cannot be null.");
     Objects.requireNonNull(defaultAnimationFileName, "defaultAnimationName cannot be null.");
-    String pngPath = path + "/" + defaultSpritemapFileName + ".png";
-    String spritemapJsonPath = path + "/" + defaultSpritemapFileName + ".json";
-    String animationJsonPath = path + "/" + defaultAnimationFileName + ".json";
+    String basePath = path.getPath();
+    String pngPath = basePath + "/" + defaultSpritemapFileName + ".png";
+    String spritemapJsonPath = basePath + "/" + defaultSpritemapFileName + ".json";
+    String animationJsonPath = basePath + "/" + defaultAnimationFileName + ".json";
     // Resolve a .ktx2 sibling before checking existence, since compressed builds delete the
     // plain PNG once its .ktx2 replacement exists.
     String resolvedPngPath = Flixel.assets.resolveTexturePath(pngPath);
@@ -201,178 +205,26 @@ public class FlixelAnimateSprite extends FlixelSprite {
       throw new IllegalArgumentException(
           "The provided path is either not a real folder, one of the required files is missing, or doesn't exist.");
     }
-    return addSpritemapAndAnimation(pngPath, spritemapJsonPath, animationJsonPath);
+    return addSpritemapAndAnimationInternal(pngPath, spritemapJsonPath, animationJsonPath, null);
   }
 
   /**
-   * Adds an Adobe Animate texture atlas from a single provided directory handle.
+   * Adds an Adobe Animate texture atlas ({@code PNG} plus spritemap JSON and animation JSON). If this
+   * sprite has no rig yet, {@link FlixelAnimateRigLoader#load} builds one and starts the anchor clip.
+   * If a rig is already installed, the same triple is merged with {@link FlixelAnimateRigLoader#append}.
    *
-   * <p>Equivalent to {@link #addSpritemapAndAnimation(String)}, but accepts a {@link FlixelFile}
-   * for callers that already resolved the directory through a file resolver instead of holding a raw path.
-   *
-   * @param path The directory handle where all three core files are stored. Must be a directory.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If the provided path isn't a real directory.
-   * @throws NullPointerException If either {@link #defaultSpritemapFileName} or {@link #defaultAnimationFileName}
-   *     are {@code null}.
-   * @see #defaultSpritemapFileName
-   * @see #defaultAnimationFileName
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(@NotNull FlixelFile path) {
-    return addSpritemapAndAnimation(pathOf(path, "path"));
-  }
-
-  /**
-   * Adds an Adobe Animate texture atlas ({@code PNG} plus spritemap JSON and {@code Animation.json}). If
-   * this sprite has no rig yet, {@link FlixelAnimateRigLoader#load} builds one and starts the anchor
-   * clip. If a rig is already installed, the same triple is merged with {@link FlixelAnimateRigLoader#append}.
-   * The {@code anchorClipName} argument is read only on the first successful load; it is ignored on merges.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
+   * @param textureFile Handle to the spritemap PNG. Must not be {@code null}.
+   * @param spritemapJsonFile Handle to the spritemap JSON. Must not be {@code null}.
+   * @param animationJsonFile Handle to the animation JSON. Must not be {@code null}.
    * @return {@code this} sprite, for chaining.
    * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
    */
   @NotNull
   public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull String animationJsonPath) {
-    return addSpritemapAndAnimation(textureKey, spritemapJsonPath, animationJsonPath, null);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts {@code textureKey}
-   * as a {@link FlixelFile} instead of a path string.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull String animationJsonPath) {
-    return addSpritemapAndAnimation(pathOf(textureKey, "textureKey"), spritemapJsonPath, animationJsonPath);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts {@code spritemapJsonPath}
-   * as a {@link FlixelFile} instead of a path string.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull String animationJsonPath) {
-    return addSpritemapAndAnimation(textureKey, pathOf(spritemapJsonPath, "spritemapJsonPath"), animationJsonPath);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts {@code animationJsonPath}
-   * as a {@link FlixelFile} instead of a path string.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath) {
-    return addSpritemapAndAnimation(textureKey, spritemapJsonPath, pathOf(animationJsonPath, "animationJsonPath"));
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts {@code textureKey}
-   * and {@code spritemapJsonPath} as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull String animationJsonPath) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"), pathOf(spritemapJsonPath, "spritemapJsonPath"), animationJsonPath);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts {@code textureKey}
-   * and {@code animationJsonPath} as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"), spritemapJsonPath, pathOf(animationJsonPath, "animationJsonPath"));
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts {@code spritemapJsonPath}
-   * and {@code animationJsonPath} as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath) {
-    return addSpritemapAndAnimation(
-        textureKey, pathOf(spritemapJsonPath, "spritemapJsonPath"), pathOf(animationJsonPath, "animationJsonPath"));
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String)} that accepts all three core
-   * parameters as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"),
-        pathOf(spritemapJsonPath, "spritemapJsonPath"),
-        pathOf(animationJsonPath, "animationJsonPath"));
+      @NotNull FlixelFile textureFile,
+      @NotNull FlixelFile spritemapJsonFile,
+      @NotNull FlixelFile animationJsonFile) {
+    return addSpritemapAndAnimation(textureFile, spritemapJsonFile, animationJsonFile, null);
   }
 
   /**
@@ -383,15 +235,39 @@ public class FlixelAnimateSprite extends FlixelSprite {
    * from the timeline (for document exports with no labels, this is the synthesized default clip). When merging
    * into an existing rig, {@code anchorClipName} is ignored.
    *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
+   * @param textureFile Handle to the spritemap PNG. Must not be {@code null}.
+   * @param spritemapJsonFile Handle to the spritemap JSON. Must not be {@code null}.
+   * @param animationJsonFile Handle to the animation JSON. Must not be {@code null}.
    * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
    * @return {@code this} sprite, for chaining.
    * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
    */
   @NotNull
   public FlixelAnimateSprite addSpritemapAndAnimation(
+      @NotNull FlixelFile textureFile,
+      @NotNull FlixelFile spritemapJsonFile,
+      @NotNull FlixelFile animationJsonFile,
+      @Nullable String anchorClipName) {
+    return addSpritemapAndAnimationInternal(
+        textureFile.getPath(),
+        spritemapJsonFile.getPath(),
+        animationJsonFile.getPath(),
+        anchorClipName);
+  }
+
+  /**
+   * Core implementation shared by all {@code addSpritemapAndAnimation} overloads. Delegates to
+   * {@link FlixelAnimateRigLoader#load} on the first call and {@link FlixelAnimateRigLoader#append}
+   * on subsequent calls.
+   *
+   * @param textureKey Asset key of the spritemap PNG.
+   * @param spritemapJsonPath Path to the spritemap JSON.
+   * @param animationJsonPath Path to the animation JSON.
+   * @param anchorClipName Anchor clip for the initial load only; ignored when appending.
+   * @return {@code this} sprite, for chaining.
+   */
+  @NotNull
+  private FlixelAnimateSprite addSpritemapAndAnimationInternal(
       @NotNull String textureKey,
       @NotNull String spritemapJsonPath,
       @NotNull String animationJsonPath,
@@ -404,182 +280,6 @@ public class FlixelAnimateSprite extends FlixelSprite {
       FlixelAnimateRigLoader.append(this, controller, textureKey, spritemapJsonPath, animationJsonPath);
     }
     return this;
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts
-   * {@code textureKey} as a {@link FlixelFile} instead of a path string.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull String animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"), spritemapJsonPath, animationJsonPath, anchorClipName);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts
-   * {@code spritemapJsonPath} as a {@link FlixelFile} instead of a path string.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull String animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        textureKey, pathOf(spritemapJsonPath, "spritemapJsonPath"), animationJsonPath, anchorClipName);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts
-   * {@code animationJsonPath} as a {@link FlixelFile} instead of a path string.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        textureKey, spritemapJsonPath, pathOf(animationJsonPath, "animationJsonPath"), anchorClipName);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts
-   * {@code textureKey} and {@code spritemapJsonPath} as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull String animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"),
-        pathOf(spritemapJsonPath, "spritemapJsonPath"),
-        animationJsonPath,
-        anchorClipName);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts
-   * {@code textureKey} and {@code animationJsonPath} as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"),
-        spritemapJsonPath,
-        pathOf(animationJsonPath, "animationJsonPath"),
-        anchorClipName);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts
-   * {@code spritemapJsonPath} and {@code animationJsonPath} as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull String textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        textureKey,
-        pathOf(spritemapJsonPath, "spritemapJsonPath"),
-        pathOf(animationJsonPath, "animationJsonPath"),
-        anchorClipName);
-  }
-
-  /**
-   * Overload of {@link #addSpritemapAndAnimation(String, String, String, String)} that accepts all
-   * three core parameters as {@link FlixelFile}s instead of path strings.
-   *
-   * @param textureKey The asset key of the spritemap PNG, as a file handle. Must not be {@code null}.
-   * @param spritemapJsonPath The path to the spritemap JSON, as a file handle. Must not be {@code null}.
-   * @param animationJsonPath The path to the animation JSON, as a file handle. Must not be {@code null}.
-   * @param anchorClipName Anchor clip name for the initial load only; ignored when appending. May be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If any file is missing, malformed, or not a recognized Adobe Animate export.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSpritemapAndAnimation(
-      @NotNull FlixelFile textureKey,
-      @NotNull FlixelFile spritemapJsonPath,
-      @NotNull FlixelFile animationJsonPath,
-      @Nullable String anchorClipName) {
-    return addSpritemapAndAnimation(
-        pathOf(textureKey, "textureKey"),
-        pathOf(spritemapJsonPath, "spritemapJsonPath"),
-        pathOf(animationJsonPath, "animationJsonPath"),
-        anchorClipName);
-  }
-
-  /**
-   * Resolves a {@link FlixelFile} into the path string the rest of {@code addSpritemapAndAnimation}
-   * overloads operate on. Asset-manager lookups (the spritemap PNG) and direct JSON reads both resolve
-   * a plain path through {@link Flixel#files}, so converting up front lets
-   * every {@link FlixelFile} overload delegate straight into the existing {@code String} pipeline
-   * without duplicating loading logic.
-   *
-   * @param handle The file handle to resolve. Must not be {@code null}.
-   * @param paramName The parameter name to report if {@code handle} is {@code null}.
-   * @return The handle's path, as returned by {@link FlixelFile#getPath()}.
-   */
-  @NotNull
-  private static String pathOf(@NotNull FlixelFile handle, @NotNull String paramName) {
-    Objects.requireNonNull(handle, paramName + " cannot be null.");
-    return handle.getPath();
   }
 
   @Nullable
@@ -595,7 +295,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
    * Sparrow frame so switching from a Sparrow clip to a rig clip does not flash stale art). For a
    * Sparrow or simple-atlas clip the callback falls through to the normal
    * {@link FlixelSprite#setCurrentFrameForAnimation} path, which is what lets a Sparrow sheet merged
-   * with {@link FlixelAnimationController#addSparrowFrames(String)} share the same sprite as the rig.
+   * with {@link FlixelAnimationController#addSparrowFrames(FlixelFile)} share the same sprite as the rig.
    *
    * @param frame The frame being advanced to by {@link FlixelAnimationController}; ignored while a
    *   rig clip is playing.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -52,7 +52,7 @@ import java.util.Comparator;
  *
  * <h2>Mixing in a Sparrow atlas</h2>
  * A character can also carry Sparrow XML clips on the same body via
- * {@link FlixelAnimationController#addSparrowFrames(String)}, allowing a single sprite to contain
+ * {@link FlixelAnimationController#addSparrowFrames(FlixelFile)}, allowing a single sprite to contain
  * multiple Sparrow sheets with unique animations.
  */
 public class FlixelAnimationController implements FlixelUpdatable {
@@ -137,25 +137,26 @@ public class FlixelAnimationController implements FlixelUpdatable {
   /**
    * Adobe/CreateJS spritemap plus animation index JSON. See {@link FlixelSpritemapJsonLoader#load} for file shapes.
    *
-   * @param textureKey Asset key of the already-enqueued {@link FlixelGraphic}.
-   * @param spritemapJsonPath Path resolved like other assets (internal or classpath).
-   * @param animationJsonPath JSON with an {@code animations} object.
+   * @param textureFile Handle to the already-enqueued spritemap PNG.
+   * @param spritemapJsonFile Handle to the spritemap JSON.
+   * @param animationJsonFile Handle to the JSON with an {@code animations} object.
    * @return The owning sprite for chaining.
    */
   @NotNull
   public FlixelSprite loadSpritemapFromJson(
-      @NotNull String textureKey,
-      @NotNull String spritemapJsonPath,
-      @NotNull String animationJsonPath) {
-    FlixelSpritemapJsonLoader.load(this, textureKey, spritemapJsonPath, animationJsonPath);
+      @NotNull FlixelFile textureFile,
+      @NotNull FlixelFile spritemapJsonFile,
+      @NotNull FlixelFile animationJsonFile) {
+    FlixelSpritemapJsonLoader.load(
+        this, textureFile.getPath(), spritemapJsonFile.getPath(), animationJsonFile.getPath());
     return owner;
   }
 
   /**
-   * Loads or merges a Sparrow atlas onto the owning sprite from a single base path, inferring the
+   * Loads or merges a Sparrow atlas onto the owning sprite from a base path handle, inferring the
    * conventional {@code .png} and {@code .xml} file names shared by a Sparrow export. For example,
-   * passing {@code "shared/images/foo"} loads the texture from {@code "shared/images/foo.png"} and
-   * the atlas data from {@code "shared/images/foo.xml"}.
+   * passing a handle to {@code "shared/images/foo"} loads the texture from
+   * {@code "shared/images/foo.png"} and the atlas data from {@code "shared/images/foo.xml"}.
    *
    * <p>When the sprite has no atlas yet, this installs the sheet as the primary atlas, sizes the
    * sprite to the first frame, and clears any previously registered clips. When the sprite already
@@ -164,70 +165,49 @@ public class FlixelAnimationController implements FlixelUpdatable {
    * multiple sheets.
    *
    * <pre>{@code
-   * sprite.ensureAnimation().addSparrowAtlas("shared/images/foo");
-   * sprite.animation.addAnimationByPrefix("idle", "idle", 24, true);
-   * sprite.animation.playAnimation("idle");
+   * FlixelFile base = Flixel.files.internal("shared/images/foo");
+   * sprite.ensureAnimation().addSparrowFrames(base);
+   * sprite.animation.addByPrefix("idle", "idle", 24, true);
+   * sprite.animation.play("idle");
    * }</pre>
    *
-   * @param path The base path, without a file extension, shared by the PNG and XML pair.
+   * @param path Handle to the base path, without a file extension, shared by the PNG and XML pair.
    * @return The owning sprite for chaining.
-   * @see #addSparrowFrames(String, String)
-   */
-  @NotNull
-  public FlixelSprite addSparrowFrames(@NotNull String path) {
-    return addSparrowFrames(path + ".png", path + ".xml");
-  }
-
-  /**
-   * Overload of {@link #addSparrowFrames(String)} that accepts the base path as a {@link FlixelFile}.
-   *
-   * @param path The base path handle, without a file extension, shared by the PNG and XML pair.
-   * @return The owning sprite for chaining.
+   * @see #addSparrowFrames(FlixelFile, FlixelFile)
    */
   @NotNull
   public FlixelSprite addSparrowFrames(@NotNull FlixelFile path) {
-    return addSparrowFrames(path.getPath());
+    String basePath = path.getPath();
+    return addSparrowFrames(
+        Flixel.files.internal(basePath + ".png"),
+        FlixelSpritemapJsonLoader.resolveAssetPath(basePath + ".xml"));
   }
 
   /**
-   * Loads or merges a Sparrow atlas onto the owning sprite from an explicit texture key and XML path.
-   * See {@link #addSparrowFrames(String)} for the full load/merge contract.
+   * Loads or merges a Sparrow atlas onto the owning sprite from an explicit texture file and XML file.
+   * See {@link #addSparrowFrames(FlixelFile)} for the full load/merge contract.
    *
-   * @param textureKey The asset key of the Sparrow PNG. Must not be {@code null}.
-   * @param xmlPath The path to the Sparrow XML. Must not be {@code null}.
+   * @param textureFile Handle to the Sparrow PNG. Must not be {@code null}.
+   * @param xmlFile Handle to the Sparrow XML file. Must not be {@code null}.
    * @return The owning sprite for chaining.
    * @throws IllegalArgumentException If either file is missing or malformed.
    */
   @NotNull
-  public FlixelSprite addSparrowFrames(@NotNull String textureKey, @NotNull String xmlPath) {
-    FlixelFile xml = FlixelSpritemapJsonLoader.resolveAssetPath(xmlPath);
-    String text = FlixelSpritemapJsonLoader.readUtf8Text(xml);
-    return addSparrowFrames(textureKey, FlixelXml.parse(text));
-  }
-
-  /**
-   * Overload of {@link #addSparrowFrames(String, String)} that accepts the XML as a {@link FlixelFile}.
-   *
-   * @param textureKey The asset key of the Sparrow PNG. Must not be {@code null}.
-   * @param xmlFile The Sparrow XML file, read as UTF-8. Must not be {@code null}.
-   * @return The owning sprite for chaining.
-   */
-  @NotNull
-  public FlixelSprite addSparrowFrames(@NotNull String textureKey, @NotNull FlixelFile xmlFile) {
+  public FlixelSprite addSparrowFrames(@NotNull FlixelFile textureFile, @NotNull FlixelFile xmlFile) {
     String text = FlixelSpritemapJsonLoader.readUtf8Text(xmlFile);
-    return addSparrowFrames(textureKey, FlixelXml.parse(text));
+    return addSparrowFrames(textureFile, FlixelXml.parse(text));
   }
 
   /**
-   * Overload of {@link #addSparrowFrames(String, String)} that accepts a pre-parsed XML root.
+   * Overload of {@link #addSparrowFrames(FlixelFile, FlixelFile)} that accepts a pre-parsed XML root.
    *
-   * @param textureKey The asset key of the Sparrow PNG. Must not be {@code null}.
+   * @param textureFile Handle to the Sparrow PNG. Must not be {@code null}.
    * @param xmlRoot The root {@code TextureAtlas} element of a Sparrow XML. Must not be {@code null}.
    * @return The owning sprite for chaining.
    */
   @NotNull
-  public FlixelSprite addSparrowFrames(@NotNull String textureKey, @NotNull FlixelXmlElement xmlRoot) {
-    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(textureKey).retain().get();
+  public FlixelSprite addSparrowFrames(@NotNull FlixelFile textureFile, @NotNull FlixelXmlElement xmlRoot) {
+    FlixelGraphic g = Flixel.assets.<FlixelGraphic>get(textureFile.getPath()).retain().get();
     FlixelTexture texture = g.getTexture();
 
     FlixelArray<FlixelFrame> parsed = parseSparrowFrames(texture, xmlRoot);
@@ -244,7 +224,7 @@ public class FlixelAnimationController implements FlixelUpdatable {
    * Parses Sparrow {@code SubTexture} entries into a fresh frame list without installing them on any
    * sprite.
    *
-   * <p>This is the shared parsing core used by {@link #addSparrowFrames(String, FlixelXmlElement)}.
+   * <p>This is the shared parsing core used by {@link #addSparrowFrames(FlixelFile, FlixelXmlElement)}.
    * Keeping it separate lets callers inspect or transform the frame list before passing it to
    * {@link FlixelSprite#applySparrowAtlas} or {@link FlixelSprite#mergeSparrowAtlas}.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundManager.java
@@ -29,6 +29,7 @@ import org.flixelgdx.asset.FlixelAsset;
 import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.asset.FlixelAssetMode;
 import org.flixelgdx.collections.FlixelArray;
+import org.flixelgdx.file.FlixelFile;
 import org.flixelgdx.file.FlixelFiles;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.functional.FlixelUpdatable;
@@ -210,184 +211,157 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
    * (volume, effects, looping) before its first {@link FlixelSound#play()}.
    *
    * <p>The sound joins the SFX group and is tracked by this manager like any played sound, so
-   * state-switch cleanup and focus pausing still apply.
+   * state-switch cleanup and focus pausing still apply. Obtain a file handle from
+   * {@link FlixelFiles Flixel.files}:
    *
-   * @param path Internal asset key / path.
+   * <pre>{@code
+   * FlixelSound sfx = Flixel.sound.create(Flixel.files.internal("sfx/jump.ogg"));
+   * sfx.setVolume(0.8f);
+   * sfx.play();
+   * }</pre>
+   *
+   * @param file Handle to the audio file. Must not be {@code null}.
    * @return The new, idle {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound create(@NotNull String path) {
-    return create(path, null, false);
+  public FlixelSound create(@NotNull FlixelFile file) {
+    return create(file, null);
   }
 
   /**
    * Creates a sound without playing it, in the given group.
    *
-   * @param path Internal asset key / path.
+   * @param file Handle to the audio file. Must not be {@code null}.
    * @param group Sound group, or {@code null} to use the default SFX group.
    * @return The new, idle {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound create(@NotNull String path, @Nullable FlixelSoundGroup group) {
-    return create(path, group, false);
-  }
-
-  /**
-   * Creates a sound without playing it.
-   *
-   * @param path Internal asset key / path, or an absolute path when {@code external} is {@code true}.
-   * @param group Sound group, or {@code null} to use the default SFX group.
-   * @param external If {@code true}, the path is read from the absolute file root.
-   * @return The new, idle {@link FlixelSound} instance.
-   */
-  @NotNull
-  public FlixelSound create(@NotNull String path, @Nullable FlixelSoundGroup group, boolean external) {
+  public FlixelSound create(@NotNull FlixelFile file, @Nullable FlixelSoundGroup group) {
     FlixelSoundGroup targetGroup = (group != null) ? group : sfxGroup;
-    FlixelSound sound = buildSound(path, external, targetGroup);
+    FlixelSound sound = buildSound(file, targetGroup);
     sound.setManager(this);
     activeSounds.add(sound);
     return sound;
   }
 
   /**
-   * Plays a new sound effect (SFX group).
+   * Plays a new sound effect (SFX group) at full volume, without looping.
    *
-   * @param path Internal asset key / path, or external path when {@code external} is {@code true}.
+   * <pre>{@code
+   * Flixel.sound.play(Flixel.files.internal("sfx/coin.ogg"));
+   * }</pre>
+   *
+   * @param file Handle to the audio file. Must not be {@code null}.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound play(@NotNull String path) {
-    return play(path, 1f, false, null, false);
+  public FlixelSound play(@NotNull FlixelFile file) {
+    return play(file, 1f, false, null);
   }
 
   /**
-   * Plays a new sound effect.
+   * Plays a new sound effect at the given volume.
    *
-   * @param path Path to the sound.
+   * @param file Handle to the audio file. Must not be {@code null}.
    * @param volume Volume to play with.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound play(@NotNull String path, float volume) {
-    return play(path, volume, false, null, false);
+  public FlixelSound play(@NotNull FlixelFile file, float volume) {
+    return play(file, volume, false, null);
   }
 
   /**
    * Plays a new sound effect.
    *
-   * @param path Path to the sound.
-   * @param volume Volume to play with.
-   * @param looping Whether to loop.
-   * @return The new {@link FlixelSound} instance.
-   */
-  @NotNull
-  public FlixelSound play(@NotNull String path, float volume, boolean looping) {
-    return play(path, volume, looping, null, false);
-  }
-
-  /**
-   * Plays a new sound effect.
-   *
-   * @param path Path to the sound.
+   * @param file Handle to the audio file. Must not be {@code null}.
    * @param volume Volume to play with.
    * @param looping Whether to loop.
-   * @param group Sound group, or {@code null} to use the default SFX group.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound play(@NotNull String path, float volume, boolean looping, @Nullable FlixelSoundGroup group) {
-    return play(path, volume, looping, group, false);
+  public FlixelSound play(@NotNull FlixelFile file, float volume, boolean looping) {
+    return play(file, volume, looping, null);
   }
 
   /**
    * Plays a new sound effect.
    *
-   * @param path Path to the sound.
+   * @param file Handle to the audio file. Must not be {@code null}.
    * @param volume Volume to play with.
    * @param looping Whether to loop.
    * @param group Sound group, or {@code null} to use the default SFX group.
-   * @param external If {@code true}, the path is read from the absolute file root.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound play(@NotNull String path, float volume, boolean looping,
-      @Nullable FlixelSoundGroup group, boolean external) {
+  public FlixelSound play(@NotNull FlixelFile file, float volume, boolean looping, @Nullable FlixelSoundGroup group) {
     FlixelSoundGroup targetGroup = (group != null) ? group : sfxGroup;
-    return createAndPlaySoundFromPath(path, external, volume, looping, targetGroup);
+    return createAndPlay(file, volume, looping, targetGroup);
   }
 
   /**
-   * Sets and plays the current music (music group). Stops any previous music.
+   * Sets and plays the current music (SFX group), looping. Stops any previous music.
    *
-   * @param path Path to the music file.
+   * <pre>{@code
+   * Flixel.sound.playMusic(Flixel.files.internal("music/theme.ogg"));
+   * }</pre>
+   *
+   * @param file Handle to the music file. Must not be {@code null}.
    * @return The new music {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound playMusic(@NotNull String path) {
-    return playMusic(path, 1f, true, false);
+  public FlixelSound playMusic(@NotNull FlixelFile file) {
+    return playMusic(file, 1f, true);
   }
 
   /**
    * Sets and plays the current music. Stops any previous music.
    *
-   * @param path Path to the music file.
+   * @param file Handle to the music file. Must not be {@code null}.
    * @param volume Volume.
    * @return The new music {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound playMusic(@NotNull String path, float volume) {
-    return playMusic(path, volume, true, false);
+  public FlixelSound playMusic(@NotNull FlixelFile file, float volume) {
+    return playMusic(file, volume, true);
   }
 
   /**
    * Sets and plays the current music. Stops any previous music.
    *
-   * @param path Path to the music file.
-   * @param volume Volume.
-   * @param looping Whether to loop.
-   * @return The new music {@link FlixelSound} instance.
-   */
-  @NotNull
-  public FlixelSound playMusic(@NotNull String path, float volume, boolean looping) {
-    return playMusic(path, volume, looping, false);
-  }
-
-  /**
-   * Sets and plays the current music. Stops any previous music.
-   *
-   * @param path Path to the music file.
+   * @param file Handle to the music file. Must not be {@code null}.
    * @param volume Volume.
    * @param looping Whether to loop.
-   * @param external If {@code true}, the path is read from the absolute file root.
    * @return The new music {@link FlixelSound} instance.
    */
   @NotNull
-  public FlixelSound playMusic(@NotNull String path, float volume, boolean looping, boolean external) {
+  public FlixelSound playMusic(@NotNull FlixelFile file, float volume, boolean looping) {
     if (music != null) {
       music.destroy();
       music = null;
     }
-    music = createAndPlaySoundFromPath(path, external, volume, looping, sfxGroup);
+    music = createAndPlay(file, volume, looping, sfxGroup);
     return music;
   }
 
   /**
-   * Builds a new {@link FlixelSound} for {@code path} without starting playback.
+   * Builds a new {@link FlixelSound} from {@code file} without starting playback.
    *
-   * <p>When {@code external} is {@code false}, reads or synchronously loads a
-   * {@link FlixelSoundSource} through the asset manager and retains its handle for the sound's
-   * lifetime. External paths read the file bytes from
-   * {@link FlixelFiles#absolute Flixel.files.absolute} directly.
+   * <p>Internal/classpath files go through the asset manager cache using the file's path as the
+   * key. Files from {@link FlixelFiles#absolute Flixel.files.absolute} or
+   * {@link FlixelFiles#external Flixel.files.external} (whose {@link FlixelFile#getAbsolutePath()}
+   * differs from {@link FlixelFile#getPath()}) bypass the cache and are decoded directly.
    *
-   * @param path The path to the sound file.
-   * @param external If {@code true}, the path is read from the absolute file root.
+   * @param file Handle to the audio file.
    * @param targetGroup The group to create the sound in.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
-  private FlixelSound buildSound(@NotNull String path, boolean external, @NotNull FlixelSoundGroup targetGroup) {
-    if (external) {
-      FlixelSoundBuffer buffer = FlixelSoundBuffer.read(path, Flixel.files.absolute(path));
+  private FlixelSound buildSound(@NotNull FlixelFile file, @NotNull FlixelSoundGroup targetGroup) {
+    String path = file.getPath();
+    String absolutePath = file.getAbsolutePath();
+    if (!absolutePath.equals(path)) {
+      FlixelSoundBuffer buffer = FlixelSoundBuffer.read(absolutePath, file);
       return factory.createSound(buffer, targetGroup);
     }
     FlixelAssetManager assets = Flixel.assets;
@@ -402,23 +376,21 @@ public class FlixelSoundManager implements FlixelUpdatable, FlixelDestroyable {
   }
 
   /**
-   * Builds a new {@link FlixelSound} for {@code path}, starts playback, and returns it.
+   * Builds a new {@link FlixelSound} from {@code file}, starts playback, and returns it.
    *
-   * @param path The path to the sound file.
-   * @param external If {@code true}, the path is read from the absolute file root.
+   * @param file Handle to the audio file.
    * @param volume The volume to play the sound at.
    * @param looping If {@code true}, the sound will loop.
    * @param targetGroup The group to play the sound in.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
-  private FlixelSound createAndPlaySoundFromPath(
-      @NotNull String path,
-      boolean external,
+  private FlixelSound createAndPlay(
+      @NotNull FlixelFile file,
       float volume,
       boolean looping,
       @NotNull FlixelSoundGroup targetGroup) {
-    FlixelSound sound = buildSound(path, external, targetGroup);
+    FlixelSound sound = buildSound(file, targetGroup);
     sound.setVolume(volume);
     sound.setLooped(looping);
     sound.play();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/package-info.java
@@ -18,7 +18,7 @@
  * releases it.
  *
  * <p>The typical path is through {@link org.flixelgdx.FlixelSprite FlixelSprite}: call
- * {@link org.flixelgdx.FlixelSprite#loadGraphic(String) FlixelSprite.loadGraphic(String)} to load a
+ * {@link org.flixelgdx.FlixelSprite#loadGraphic(org.flixelgdx.file.FlixelFile) FlixelSprite.loadGraphic(FlixelFile)} to load a
  * path, or
  * {@link org.flixelgdx.FlixelSprite#makeGraphic(int, int, org.flixelgdx.util.FlixelColor) FlixelSprite.makeGraphic(...)}
  * to generate a solid-color rectangle on the fly. Both handle the graphic lifecycle automatically.


### PR DESCRIPTION
## Description

Every public method in the framework that previously accepted a `String` asset path or key has been replaced with a `FlixelFile` handle. This eliminates raw strings from the public game-facing API entirely and routes all asset access through the `Flixel.files` seam.

**Files changed:**
- `FlixelSprite` - `loadGraphic(String)` overloads removed; `loadGraphic(FlixelFile)` is now the real implementation.
- `FlixelSoundManager` - all `play`/`playMusic`/`create` string overloads removed; the `boolean external` parameter is gone too. External files are detected automatically via `FlixelFile.getAbsolutePath()` vs `getPath()` difference.
- `FlixelAnimationController` - `addSparrowFrames(String)` and related string overloads removed; `addSparrowFrames(FlixelFile)` is now the primary implementation.
- `FlixelAnimateSprite` - the previous 16+ mixed String/FlixelFile overload matrix was collapsed to 3 public `FlixelFile` methods + 1 private string-based internal implementation.
- `graphics/package-info.java` - updated broken `@link` reference.

Internal helpers (`FlixelAnimateRigLoader`, `FlixelSpritemapJsonLoader`) are package-private and were intentionally left with string parameters since they are not part of the public game API.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor / Optimization

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).