### PR TITLE
Added a blank streaming texture factory to the graphics manager

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicsManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicsManager.java
@@ -245,6 +245,24 @@ public interface FlixelGraphicsManager {
   default void endScene() {}
 
   /**
+   * Creates a blank, updateable GPU texture of the given dimensions.
+   *
+   * <p>Unlike {@link #createTexture(FlixelImage)}, which uploads pixels immediately and produces a
+   * static texture on some backends, this method produces a texture whose pixels can be replaced at
+   * any time via {@link FlixelTexture#update(int, int, FlixelImage)} after creation. Use it for
+   * streaming pixel sources such as video frames, where every frame overwrites the previous one.
+   * Backends that do not support dynamic textures return a size-only stand-in.
+   *
+   * @param width Texture width in pixels.
+   * @param height Texture height in pixels.
+   * @return An updateable texture; a size-only stand-in when no backend is present.
+   */
+  @NotNull
+  default FlixelTexture createTexture(int width, int height) {
+    return new FlixelNoopTexture(width, height);
+  }
+
+  /**
    * Uploads pixel data to a new GPU texture.
    *
    * @param width Texture width in pixels.

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxGraphics.java
@@ -396,6 +396,20 @@ public class FlixelBgfxGraphics implements FlixelGraphicsManager {
 
   @NotNull
   @Override
+  public FlixelTexture createTexture(int width, int height) {
+    // Passing null for the initial memory creates a dynamic (updateable) bgfx texture. Static
+    // textures (created with bgfx_copy) silently ignore bgfx_update_texture_2d, which is why
+    // streaming sources like video frames must always go through this path.
+    short handle = BGFX.bgfx_create_texture_2d(
+        width, height, false, 1,
+        BGFX.BGFX_TEXTURE_FORMAT_RGBA8,
+        BGFX.BGFX_TEXTURE_NONE,
+        null, 0L);
+    return new FlixelBgfxTexture(handle, width, height);
+  }
+
+  @NotNull
+  @Override
   public FlixelTexture createTexture(int width, int height, @NotNull ByteBuffer rgba) {
     ByteBuffer copy = ByteBuffer.allocateDirect(width * height * 4);
     rgba.position(0).limit(width * height * 4);

--- a/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxTexture.java
+++ b/flixelgdx-desktop/src/main/java/org/flixelgdx/backend/desktop/graphics/FlixelBgfxTexture.java
@@ -138,28 +138,27 @@ public class FlixelBgfxTexture implements FlixelTexture {
     ByteBuffer pixels = image.getPixels();
     pixels.position(0).limit(count * 4);
     if (swapRB) {
-      ByteBuffer swapped = swapRedBlue(pixels, count);
-      BGFX.bgfx_update_texture_2d(handle, 0, 0,
-          (short) x, (short) y, (short) image.getWidth(), (short) image.getHeight(),
-          BGFX.bgfx_copy(swapped), 0xFFFF);
-      MemoryUtil.memFree(swapped);
-    } else {
-      BGFX.bgfx_update_texture_2d(handle, 0, 0,
-          (short) x, (short) y, (short) image.getWidth(), (short) image.getHeight(),
-          BGFX.bgfx_copy(pixels), 0xFFFF);
+      // Swap R and B bytes in-place so the channel layout matches bgfx's expectation for this
+      // backend. The caller owns the buffer and must tolerate this side effect; streaming sources
+      // (e.g., video frames) overwrite the buffer before the next update, so the in-place swap
+      // does not escape to the caller between updates.
+      swapRedBlueInPlace(pixels, count);
     }
+    // bgfx_make_ref stores a pointer to the caller-owned buffer rather than copying it. The buffer
+    // must remain valid until bgfx_frame() processes this submission (end of the current frame).
+    // FlixelImage backs its pixels with a direct ByteBuffer whose lifetime is tied to the image
+    // object, so the memory is guaranteed to outlive the submission.
+    BGFX.bgfx_update_texture_2d(handle, 0, 0,
+        (short) x, (short) y, (short) image.getWidth(), (short) image.getHeight(),
+        BGFX.bgfx_make_ref(pixels), 0xFFFF);
   }
 
   /**
    * Returns a malloc-backed {@link ByteBuffer} whose R and B bytes are swapped relative to
    * {@code src}.
    *
-   * <p>stb_image always delivers pixels as RGBA, but certain bgfx backends invert the red and blue
-   * channels during sampling. This method compensates on the CPU at load time so the GPU sees the
-   * correct channel layout. The original {@code src} buffer is left unmodified.
-   *
-   * <p>The returned buffer is allocated via {@link MemoryUtil#memAlloc} and must be freed by the
-   * caller with {@link MemoryUtil#memFree} once bgfx has consumed the data.
+   * <p>Used at texture-creation time when a full copy is needed anyway (bgfx_copy). For the
+   * per-frame streaming path, use {@link #swapRedBlueInPlace} to avoid a separate allocation.
    *
    * @param src The source RGBA pixel buffer (position 0, at least {@code pixelCount * 4} bytes).
    * @param pixelCount The number of pixels to process.
@@ -169,12 +168,21 @@ public class FlixelBgfxTexture implements FlixelTexture {
     ByteBuffer dst = MemoryUtil.memAlloc(pixelCount * 4);
     for (int i = 0; i < pixelCount; i++) {
       int base = i * 4;
-      dst.put(base, src.get(base + 2)); // R slot <- B value
-      dst.put(base + 1, src.get(base + 1)); // G unchanged
-      dst.put(base + 2, src.get(base));     // B slot <- R value
-      dst.put(base + 3, src.get(base + 3)); // A unchanged
+      dst.put(base, src.get(base + 2));
+      dst.put(base + 1, src.get(base + 1));
+      dst.put(base + 2, src.get(base));
+      dst.put(base + 3, src.get(base + 3));
     }
     return dst;
+  }
+
+  private static void swapRedBlueInPlace(ByteBuffer buf, int pixelCount) {
+    for (int i = 0; i < pixelCount; i++) {
+      int base = i * 4;
+      byte r = buf.get(base);
+      buf.put(base, buf.get(base + 2));
+      buf.put(base + 2, r);
+    }
   }
 
   @Override

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Alerter.java
@@ -65,7 +65,7 @@ public class FlixelHtml5Alerter implements FlixelAlerter {
    * Shows a full-screen DOM alert overlay with an OK button that dismisses it.
    *
    * <p>Delegates to {@code window.__flixelOverlay}, which is defined by
-   * {@link FlixelHtml5RuntimeDevice#installJsErrorHandlers} and holds the single shared
+   * {@code FlixelHtml5RuntimeDevice.installJsErrorHandlers} and holds the single shared
    * overlay-building implementation for both alert dialogs and crash reports.
    */
   @JSBody(params = { "title", "message", "titleColor" }, script = """

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/FlixelHtml5Runner.java
@@ -128,14 +128,28 @@ public class FlixelHtml5Runner implements FlixelGameRunner {
         this::startGame, FlixelHtml5Runner::onPreloadFailed);
   }
 
-  /** Runs once every asset is cached: dismisses the loading overlay, creates the first state, and starts the loop. */
+  /**
+   * Runs once every asset is cached: dismisses the loading overlay, creates the first state, and
+   * starts the loop.
+   *
+   * <p>The crash handler is fetched before {@link FlixelGame#create()} so that any exception
+   * thrown during the initial state's create phase is routed through the same overlay as runtime
+   * exceptions. Without this ordering the handler field is still {@code null} when {@code create}
+   * runs, and the exception escapes to the browser with only a console log from
+   * {@code window.onerror}.
+   */
   private void startGame() {
     hideLoadingOverlay();
-    game.create();
-    // Cache the crash handler here so the game loop can route frame exceptions
-    // through the handler without re-casting on every frame.
     if (Flixel.runtime instanceof FlixelHtml5RuntimeDevice device) {
       crashHandler = device.getCrashHandler();
+    }
+    try {
+      game.create();
+    } catch (Throwable t) {
+      if (crashHandler != null) {
+        crashHandler.onCrash(null, t);
+      }
+      return;
     }
     Window.requestAnimationFrame(this::onAnimationFrame);
   }

--- a/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/graphics/FlixelHtml5Graphics.java
+++ b/flixelgdx-html5/src/main/java/org/flixelgdx/backend/html5/graphics/FlixelHtml5Graphics.java
@@ -202,8 +202,28 @@ public class FlixelHtml5Graphics implements FlixelGraphicsManager {
 
   @Override
   @NotNull
+  public FlixelTexture createTexture(int width, int height) {
+    return new FlixelWebGlTexture(gl, width, height, false);
+  }
+
+  @Override
+  @NotNull
   public FlixelTexture createTexture(int width, int height, @NotNull ByteBuffer rgba) {
     return new FlixelWebGlTexture(gl, width, height, rgba, false);
+  }
+
+  /**
+   * Returns the WebGL rendering context used by this backend.
+   *
+   * <p>Extensions that need to call WebGL directly (for example, a video backend that uploads
+   * frames through {@code texSubImage2D} without a Java-side copy) can retrieve the context here
+   * by casting {@link Flixel#graphics} to {@code FlixelHtml5Graphics}.
+   *
+   * @return The WebGL2 rendering context, or {@code null} before {@link #initialize} is called.
+   */
+  @Nullable
+  public WebGLRenderingContext getGl() {
+    return gl;
   }
 
   @Override


### PR DESCRIPTION
## Description

Adds a `createTexture(int, int)` overload to `FlixelGraphicsManager` that allocates a blank, updateable texture suited for streaming sources like video. Both the desktop (bgfx) and HTML5 (WebGL) backends provide a concrete implementation.

The desktop implementation passes `null` memory to `bgfx_create_texture_2d`, which is what makes bgfx mark the texture as dynamic. The existing `createTexture(int, int, ByteBuffer)` path passes initial pixel data through `bgfx_copy`, which produces a static (immutable) texture -- `bgfx_update_texture_2d` silently does nothing on those. This distinction is the root cause of the desktop video first-frame bug fixed in the companion PR on the video extension.

The HTML5 implementation creates a blank `FlixelWebGlTexture`. A new `getGl()` accessor is also added to `FlixelHtml5Graphics` so extension modules (like the video extension) can reach the `WebGLRenderingContext` directly for zero-copy DOM-element uploads.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **master** branch.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - the API addition is exercised by the companion video extension PR.